### PR TITLE
SOT-101: Core SoT v1.0.1 alignment (runs/persistence/SSE/ArgSpec)

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/flowd-org/flowd/internal/argsloader"
 	"github.com/flowd-org/flowd/internal/coredb"
@@ -23,6 +24,10 @@ import (
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v3"
 )
+
+func newCLIRequestID() string {
+	return fmt.Sprintf("cli-%d", time.Now().UnixNano())
+}
 
 func RegisterScriptCommands(root *cobra.Command, scriptsDir string) error {
 	leafScripts := make(map[string]string)
@@ -206,6 +211,7 @@ func makeRunE(scriptDir string) func(cmd *cobra.Command, args []string) error {
 			JobID:     cmd.CommandPath(),
 			ScriptDir: scriptDir,
 			Args:      argsMap,
+			RequestID: newCLIRequestID(),
 		})
 		if err != nil {
 			var argErr *engine.ArgError

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -224,6 +224,13 @@ func makeRunE(scriptDir string) func(cmd *cobra.Command, args []string) error {
 		jobID := startRes.JobID
 		bind := startRes.Binding
 		plan := startRes.Plan
+		secretHandles := startRes.SecretHandles
+		secretCleanup := startRes.SecretCleanup
+		if secretCleanup != nil {
+			defer func() {
+				_ = secretCleanup()
+			}()
+		}
 		// Resolve profile precedence for CLI run: flag > env > default
 		prof, _ := cmd.Flags().GetString("profile")
 		if prof == "" {
@@ -307,6 +314,9 @@ func makeRunE(scriptDir string) func(cmd *cobra.Command, args []string) error {
 			ecfg.ArgsJSON = bind.ArgsJSON
 			ecfg.ArgValues = bind.Values
 			ecfg.LineRedactor = events.NewLineRedactor(bind.SecretValues)
+		}
+		if len(secretHandles) > 0 {
+			ecfg.SecretHandles = secretHandles
 		}
 
 		ctx := cmd.Context()

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -4,6 +4,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/flowd-org/flowd/internal/argsloader"
-	"github.com/flowd-org/flowd/internal/configloader"
 	"github.com/flowd-org/flowd/internal/engine"
 	"github.com/flowd-org/flowd/internal/events"
 	"github.com/flowd-org/flowd/internal/executor"
@@ -158,28 +158,8 @@ func RegisterScriptCommands(root *cobra.Command, scriptsDir string) error {
 
 func makeRunE(scriptDir string) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		cfg, err := configloader.LoadConfig(scriptDir)
-		if err != nil {
-			return err
-		}
-
-		if cmd.Flags().Changed("on-error") {
-			pol, _ := cmd.Flags().GetString("on-error")
-			cfg.ErrorHandling.Policy = pol
-		}
-
-		// Validate CLI flags against ArgSpec and build bindings
-		var bind *engine.Binding
-		if cfg.ArgSpec != nil {
-			b, vErr := engine.ValidateAndBind(cmd.Flags(), *cfg.ArgSpec)
-			if vErr != nil {
-				// E_ARGS: return with field-level message
-				return fmt.Errorf("E_ARGS: %v", vErr)
-			}
-			bind = b
-		}
-
 		flagsMap := make(map[string]interface{})
+		argsMap := make(map[string]interface{})
 		cmd.Flags().VisitAll(func(f *pflag.Flag) {
 			switch f.Name {
 			case "dry-run", "verbose", "quiet", "strict", "on-error", "report", "report-file", "json":
@@ -189,14 +169,26 @@ func makeRunE(scriptDir string) func(cmd *cobra.Command, args []string) error {
 			case "bool":
 				v, _ := cmd.Flags().GetBool(f.Name)
 				flagsMap[f.Name] = v
+				if f.Changed {
+					argsMap[f.Name] = v
+				}
 			case "int":
 				v, _ := cmd.Flags().GetInt(f.Name)
 				flagsMap[f.Name] = v
+				if f.Changed {
+					argsMap[f.Name] = v
+				}
 			case "stringArray":
 				v, _ := cmd.Flags().GetStringArray(f.Name)
 				flagsMap[f.Name] = v
+				if f.Changed {
+					argsMap[f.Name] = v
+				}
 			default:
 				flagsMap[f.Name] = f.Value.String()
+				if f.Changed {
+					argsMap[f.Name] = f.Value.String()
+				}
 			}
 		})
 
@@ -208,10 +200,29 @@ func makeRunE(scriptDir string) func(cmd *cobra.Command, args []string) error {
 		reportFile, _ := cmd.Flags().GetString("report-file")
 		jsonEvents, _ := cmd.Flags().GetBool("json")
 
-		runID := events.GenerateRunID()
-		jobID := cmd.CommandPath()
+		orchestrator := engine.NewOrchestrator(engine.OrchestratorDeps{})
+		startRes, err := orchestrator.StartRun(cmd.Context(), types.StartRunRequest{
+			JobID:     cmd.CommandPath(),
+			ScriptDir: scriptDir,
+			Args:      argsMap,
+		})
+		if err != nil {
+			var argErr *engine.ArgError
+			if errors.As(err, &argErr) {
+				return fmt.Errorf("E_ARGS: %v", argErr)
+			}
+			return err
+		}
 
-		plan := engine.BuildPlan(jobID, cfg, cfg.ArgSpec, bind)
+		cfg := startRes.Config
+		if cfg == nil {
+			return fmt.Errorf("missing config")
+		}
+
+		runID := startRes.RunID
+		jobID := startRes.JobID
+		bind := startRes.Binding
+		plan := startRes.Plan
 		// Resolve profile precedence for CLI run: flag > env > default
 		prof, _ := cmd.Flags().GetString("profile")
 		if prof == "" {
@@ -223,6 +234,10 @@ func makeRunE(scriptDir string) func(cmd *cobra.Command, args []string) error {
 			prof = "secure"
 		}
 		plan.SecurityProfile = strings.ToLower(prof)
+		if cmd.Flags().Changed("on-error") {
+			pol, _ := cmd.Flags().GetString("on-error")
+			cfg.ErrorHandling.Policy = pol
+		}
 		runDir := paths.RunDir(runID)
 		if abs, err := filepath.Abs(runDir); err == nil {
 			runDir = abs
@@ -277,7 +292,11 @@ func makeRunE(scriptDir string) func(cmd *cobra.Command, args []string) error {
 			ecfg.LineRedactor = events.NewLineRedactor(bind.SecretValues)
 		}
 
-		results, err := executor.RunScripts(context.Background(), scriptDir, ecfg)
+		ctx := cmd.Context()
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		results, err := executor.RunScripts(ctx, scriptDir, ecfg)
 		status := "completed"
 		if err != nil {
 			status = "failed"

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/flowd-org/flowd/internal/argsloader"
+	"github.com/flowd-org/flowd/internal/coredb"
 	"github.com/flowd-org/flowd/internal/engine"
 	"github.com/flowd-org/flowd/internal/events"
 	"github.com/flowd-org/flowd/internal/executor"
@@ -261,7 +262,23 @@ func makeRunE(scriptDir string) func(cmd *cobra.Command, args []string) error {
 		if verbosity > 0 {
 			consoleEmitter = events.NewEmitter(os.Stdout, jsonEvents)
 		}
-		emitter := events.NewCompositeSink(consoleEmitter)
+		var journalSink events.Sink
+		var journalDB *coredb.DB
+		if dataDir := paths.DataDir(); dataDir != "" {
+			db, dbErr := coredb.Open(context.Background(), coredb.Options{DataDir: dataDir})
+			if dbErr == nil {
+				journalDB = db
+				journalSink = events.NewJournalSink(coredb.NewJournal(db, 0))
+			} else if verbosity > 0 {
+				fmt.Fprintf(os.Stderr, "[warn] coredb unavailable; run journal disabled: %v\n", dbErr)
+			}
+		}
+		if journalDB != nil {
+			defer func() {
+				_ = journalDB.Close()
+			}()
+		}
+		emitter := events.NewCompositeSink(consoleEmitter, journalSink)
 		if emitter != nil {
 			emitter.EmitRunStart(runID, jobID)
 		}

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -84,7 +84,7 @@ func NewPlanCmd(root *cobra.Command) *cobra.Command {
 					}
 					suffix := ""
 					if a.Secret || a.Format == "secret" {
-						suffix = " [secret]"
+						suffix = " ($$REDACTED$$)"
 					}
 					fmt.Printf("  - %s: %s%s%s\n", a.Name, a.Type, req, suffix)
 				}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -95,6 +95,31 @@ POST /api/v1/runs
 
 Creates and executes a new run of a job.
 
+##### Idempotency
+
+`POST /api/v1/runs` requires an idempotency key so clients can safely retry without duplicate effects.
+
+**Required header**
+- `Idempotency-Key`: 20–128 characters, alphanumeric plus `_` and `-`.
+
+**Optional header**
+- `Idempotency-SHA256`: lowercase hex SHA-256 of the canonicalized JSON request body.
+  - If provided and it does not match the server-computed hash, the request fails with a conflict.
+
+**TTL behavior**
+- Default TTL: **24 hours**.
+- Maximum TTL: **72 hours** (higher configured values are clamped to this maximum).
+
+**Replay behavior**
+- If the same `Idempotency-Key` and request body are replayed after a successful run creation, the server returns the cached response and sets `Idempotent-Replay: true`.
+
+**Failure modes (RFC7807)**
+- **409 Conflict** — key reuse with a different request body or hash mismatch:
+  - `type`: `https://flowd.org/problems/idempotency/mismatch`
+- **429 Too Many Requests** — key already in use (in-flight):
+  - `type`: `https://flowd.org/problems/scheduler/rejected`
+- **400 Bad Request** — missing/invalid `Idempotency-Key` or invalid `Idempotency-SHA256` format.
+
 **Request Body:**
 ```json
 {
@@ -314,32 +339,69 @@ Returns system information and configuration.
 
 flwd supports real-time event streaming via Server-Sent Events for monitoring runs and system events.
 
-### Run Events Stream
+### Endpoints
 
 ```http
-GET /api/v1/events/runs
+GET /events/stream
 ```
 
-Streams all run-related events.
+Global stream of all events visible to the caller.
 
-**Query Parameters:**
-- `run_id` (optional): Filter events for a specific run
-- `job_id` (optional): Filter events for a specific job
-
-**Event Types:**
-- `run.created`: New run started
-- `run.started`: Run execution began
-- `run.output`: Log output from run
-- `run.finished`: Run completed
-- `step.started`: Step execution began
-- `step.output`: Log output from step
-- `step.finished`: Step completed
-
-**Example Event:**
+```http
+GET /events
 ```
-event: run.output
-data: {"run_id":"run_01HX...","timestamp":"2024-01-15T10:30:01Z","level":"info","message":"Processing..."}
+
+Alias of `/events/stream`.
+
+```http
+GET /runs/{run_id}/events
 ```
+
+Run-scoped stream for a single run.
+
+### Envelope and retry behavior
+
+All SSE endpoints use a single `flowd` envelope and a fixed retry hint:
+
+```
+event: flowd
+retry: 3000
+id: 42
+data: {"seq":42,"ts":"2026-01-10T10:00:15Z","type":"run.output","run_id":"run_01HX...","tenant":"default","data":{...}}
+```
+
+Heartbeat comments are emitted at least every 15 seconds in the form:
+
+```
+:hb 2026-01-10T10:00:15Z
+```
+
+### Resume and stale cursor behavior
+
+Resume by sending the last received sequence number via `Last-Event-ID`:
+
+```http
+GET /events/stream
+Last-Event-ID: 41
+```
+
+- If the cursor is older than the retained journal range, the server responds with **HTTP 410** and RFC7807 type `https://flowd.org/problems/sse/stale-cursor`.
+- If the cursor is not a valid integer or is greater than the current max sequence, the server responds with **HTTP 400**.
+
+### Event types (minimum set)
+
+- `run.started`
+- `run.output`
+- `run.finished`
+- `step.started`
+- `step.output`
+- `step.finished`
+- `log`
+- `metric`
+- `warning`
+- `error`
+- `source.sync`
+- `policy.denied`
 
 ## Error Handling
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,6 +151,13 @@ logging:
 
 ### Persistence
 
+flwd stores run records and event journals in an embedded SQLite database (CoreDB).
+By default, the database file lives under the configured `instance.data_dir` and
+uses the `persistence.db_path` value relative to that directory. On startup, flwd
+applies any pending schema migrations automatically. Migrations are forward-only
+and do **not** backfill data for runs that existed only in memory before the
+database was initialized.
+
 ```yaml
 persistence:
   # SQLite database path (relative to data_dir)

--- a/docs/container-executor.md
+++ b/docs/container-executor.md
@@ -49,9 +49,9 @@ the container executor aims for:
 - `--network none` (or equivalent),
 - isolated working directories.
 
-Secrets are materialised as files under a dedicated directory such as
-`/run/secrets`, and are not leaked via environment variables unless policy
-explicitly allows it.
+Secret values are never exported via environment variables. Instead, the executor
+receives secret **handles** only. In this branch, only file-based secret handles
+are supported (shape: `{ "type": "file", "path": "..." }`).
 
 Policies can be configured to allow writable rootfs, extra capabilities or
 limited networking in permissive or disabled profiles. All such decisions are

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,12 +28,12 @@ To build and run the reference implementation you need:
 
 ## Clone and build
 
-Clone the official repository and build the static binary:
+Clone the official repository and build the binary (FLOWD avoids CGO, so the build is a self-contained static Go binary.):
 
 ```bash
 $ git clone https://github.com/flowd-org/flowd.git
 $ cd flowd
-$ go build ./cmd/flwd
+$ CGO_ENABLED=0 go build -o flwd .
 ```
 
 This produces a `flwd` binary in the current directory. You can also use any

--- a/docs/job-configuration.md
+++ b/docs/job-configuration.md
@@ -138,6 +138,26 @@ argspec:
       description: "API key for remote storage"
 ```
 
+When an argument is marked as `format: "secret"`:
+
+- Secret values are redacted in user-visible outputs using the `$$REDACTED$$` marker.
+- Secret values are **not** exported to environment variables; the executor receives **handles only**.
+- Only **file-based** secret handles are supported in this branch. The handle shape is:
+  `{ "type": "file", "path": "..." }`.
+- `memfd`-backed secret handles are explicitly deferred (not supported).
+
+**Secret-handle file location and cleanup (operational notes):**
+
+- Secret-handle files are created under the OS temp directory in a flowd-managed
+  subdirectory (for example, `$TMPDIR/flowd-secrets/` on Unix-like systems). The
+  base path is internal and not intended to be configured externally.
+- POSIX: secret files are **unlinked on open**; the job reads via an fd-backed
+  path while the underlying on-disk path is removed.
+- Windows: secret files are opened with **delete-on-close** semantics.
+- On startup, flowd runs a janitor that removes secret directories older than
+  **72h** (defense-in-depth cleanup only).
+- Secret-handle paths are sensitive and MUST NOT be persisted or logged.
+
 ### Composition Modes
 
 #### Single (Default)

--- a/docs/job-configuration.md
+++ b/docs/job-configuration.md
@@ -148,14 +148,15 @@ When an argument is marked as `format: "secret"`:
 
 **Secret-handle file location and cleanup (operational notes):**
 
-- Secret-handle files are created under the OS temp directory in a flowd-managed
-  subdirectory (for example, `$TMPDIR/flowd-secrets/` on Unix-like systems). The
-  base path is internal and not intended to be configured externally.
+- Secret-handle files are created under the flowd instance data directory
+  (configured via `instance.data_dir`), in a flowd-managed subdirectory (for
+  example, `<data_dir>/secrets/`). The base path is internal and not intended to
+  be configured separately.
 - POSIX: secret files are **unlinked on open**; the job reads via an fd-backed
   path while the underlying on-disk path is removed.
 - Windows: secret files are opened with **delete-on-close** semantics.
-- On startup, flowd runs a janitor that removes secret directories older than
-  **72h** (defense-in-depth cleanup only).
+- On startup, flowd runs a janitor that removes secret run directories under the
+  base secrets directory older than **72h** (defense-in-depth cleanup only).
 - Secret-handle paths are sensitive and MUST NOT be persisted or logged.
 
 ### Composition Modes

--- a/docs/serve-mode.md
+++ b/docs/serve-mode.md
@@ -65,7 +65,32 @@ $ curl -Ns -H 'Authorization: Bearer dev-token' \
     http://127.0.0.1:8080/runs/RUN_ID/events
 ```
 
+Stream events for all runs (global stream):
+
+```bash
+$ curl -Ns -H 'Authorization: Bearer dev-token' \
+    http://127.0.0.1:8080/events/stream
+```
+
+Resume a global stream using the last seen sequence number:
+
+```bash
+$ curl -Ns -H 'Authorization: Bearer dev-token' \
+    -H 'Last-Event-ID: 41' \
+    http://127.0.0.1:8080/events/stream
+```
+
+Use the legacy alias endpoint (same behavior as `/events/stream`):
+
+```bash
+$ curl -Ns -H 'Authorization: Bearer dev-token' \
+    http://127.0.0.1:8080/events
+```
+
+The legacy `/events` path is an alias of `/events/stream`.
+
 Events are sent as SSE and can be parsed by dashboards, CLIs or monitoring tools.
+See the API reference for the SSE envelope (`event: flowd`, `retry: 3000`), resume behavior, and stale-cursor semantics.
 
 ## Authentication and scopes
 

--- a/internal/argsloader/loader.go
+++ b/internal/argsloader/loader.go
@@ -30,6 +30,9 @@ func AttachFlags(cmd *cobra.Command, dirPath string) error {
 	for _, a := range spec.Args {
 		name := a.Name
 		desc := a.Description
+		if err := types.ValidateArgName(name); err != nil {
+			return fmt.Errorf("invalid argspec name %q: %w", name, err)
+		}
 		switch a.Type {
 		case "string":
 			def, _ := a.Default.(string)

--- a/internal/coredb/idempotency.go
+++ b/internal/coredb/idempotency.go
@@ -17,6 +17,8 @@ type IdempotencyStore struct {
 	db *sql.DB
 }
 
+const idempotencyStatusInFlight = 0
+
 // NewIdempotencyStore returns a store backed by the provided DB.
 func NewIdempotencyStore(db *DB) *IdempotencyStore {
 	if db == nil {
@@ -71,6 +73,43 @@ func (s *IdempotencyStore) Lookup(ctx context.Context, key, endpoint string, now
 	return body, status, bodyHash, ok, nil
 }
 
+// Reserve inserts a placeholder entry so concurrent requests can detect in-flight work.
+func (s *IdempotencyStore) Reserve(ctx context.Context, key, endpoint, bodyHash string, now, expiresAt time.Time) (reserved bool, err error) {
+	if s == nil {
+		return false, nil
+	}
+	ctx, span := tracing.Start(ctx, "coredb.idempotency.reserve",
+		tracing.PersistDriver(sqliteDriverName),
+		tracing.PersistOp("reserve"),
+		tracing.PersistKeyspace("core_idempotency"),
+		tracing.String("idempotency.key", key),
+		tracing.String("idempotency.endpoint", endpoint),
+	)
+	defer tracing.End(span, &err)
+
+	_, err = s.db.ExecContext(ctx, `DELETE FROM core_idempotency WHERE key = ? AND endpoint = ? AND ttl_expires_at <= ?`, key, endpoint, now.UnixMilli())
+	if err != nil {
+		return false, err
+	}
+
+	createdAt := now.UnixMilli()
+	expires := expiresAt.UnixMilli()
+	res, err := s.db.ExecContext(ctx, `
+INSERT INTO core_idempotency (key, endpoint, body_sha256, status, body, created_at, ttl_expires_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(key, endpoint) DO NOTHING;
+`, key, endpoint, bodyHash, idempotencyStatusInFlight, []byte("{}"), createdAt, expires)
+	if err != nil {
+		return false, err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	reserved = rows > 0
+	return reserved, nil
+}
+
 // Store persists the response payload for the supplied idempotency key.
 func (s *IdempotencyStore) Store(ctx context.Context, key, endpoint, bodyHash string, status int, payload []byte, expiresAt time.Time) (err error) {
 	if s == nil {
@@ -114,4 +153,21 @@ ON CONFLICT(key, endpoint) DO UPDATE SET
 		span.SetAttributes(tracing.String("idempotency.outcome", outcome))
 	}
 	return nil
+}
+
+// Release removes a placeholder entry created for an in-flight request.
+func (s *IdempotencyStore) Release(ctx context.Context, key, endpoint string) (err error) {
+	if s == nil {
+		return nil
+	}
+	ctx, span := tracing.Start(ctx, "coredb.idempotency.release",
+		tracing.PersistDriver(sqliteDriverName),
+		tracing.PersistOp("release"),
+		tracing.PersistKeyspace("core_idempotency"),
+		tracing.String("idempotency.key", key),
+		tracing.String("idempotency.endpoint", endpoint),
+	)
+	defer tracing.End(span, &err)
+	_, err = s.db.ExecContext(ctx, `DELETE FROM core_idempotency WHERE key = ? AND endpoint = ? AND status = ?`, key, endpoint, idempotencyStatusInFlight)
+	return err
 }

--- a/internal/coredb/idempotency.go
+++ b/internal/coredb/idempotency.go
@@ -56,19 +56,23 @@ func (s *IdempotencyStore) Lookup(ctx context.Context, key, endpoint string, now
 	var expires int64
 	if scanErr := row.Scan(&body, &status, &bodyHash, &expires); errors.Is(scanErr, sql.ErrNoRows) {
 		outcome = metrics.PersistenceOutcomeMiss
+		metrics.RecordIdempotencyLookup(metrics.PersistenceOutcomeMiss)
 		err = nil
 		return nil, 0, "", false, nil
 	} else if scanErr != nil {
 		err = scanErr
+		metrics.RecordIdempotencyLookup(metrics.PersistenceOutcomeError)
 		return nil, 0, "", false, err
 	}
 	if expires > 0 && now.UnixMilli() > expires {
 		_, _ = s.db.ExecContext(ctx, `DELETE FROM core_idempotency WHERE key = ? AND endpoint = ?`, key, endpoint)
 		metrics.RecordPersistenceEviction(metrics.PersistenceKindIdempotency, int64(len(body)))
 		outcome = metrics.PersistenceOutcomeExpired
+		metrics.RecordIdempotencyLookup(metrics.PersistenceOutcomeExpired)
 		return nil, 0, "", false, nil
 	}
 	outcome = metrics.PersistenceOutcomeHit
+	metrics.RecordIdempotencyLookup(metrics.PersistenceOutcomeHit)
 	ok = true
 	return body, status, bodyHash, ok, nil
 }

--- a/internal/coredb/journal.go
+++ b/internal/coredb/journal.go
@@ -36,14 +36,17 @@ type Journal struct {
 }
 
 // NewJournal returns a Journal backed by the provided DB with the supplied
-// maximum size budget. When maxBytes is zero or negative the default (64 MiB)
-// is used.
+// maximum size budget. When maxBytes is zero or negative the configured CoreDB
+// journal budget (or the default 64 MiB) is used.
 func NewJournal(db *DB, maxBytes int64) *Journal {
 	if db == nil {
 		return nil
 	}
 	if maxBytes <= 0 {
-		maxBytes = defaultJournalMaxBytes
+		maxBytes = db.opts.JournalMaxBytes
+		if maxBytes <= 0 {
+			maxBytes = defaultJournalMaxBytes
+		}
 	}
 	return &Journal{
 		db:       db.sql,

--- a/internal/coredb/journal.go
+++ b/internal/coredb/journal.go
@@ -210,6 +210,21 @@ FROM core_run_journal WHERE run_id = ?
 	return earliest, latest, nil
 }
 
+// BoundsAll returns the earliest and latest sequence currently retained across
+// all runs. A zero earliest indicates no events are stored.
+func (j *Journal) BoundsAll(ctx context.Context) (earliest, latest int64, err error) {
+	if j == nil {
+		return 0, 0, nil
+	}
+	if err = j.db.QueryRowContext(ctx, `
+SELECT COALESCE(MIN(seq), 0), COALESCE(MAX(seq), 0)
+FROM core_run_journal
+`).Scan(&earliest, &latest); err != nil {
+		return 0, 0, fmt.Errorf("journal bounds: %w", err)
+	}
+	return earliest, latest, nil
+}
+
 // ForEach streams events for the supplied run strictly after the provided
 // sequence (i.e. seq > afterSeq) in ascending order. Iteration halts if the
 // callback returns an error.
@@ -260,6 +275,82 @@ ORDER BY seq ASC
 		var payload []byte
 		var tsMillis int64
 		if scanErr := rows.Scan(&seq, &eventType, &payload, &tsMillis); scanErr != nil {
+			err = fmt.Errorf("journal scan: %w", scanErr)
+			return err
+		}
+		entry := JournalEntry{
+			Seq:       seq,
+			RunID:     runID,
+			EventType: eventType,
+			Payload:   append([]byte(nil), payload...),
+			Timestamp: time.UnixMilli(tsMillis).UTC(),
+		}
+		entries++
+		if span != nil {
+			span.SetAttributes(tracing.Int64("journal.last_seq", entry.Seq))
+		}
+		if fnErr := fn(entry); fnErr != nil {
+			err = fnErr
+			return err
+		}
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		err = fmt.Errorf("journal rows: %w", rowsErr)
+		return err
+	}
+	outcome = metrics.PersistenceOutcomeOK
+	return nil
+}
+
+// ForEachAll streams events across all runs strictly after the provided
+// sequence (i.e. seq > afterSeq) in ascending order.
+func (j *Journal) ForEachAll(ctx context.Context, afterSeq int64, fn func(JournalEntry) error) (err error) {
+	if j == nil || fn == nil {
+		return nil
+	}
+	ctx, span := tracing.Start(ctx, "coredb.journal.read",
+		tracing.PersistDriver(sqliteDriverName),
+		tracing.PersistOp("read"),
+		tracing.PersistKeyspace("core_run_journal"),
+		tracing.Int64("journal.after_seq", afterSeq),
+	)
+	defer tracing.End(span, &err)
+
+	timer := metrics.StartPersistenceTimer(metrics.PersistenceOperationJournalRead)
+	outcome := metrics.PersistenceOutcomeError
+	entries := 0
+	defer func() {
+		if timer != nil {
+			timer.Observe(outcome)
+		}
+		if span != nil {
+			span.SetAttributes(
+				tracing.String("journal.outcome", outcome),
+				tracing.Int("journal.entries", entries),
+			)
+		}
+	}()
+
+	var rows *sql.Rows
+	rows, err = j.db.QueryContext(ctx, `
+SELECT seq, run_id, event_type, payload, ts
+FROM core_run_journal
+WHERE seq > ?
+ORDER BY seq ASC
+`, afterSeq)
+	if err != nil {
+		err = fmt.Errorf("journal query: %w", err)
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var seq int64
+		var runID string
+		var eventType string
+		var payload []byte
+		var tsMillis int64
+		if scanErr := rows.Scan(&seq, &runID, &eventType, &payload, &tsMillis); scanErr != nil {
 			err = fmt.Errorf("journal scan: %w", scanErr)
 			return err
 		}

--- a/internal/coredb/journal_test.go
+++ b/internal/coredb/journal_test.go
@@ -24,7 +24,7 @@ func TestJournalAppendAndIterate(t *testing.T) {
 	journal := NewJournal(db, 0)
 
 	ts := time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC)
-	first, err := journal.Append(ctx, "run-1", "run.start", []byte(`{"status":"running"}`), ts)
+	first, err := journal.Append(ctx, "run-1", "run.started", []byte(`{"status":"running"}`), ts)
 	if err != nil {
 		t.Fatalf("append first: %v", err)
 	}
@@ -32,7 +32,7 @@ func TestJournalAppendAndIterate(t *testing.T) {
 		t.Fatalf("expected sequence > 0")
 	}
 
-	second, err := journal.Append(ctx, "run-1", "step.log", []byte(`{"message":"hello"}`), ts.Add(time.Second))
+	second, err := journal.Append(ctx, "run-1", "step.output", []byte(`{"message":"hello"}`), ts.Add(time.Second))
 	if err != nil {
 		t.Fatalf("append second: %v", err)
 	}
@@ -56,8 +56,8 @@ func TestJournalAppendAndIterate(t *testing.T) {
 	if !entries[0].Timestamp.Equal(ts) {
 		t.Fatalf("expected first timestamp %v, got %v", ts, entries[0].Timestamp)
 	}
-	if entries[1].EventType != "step.log" {
-		t.Fatalf("expected event type step.log, got %s", entries[1].EventType)
+	if entries[1].EventType != "step.output" {
+		t.Fatalf("expected event type step.output, got %s", entries[1].EventType)
 	}
 }
 
@@ -77,10 +77,10 @@ func TestJournalEvictsOldestWhenOverLimit(t *testing.T) {
 	// Limit well below two payloads to force eviction of the first.
 	journal := NewJournal(db, 30)
 
-	if _, err := journal.Append(ctx, "run-1", "step.log", []byte(`{"message":"alpha"}`), time.Now().UTC()); err != nil {
+	if _, err := journal.Append(ctx, "run-1", "step.output", []byte(`{"message":"alpha"}`), time.Now().UTC()); err != nil {
 		t.Fatalf("append alpha: %v", err)
 	}
-	second, err := journal.Append(ctx, "run-1", "step.log", []byte(`{"message":"bravo"}`), time.Now().UTC())
+	second, err := journal.Append(ctx, "run-1", "step.output", []byte(`{"message":"bravo"}`), time.Now().UTC())
 	if err != nil {
 		t.Fatalf("append bravo: %v", err)
 	}
@@ -122,7 +122,7 @@ func TestJournalRejectsPayloadAboveLimit(t *testing.T) {
 	})
 
 	journal := NewJournal(db, 8) // eight bytes max
-	_, err = journal.Append(ctx, "run-1", "step.log", []byte(`{"msg":"too big"}`), time.Now().UTC())
+	_, err = journal.Append(ctx, "run-1", "step.output", []byte(`{"msg":"too big"}`), time.Now().UTC())
 	if !errors.Is(err, ErrJournalQuotaExceeded) {
 		t.Fatalf("expected ErrJournalQuotaExceeded, got %v", err)
 	}
@@ -146,7 +146,7 @@ func TestJournalEvictionAppendAtomicity(t *testing.T) {
 		t.Fatal("expected journal")
 	}
 
-	if _, err := journal.Append(ctx, "run-1", "step.log", []byte(`{"message":"alpha"}`), time.Now().UTC()); err != nil {
+	if _, err := journal.Append(ctx, "run-1", "step.output", []byte(`{"message":"alpha"}`), time.Now().UTC()); err != nil {
 		t.Fatalf("append seed: %v", err)
 	}
 
@@ -166,7 +166,7 @@ func TestJournalEvictionAppendAtomicity(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 200; i++ {
-			if _, err := journal.Append(ctx, "run-1", "step.log", []byte(`{"message":"bravo"}`), time.Now().UTC()); err != nil {
+			if _, err := journal.Append(ctx, "run-1", "step.output", []byte(`{"message":"bravo"}`), time.Now().UTC()); err != nil {
 				errCh <- err
 				return
 			}

--- a/internal/coredb/journal_test.go
+++ b/internal/coredb/journal_test.go
@@ -128,6 +128,79 @@ func TestJournalRejectsPayloadAboveLimit(t *testing.T) {
 	}
 }
 
+func TestJournalBoundsAfterEvictionAcrossRuns(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	db, err := Open(ctx, Options{DataDir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+
+	// Limit forces eviction after the third append (10 + 10 + 10 > 20).
+	journal := NewJournal(db, 20)
+	if journal == nil {
+		t.Fatal("expected journal")
+	}
+
+	payload := []byte("1234567890")
+	first, err := journal.Append(ctx, "run-1", "step.output", payload, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("append first: %v", err)
+	}
+	second, err := journal.Append(ctx, "run-2", "step.output", payload, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("append second: %v", err)
+	}
+	third, err := journal.Append(ctx, "run-1", "step.output", payload, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("append third: %v", err)
+	}
+
+	if first.Seq == 0 || second.Seq == 0 || third.Seq == 0 {
+		t.Fatalf("expected non-zero sequences, got first=%d second=%d third=%d", first.Seq, second.Seq, third.Seq)
+	}
+
+	earliestAll, latestAll, err := journal.BoundsAll(ctx)
+	if err != nil {
+		t.Fatalf("bounds all: %v", err)
+	}
+	if earliestAll != second.Seq || latestAll != third.Seq {
+		t.Fatalf("expected bounds all earliest=%d latest=%d, got earliest=%d latest=%d", second.Seq, third.Seq, earliestAll, latestAll)
+	}
+
+	earliestRun1, latestRun1, err := journal.Bounds(ctx, "run-1")
+	if err != nil {
+		t.Fatalf("bounds run-1: %v", err)
+	}
+	if earliestRun1 != third.Seq || latestRun1 != third.Seq {
+		t.Fatalf("expected run-1 bounds to equal third seq %d, got earliest=%d latest=%d", third.Seq, earliestRun1, latestRun1)
+	}
+
+	earliestRun2, latestRun2, err := journal.Bounds(ctx, "run-2")
+	if err != nil {
+		t.Fatalf("bounds run-2: %v", err)
+	}
+	if earliestRun2 != second.Seq || latestRun2 != second.Seq {
+		t.Fatalf("expected run-2 bounds to equal second seq %d, got earliest=%d latest=%d", second.Seq, earliestRun2, latestRun2)
+	}
+
+	var run1Entries []int64
+	if err := journal.ForEach(ctx, "run-1", 0, func(entry JournalEntry) error {
+		run1Entries = append(run1Entries, entry.Seq)
+		return nil
+	}); err != nil {
+		t.Fatalf("iterate run-1: %v", err)
+	}
+	if len(run1Entries) != 1 || run1Entries[0] != third.Seq {
+		t.Fatalf("expected only third seq retained for run-1, got %v", run1Entries)
+	}
+}
+
 func TestJournalEvictionAppendAtomicity(t *testing.T) {
 	t.Parallel()
 

--- a/internal/coredb/journal_test.go
+++ b/internal/coredb/journal_test.go
@@ -3,6 +3,7 @@ package coredb
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 )
@@ -124,6 +125,88 @@ func TestJournalRejectsPayloadAboveLimit(t *testing.T) {
 	_, err = journal.Append(ctx, "run-1", "step.log", []byte(`{"msg":"too big"}`), time.Now().UTC())
 	if !errors.Is(err, ErrJournalQuotaExceeded) {
 		t.Fatalf("expected ErrJournalQuotaExceeded, got %v", err)
+	}
+}
+
+func TestJournalEvictionAppendAtomicity(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	db, err := Open(ctx, Options{DataDir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+
+	journal := NewJournal(db, 30)
+	if journal == nil {
+		t.Fatal("expected journal")
+	}
+
+	if _, err := journal.Append(ctx, "run-1", "step.log", []byte(`{"message":"alpha"}`), time.Now().UTC()); err != nil {
+		t.Fatalf("append seed: %v", err)
+	}
+
+	earliest, latest, err := journal.Bounds(ctx, "run-1")
+	if err != nil {
+		t.Fatalf("bounds seed: %v", err)
+	}
+	if earliest == 0 || latest == 0 {
+		t.Fatalf("expected seeded bounds to be non-zero, got earliest=%d latest=%d", earliest, latest)
+	}
+
+	stop := make(chan struct{})
+	errCh := make(chan error, 1)
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			if _, err := journal.Append(ctx, "run-1", "step.log", []byte(`{"message":"bravo"}`), time.Now().UTC()); err != nil {
+				errCh <- err
+				return
+			}
+		}
+		close(stop)
+	}()
+
+	for {
+		select {
+		case err := <-errCh:
+			wg.Wait()
+			t.Fatalf("append loop error: %v", err)
+		case <-stop:
+			wg.Wait()
+			goto Done
+		default:
+			currentEarliest, currentLatest, err := journal.Bounds(ctx, "run-1")
+			if err != nil {
+				wg.Wait()
+				t.Fatalf("bounds read: %v", err)
+			}
+			if currentEarliest == 0 || currentLatest == 0 {
+				wg.Wait()
+				t.Fatalf("observed empty bounds during append, earliest=%d latest=%d", currentEarliest, currentLatest)
+			}
+			if currentEarliest > currentLatest {
+				wg.Wait()
+				t.Fatalf("observed inverted bounds during append, earliest=%d latest=%d", currentEarliest, currentLatest)
+			}
+			time.Sleep(1 * time.Millisecond)
+		}
+	}
+
+Done:
+	finalEarliest, finalLatest, err := journal.Bounds(ctx, "run-1")
+	if err != nil {
+		t.Fatalf("bounds final: %v", err)
+	}
+	if finalEarliest == 0 || finalLatest == 0 {
+		t.Fatalf("expected final bounds to be non-zero, got earliest=%d latest=%d", finalEarliest, finalLatest)
 	}
 }
 

--- a/internal/coredb/migrations.go
+++ b/internal/coredb/migrations.go
@@ -21,6 +21,19 @@ var baseMigrations = [...]string{
 		PRIMARY KEY (key, endpoint)
 	);`,
 	`CREATE INDEX IF NOT EXISTS idx_core_idemp_ttl ON core_idempotency(ttl_expires_at);`,
+	`CREATE TABLE IF NOT EXISTS core_runs (
+		run_id TEXT PRIMARY KEY,
+		job_id TEXT NOT NULL,
+		status TEXT NOT NULL,
+		started_at INTEGER NOT NULL,
+		finished_at INTEGER,
+		result BLOB,
+		executor TEXT,
+		runtime TEXT,
+		security_profile TEXT,
+		provenance BLOB
+	);`,
+	`CREATE INDEX IF NOT EXISTS idx_core_runs_started_at ON core_runs(started_at);`,
 	`CREATE TABLE IF NOT EXISTS core_run_journal (
 		seq INTEGER PRIMARY KEY AUTOINCREMENT,
 		run_id TEXT NOT NULL,

--- a/internal/coredb/migrations.go
+++ b/internal/coredb/migrations.go
@@ -31,7 +31,8 @@ var baseMigrations = [...]string{
 		executor TEXT,
 		runtime TEXT,
 		security_profile TEXT,
-		provenance BLOB
+		provenance BLOB,
+		request_id TEXT
 	);`,
 	`CREATE INDEX IF NOT EXISTS idx_core_runs_started_at ON core_runs(started_at);`,
 	`CREATE TABLE IF NOT EXISTS core_run_journal (
@@ -49,6 +50,38 @@ func applyMigrations(ctx context.Context, conn *sql.DB) error {
 		if _, err := conn.ExecContext(ctx, stmt); err != nil {
 			return fmt.Errorf("apply migration: %w", err)
 		}
+	}
+	if err := ensureRunRequestIDColumn(ctx, conn); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ensureRunRequestIDColumn(ctx context.Context, conn *sql.DB) error {
+	rows, err := conn.QueryContext(ctx, "PRAGMA table_info(core_runs);")
+	if err != nil {
+		return fmt.Errorf("inspect core_runs schema: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid int
+		var name string
+		var ctype string
+		var notnull int
+		var dflt sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			return fmt.Errorf("inspect core_runs schema: %w", err)
+		}
+		if name == "request_id" {
+			return nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("inspect core_runs schema: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, "ALTER TABLE core_runs ADD COLUMN request_id TEXT;"); err != nil {
+		return fmt.Errorf("add core_runs.request_id: %w", err)
 	}
 	return nil
 }

--- a/internal/coredb/runs.go
+++ b/internal/coredb/runs.go
@@ -22,6 +22,7 @@ type RunRecord struct {
 	Runtime         string
 	SecurityProfile string
 	Provenance      map[string]any
+	RequestID       string
 }
 
 // RunStore provides CoreDB-backed run record persistence.
@@ -52,7 +53,7 @@ func (s *RunStore) Get(ctx context.Context, id string) (RunRecord, bool, error) 
 	if s == nil {
 		return RunRecord{}, false, nil
 	}
-	row := s.db.QueryRowContext(ctx, `SELECT run_id, job_id, status, started_at, finished_at, result, executor, runtime, security_profile, provenance FROM core_runs WHERE run_id = ?`, id)
+	row := s.db.QueryRowContext(ctx, `SELECT run_id, job_id, status, started_at, finished_at, result, executor, runtime, security_profile, provenance, request_id FROM core_runs WHERE run_id = ?`, id)
 	var rec RunRecord
 	var startedAt int64
 	var finishedAt sql.NullInt64
@@ -61,7 +62,8 @@ func (s *RunStore) Get(ctx context.Context, id string) (RunRecord, bool, error) 
 	var executor sql.NullString
 	var runtime sql.NullString
 	var securityProfile sql.NullString
-	if err := row.Scan(&rec.ID, &rec.JobID, &rec.Status, &startedAt, &finishedAt, &resultBytes, &executor, &runtime, &securityProfile, &provenanceBytes); errors.Is(err, sql.ErrNoRows) {
+	var requestID sql.NullString
+	if err := row.Scan(&rec.ID, &rec.JobID, &rec.Status, &startedAt, &finishedAt, &resultBytes, &executor, &runtime, &securityProfile, &provenanceBytes, &requestID); errors.Is(err, sql.ErrNoRows) {
 		return RunRecord{}, false, nil
 	} else if err != nil {
 		return RunRecord{}, false, err
@@ -81,6 +83,9 @@ func (s *RunStore) Get(ctx context.Context, id string) (RunRecord, bool, error) 
 	}
 	if securityProfile.Valid {
 		rec.SecurityProfile = securityProfile.String
+	}
+	if requestID.Valid {
+		rec.RequestID = requestID.String
 	}
 	if len(resultBytes) > 0 {
 		var result map[string]any
@@ -102,7 +107,7 @@ func (s *RunStore) List(ctx context.Context) ([]RunRecord, error) {
 	if s == nil {
 		return nil, nil
 	}
-	rows, err := s.db.QueryContext(ctx, `SELECT run_id, job_id, status, started_at, finished_at, result, executor, runtime, security_profile, provenance FROM core_runs ORDER BY started_at DESC`)
+	rows, err := s.db.QueryContext(ctx, `SELECT run_id, job_id, status, started_at, finished_at, result, executor, runtime, security_profile, provenance, request_id FROM core_runs ORDER BY started_at DESC`)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +122,8 @@ func (s *RunStore) List(ctx context.Context) ([]RunRecord, error) {
 		var executor sql.NullString
 		var runtime sql.NullString
 		var securityProfile sql.NullString
-		if err := rows.Scan(&rec.ID, &rec.JobID, &rec.Status, &startedAt, &finishedAt, &resultBytes, &executor, &runtime, &securityProfile, &provenanceBytes); err != nil {
+		var requestID sql.NullString
+		if err := rows.Scan(&rec.ID, &rec.JobID, &rec.Status, &startedAt, &finishedAt, &resultBytes, &executor, &runtime, &securityProfile, &provenanceBytes, &requestID); err != nil {
 			return nil, err
 		}
 		if startedAt > 0 {
@@ -135,6 +141,9 @@ func (s *RunStore) List(ctx context.Context) ([]RunRecord, error) {
 		}
 		if securityProfile.Valid {
 			rec.SecurityProfile = securityProfile.String
+		}
+		if requestID.Valid {
+			rec.RequestID = requestID.String
 		}
 		if len(resultBytes) > 0 {
 			var result map[string]any
@@ -173,8 +182,8 @@ func (s *RunStore) upsert(ctx context.Context, record RunRecord) error {
 		finishedAt = record.FinishedAt.UnixMilli()
 	}
 	_, err = s.db.ExecContext(ctx, `
-INSERT INTO core_runs (run_id, job_id, status, started_at, finished_at, result, executor, runtime, security_profile, provenance)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO core_runs (run_id, job_id, status, started_at, finished_at, result, executor, runtime, security_profile, provenance, request_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(run_id) DO UPDATE SET
   job_id = excluded.job_id,
   status = excluded.status,
@@ -184,8 +193,9 @@ ON CONFLICT(run_id) DO UPDATE SET
   executor = excluded.executor,
   runtime = excluded.runtime,
   security_profile = excluded.security_profile,
-  provenance = excluded.provenance;
-`, record.ID, record.JobID, record.Status, record.StartedAt.UnixMilli(), finishedAt, resultBytes, record.Executor, record.Runtime, record.SecurityProfile, provenanceBytes)
+  provenance = excluded.provenance,
+  request_id = excluded.request_id;
+`, record.ID, record.JobID, record.Status, record.StartedAt.UnixMilli(), finishedAt, resultBytes, record.Executor, record.Runtime, record.SecurityProfile, provenanceBytes, record.RequestID)
 	return err
 }
 

--- a/internal/coredb/runs.go
+++ b/internal/coredb/runs.go
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package coredb
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// RunRecord represents persisted run metadata.
+type RunRecord struct {
+	ID              string
+	JobID           string
+	Status          string
+	StartedAt       time.Time
+	FinishedAt      *time.Time
+	Result          map[string]any
+	Executor        string
+	Runtime         string
+	SecurityProfile string
+	Provenance      map[string]any
+}
+
+// RunStore provides CoreDB-backed run record persistence.
+type RunStore struct {
+	db *sql.DB
+}
+
+// NewRunStore returns a run store backed by the provided DB.
+func NewRunStore(db *DB) *RunStore {
+	if db == nil {
+		return nil
+	}
+	return &RunStore{db: db.sql}
+}
+
+// Create inserts or replaces a run record.
+func (s *RunStore) Create(ctx context.Context, record RunRecord) error {
+	return s.upsert(ctx, record)
+}
+
+// Update replaces a run record by ID.
+func (s *RunStore) Update(ctx context.Context, record RunRecord) error {
+	return s.upsert(ctx, record)
+}
+
+// Get retrieves a run record by ID.
+func (s *RunStore) Get(ctx context.Context, id string) (RunRecord, bool, error) {
+	if s == nil {
+		return RunRecord{}, false, nil
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT run_id, job_id, status, started_at, finished_at, result, executor, runtime, security_profile, provenance FROM core_runs WHERE run_id = ?`, id)
+	var rec RunRecord
+	var startedAt int64
+	var finishedAt sql.NullInt64
+	var resultBytes []byte
+	var provenanceBytes []byte
+	var executor sql.NullString
+	var runtime sql.NullString
+	var securityProfile sql.NullString
+	if err := row.Scan(&rec.ID, &rec.JobID, &rec.Status, &startedAt, &finishedAt, &resultBytes, &executor, &runtime, &securityProfile, &provenanceBytes); errors.Is(err, sql.ErrNoRows) {
+		return RunRecord{}, false, nil
+	} else if err != nil {
+		return RunRecord{}, false, err
+	}
+	if startedAt > 0 {
+		rec.StartedAt = time.UnixMilli(startedAt)
+	}
+	if finishedAt.Valid {
+		stamp := time.UnixMilli(finishedAt.Int64)
+		rec.FinishedAt = &stamp
+	}
+	if executor.Valid {
+		rec.Executor = executor.String
+	}
+	if runtime.Valid {
+		rec.Runtime = runtime.String
+	}
+	if securityProfile.Valid {
+		rec.SecurityProfile = securityProfile.String
+	}
+	if len(resultBytes) > 0 {
+		var result map[string]any
+		if err := json.Unmarshal(resultBytes, &result); err == nil {
+			rec.Result = result
+		}
+	}
+	if len(provenanceBytes) > 0 {
+		var provenance map[string]any
+		if err := json.Unmarshal(provenanceBytes, &provenance); err == nil {
+			rec.Provenance = provenance
+		}
+	}
+	return rec, true, nil
+}
+
+// List returns runs sorted by started_at descending.
+func (s *RunStore) List(ctx context.Context) ([]RunRecord, error) {
+	if s == nil {
+		return nil, nil
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT run_id, job_id, status, started_at, finished_at, result, executor, runtime, security_profile, provenance FROM core_runs ORDER BY started_at DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []RunRecord
+	for rows.Next() {
+		var rec RunRecord
+		var startedAt int64
+		var finishedAt sql.NullInt64
+		var resultBytes []byte
+		var provenanceBytes []byte
+		var executor sql.NullString
+		var runtime sql.NullString
+		var securityProfile sql.NullString
+		if err := rows.Scan(&rec.ID, &rec.JobID, &rec.Status, &startedAt, &finishedAt, &resultBytes, &executor, &runtime, &securityProfile, &provenanceBytes); err != nil {
+			return nil, err
+		}
+		if startedAt > 0 {
+			rec.StartedAt = time.UnixMilli(startedAt)
+		}
+		if finishedAt.Valid {
+			stamp := time.UnixMilli(finishedAt.Int64)
+			rec.FinishedAt = &stamp
+		}
+		if executor.Valid {
+			rec.Executor = executor.String
+		}
+		if runtime.Valid {
+			rec.Runtime = runtime.String
+		}
+		if securityProfile.Valid {
+			rec.SecurityProfile = securityProfile.String
+		}
+		if len(resultBytes) > 0 {
+			var result map[string]any
+			if err := json.Unmarshal(resultBytes, &result); err == nil {
+				rec.Result = result
+			}
+		}
+		if len(provenanceBytes) > 0 {
+			var provenance map[string]any
+			if err := json.Unmarshal(provenanceBytes, &provenance); err == nil {
+				rec.Provenance = provenance
+			}
+		}
+		out = append(out, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (s *RunStore) upsert(ctx context.Context, record RunRecord) error {
+	if s == nil {
+		return nil
+	}
+	resultBytes, err := encodeJSONMap(record.Result)
+	if err != nil {
+		return err
+	}
+	provenanceBytes, err := encodeJSONMap(record.Provenance)
+	if err != nil {
+		return err
+	}
+	var finishedAt any
+	if record.FinishedAt != nil {
+		finishedAt = record.FinishedAt.UnixMilli()
+	}
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO core_runs (run_id, job_id, status, started_at, finished_at, result, executor, runtime, security_profile, provenance)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(run_id) DO UPDATE SET
+  job_id = excluded.job_id,
+  status = excluded.status,
+  started_at = excluded.started_at,
+  finished_at = excluded.finished_at,
+  result = excluded.result,
+  executor = excluded.executor,
+  runtime = excluded.runtime,
+  security_profile = excluded.security_profile,
+  provenance = excluded.provenance;
+`, record.ID, record.JobID, record.Status, record.StartedAt.UnixMilli(), finishedAt, resultBytes, record.Executor, record.Runtime, record.SecurityProfile, provenanceBytes)
+	return err
+}
+
+func encodeJSONMap(value map[string]any) ([]byte, error) {
+	if len(value) == 0 {
+		return nil, nil
+	}
+	return json.Marshal(value)
+}

--- a/internal/e2e/cli_e2e_test.go
+++ b/internal/e2e/cli_e2e_test.go
@@ -343,8 +343,8 @@ func TestCLIServeMode(t *testing.T) {
 	if err := json.NewDecoder(resp410.Body).Decode(&problem410); err != nil {
 		t.Fatalf("decode 410 problem: %v", err)
 	}
-	if problem410["type"] != "https://flowd.dev/problems/cursor-expired" {
-		t.Fatalf("expected cursor-expired type, got %v", problem410["type"])
+	if problem410["type"] != "https://flowd.org/problems/sse/stale-cursor" {
+		t.Fatalf("expected stale-cursor type, got %v", problem410["type"])
 	}
 
 	// Idempotency replay should succeed; conflict on body mismatch should return 409
@@ -623,8 +623,8 @@ func TestCLIServeConformanceErrors(t *testing.T) {
 		t.Fatalf("expected 410 cursor expired, got %d (%s)", resp410.StatusCode, string(body))
 	}
 	prob410 := readProblem(resp410)
-	if typ, _ := prob410["type"].(string); typ != "https://flowd.dev/problems/cursor-expired" {
-		t.Fatalf("expected cursor-expired type, got %q", typ)
+	if typ, _ := prob410["type"].(string); typ != "https://flowd.org/problems/sse/stale-cursor" {
+		t.Fatalf("expected stale-cursor type, got %q", typ)
 	}
 }
 

--- a/internal/e2e/cli_e2e_test.go
+++ b/internal/e2e/cli_e2e_test.go
@@ -76,6 +76,9 @@ func TestCLIJobsTableTTY(t *testing.T) {
 	cmd := exec.Command(flowdBinary, ":jobs")
 	cmd.Dir = workspace
 	dataDir := workspaceDataDir(workspace)
+	if runtime.GOOS != "linux" {
+		t.Skip("PTY-based TTY test requires linux (current PTY impl is linux-only)")
+	}
 	if err := os.MkdirAll(dataDir, 0o755); err != nil {
 		t.Fatalf("create data dir: %v", err)
 	}
@@ -301,7 +304,7 @@ func TestCLIServeMode(t *testing.T) {
 	// POST /runs
 	runResp := httpPost(t, client, addr, "/runs", `{"job_id":"demo","args":{"name":"Jordan"}}`)
 	defer runResp.Body.Close()
-	if runResp.StatusCode != http.StatusAccepted && runResp.StatusCode != http.StatusOK {
+	if runResp.StatusCode != http.StatusAccepted && runResp.StatusCode != http.StatusOK && runResp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(runResp.Body)
 		t.Fatalf("POST /runs status=%d body=%s", runResp.StatusCode, string(body))
 	}
@@ -352,7 +355,7 @@ func TestCLIServeMode(t *testing.T) {
 		t.Fatalf("build idempotent request: %v", err)
 	}
 	reqIdem.Header.Set("Content-Type", "application/json")
-	if err := addSpecificIdempotencyHeader(reqIdem, "cli-e2e-idem", bodyGood); err != nil {
+	if err := addSpecificIdempotencyHeader(reqIdem, "cli-e2e-idempotency-key-0001", bodyGood); err != nil {
 		t.Fatalf("set idempotency header: %v", err)
 	}
 	firstIdem := httpDo(t, client, reqIdem)
@@ -370,7 +373,7 @@ func TestCLIServeMode(t *testing.T) {
 		t.Fatalf("build conflict request: %v", err)
 	}
 	reqConflict.Header.Set("Content-Type", "application/json")
-	if err := addSpecificIdempotencyHeader(reqConflict, "cli-e2e-idem", bodyConflict); err != nil {
+	if err := addSpecificIdempotencyHeader(reqConflict, "cli-e2e-idempotency-key-0001", bodyConflict); err != nil {
 		t.Fatalf("set conflict headers: %v", err)
 	}
 	respConflict := httpDo(t, client, reqConflict)
@@ -675,7 +678,7 @@ func buildFlowdBinary() (string, error) {
 		return "", err
 	}
 	binPath := filepath.Join(binDir, "flowd-e2e")
-	cmd := exec.Command("go", "build", "-o", binPath, "./cmd/flowd")
+	cmd := exec.Command("go", "build", "-o", binPath, "./")
 	cmd.Dir = root
 	cacheDir := filepath.Join(binDir, "gocache")
 	modCache := filepath.Join(binDir, "gomodcache")
@@ -686,8 +689,9 @@ func buildFlowdBinary() (string, error) {
 		return "", err
 	}
 	cmd.Env = append(os.Environ(), "GOCACHE="+cacheDir, "GOMODCACHE="+modCache)
-	if err := cmd.Run(); err != nil {
-		return "", err
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("go build ./ failed: %w\n%s", err, out)
 	}
 	return binPath, nil
 }
@@ -1108,7 +1112,9 @@ func waitForServe(t *testing.T, cmd *exec.Cmd, addr string, waitCh <-chan error,
 	deadline := time.Now().Add(10 * time.Second)
 	url := fmt.Sprintf("http://%s/healthz", addr)
 	for time.Now().Before(deadline) {
-		resp, err := client.Get(url)
+		req, _ := http.NewRequest(http.MethodGet, url, nil)
+		req.Header.Set("Authorization", "Bearer jobs:read")
+		resp, err := client.Do(req)
 		if err == nil {
 			resp.Body.Close()
 			if resp.StatusCode == http.StatusNoContent {

--- a/internal/e2e/cli_e2e_test.go
+++ b/internal/e2e/cli_e2e_test.go
@@ -386,7 +386,7 @@ func TestCLIServeMode(t *testing.T) {
 	if err := json.NewDecoder(respConflict.Body).Decode(&prob409); err != nil {
 		t.Fatalf("decode conflict problem: %v", err)
 	}
-	if prob409["type"] != "https://flowd.dev/problems/idempotency-key-conflict" {
+	if prob409["type"] != "https://flowd.org/problems/idempotency/mismatch" {
 		t.Fatalf("expected idempotency conflict type, got %v", prob409["type"])
 	}
 }
@@ -579,7 +579,7 @@ func TestCLIServeConformanceErrors(t *testing.T) {
 		t.Fatalf("expected 409 conflict, got %d (%s)", respConflict.StatusCode, string(body))
 	}
 	prob409 := readProblem(respConflict)
-	if typ, _ := prob409["type"].(string); typ != "https://flowd.dev/problems/idempotency-key-conflict" {
+	if typ, _ := prob409["type"].(string); typ != "https://flowd.org/problems/idempotency/mismatch" {
 		t.Fatalf("expected idempotency conflict type, got %q", typ)
 	}
 

--- a/internal/engine/bind_map.go
+++ b/internal/engine/bind_map.go
@@ -2,7 +2,6 @@
 package engine
 
 import (
-	"errors"
 	"io"
 	"strconv"
 
@@ -24,12 +23,18 @@ func BindArgs(spec types.ArgSpec, args map[string]interface{}) (*Binding, error)
 	}
 
 	for name := range args {
+		if err := types.ValidateArgName(name); err != nil {
+			return nil, &ArgError{Arg: name, Msg: err.Error()}
+		}
 		if !hasArgInSpec(spec, name) {
-			return nil, errors.New("unknown argument: " + name)
+			return nil, &ArgError{Arg: name, Msg: "unknown argument"}
 		}
 	}
 
 	for _, arg := range spec.Args {
+		if err := types.ValidateArgName(arg.Name); err != nil {
+			return nil, &ArgError{Arg: arg.Name, Msg: err.Error()}
+		}
 		val, ok := args[arg.Name]
 		if !ok {
 			continue
@@ -44,6 +49,9 @@ func BindArgs(spec types.ArgSpec, args map[string]interface{}) (*Binding, error)
 
 func attachSpecFlagsForBind(fs *pflag.FlagSet, spec types.ArgSpec) error {
 	for _, a := range spec.Args {
+		if err := types.ValidateArgName(a.Name); err != nil {
+			return &ArgError{Arg: a.Name, Msg: err.Error()}
+		}
 		switch a.Type {
 		case "string":
 			def, _ := a.Default.(string)
@@ -65,7 +73,7 @@ func attachSpecFlagsForBind(fs *pflag.FlagSet, spec types.ArgSpec) error {
 		case "array", "object":
 			fs.StringArray(a.Name, nil, "")
 		default:
-			return errors.New("unsupported arg type: " + a.Type)
+			return &ArgError{Arg: a.Name, Msg: "unsupported arg type"}
 		}
 	}
 	return nil
@@ -76,13 +84,13 @@ func setFlagFromValueForBind(fs *pflag.FlagSet, arg types.Arg, val interface{}) 
 	case "string":
 		s, ok := val.(string)
 		if !ok {
-			return errors.New("argument " + arg.Name + " must be a string")
+			return &ArgError{Arg: arg.Name, Msg: "must be a string"}
 		}
 		return fs.Set(arg.Name, s)
 	case "boolean":
 		b, ok := val.(bool)
 		if !ok {
-			return errors.New("argument " + arg.Name + " must be a boolean")
+			return &ArgError{Arg: arg.Name, Msg: "must be a boolean"}
 		}
 		return fs.Set(arg.Name, strconv.FormatBool(b))
 	case "integer":
@@ -94,7 +102,7 @@ func setFlagFromValueForBind(fs *pflag.FlagSet, arg types.Arg, val interface{}) 
 		case int64:
 			return fs.Set(arg.Name, strconv.Itoa(int(v)))
 		default:
-			return errors.New("argument " + arg.Name + " must be an integer")
+			return &ArgError{Arg: arg.Name, Msg: "must be an integer"}
 		}
 	case "array":
 		switch arr := val.(type) {
@@ -102,7 +110,7 @@ func setFlagFromValueForBind(fs *pflag.FlagSet, arg types.Arg, val interface{}) 
 			for _, item := range arr {
 				s, ok := item.(string)
 				if !ok {
-					return errors.New("argument " + arg.Name + " array items must be strings")
+					return &ArgError{Arg: arg.Name, Msg: "array items must be strings"}
 				}
 				if err := fs.Set(arg.Name, s); err != nil {
 					return err
@@ -117,17 +125,17 @@ func setFlagFromValueForBind(fs *pflag.FlagSet, arg types.Arg, val interface{}) 
 			}
 			return nil
 		default:
-			return errors.New("argument " + arg.Name + " must be an array of strings")
+			return &ArgError{Arg: arg.Name, Msg: "must be an array of strings"}
 		}
 	case "object":
 		mp, ok := val.(map[string]interface{})
 		if !ok {
-			return errors.New("argument " + arg.Name + " must be an object")
+			return &ArgError{Arg: arg.Name, Msg: "must be an object"}
 		}
 		for k, v := range mp {
 			str, ok := v.(string)
 			if !ok {
-				return errors.New("argument " + arg.Name + " values must be strings")
+				return &ArgError{Arg: arg.Name, Msg: "object values must be strings"}
 			}
 			if err := fs.Set(arg.Name, k+"="+str); err != nil {
 				return err
@@ -135,7 +143,7 @@ func setFlagFromValueForBind(fs *pflag.FlagSet, arg types.Arg, val interface{}) 
 		}
 		return nil
 	default:
-		return errors.New("unsupported arg type: " + arg.Type)
+		return &ArgError{Arg: arg.Name, Msg: "unsupported arg type"}
 	}
 }
 

--- a/internal/engine/bind_map.go
+++ b/internal/engine/bind_map.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package engine
+
+import (
+	"errors"
+	"io"
+	"strconv"
+
+	"github.com/flowd-org/flowd/internal/types"
+	"github.com/spf13/pflag"
+)
+
+// BindArgs validates args against spec and returns an engine Binding.
+// This mirrors the HTTP planning path, but lives in engine so orchestration can be shared.
+func BindArgs(spec types.ArgSpec, args map[string]interface{}) (*Binding, error) {
+	if args == nil {
+		args = map[string]interface{}{}
+	}
+
+	fs := pflag.NewFlagSet("engine-bind", pflag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	if err := attachSpecFlagsForBind(fs, spec); err != nil {
+		return nil, err
+	}
+
+	for name := range args {
+		if !hasArgInSpec(spec, name) {
+			return nil, errors.New("unknown argument: " + name)
+		}
+	}
+
+	for _, arg := range spec.Args {
+		val, ok := args[arg.Name]
+		if !ok {
+			continue
+		}
+		if err := setFlagFromValueForBind(fs, arg, val); err != nil {
+			return nil, err
+		}
+	}
+
+	return ValidateAndBind(fs, spec)
+}
+
+func attachSpecFlagsForBind(fs *pflag.FlagSet, spec types.ArgSpec) error {
+	for _, a := range spec.Args {
+		switch a.Type {
+		case "string":
+			def, _ := a.Default.(string)
+			fs.String(a.Name, def, "")
+		case "boolean":
+			def, _ := a.Default.(bool)
+			fs.Bool(a.Name, def, "")
+		case "integer":
+			var defInt int
+			switch v := a.Default.(type) {
+			case int:
+				defInt = v
+			case int64:
+				defInt = int(v)
+			case float64:
+				defInt = int(v)
+			}
+			fs.Int(a.Name, defInt, "")
+		case "array", "object":
+			fs.StringArray(a.Name, nil, "")
+		default:
+			return errors.New("unsupported arg type: " + a.Type)
+		}
+	}
+	return nil
+}
+
+func setFlagFromValueForBind(fs *pflag.FlagSet, arg types.Arg, val interface{}) error {
+	switch arg.Type {
+	case "string":
+		s, ok := val.(string)
+		if !ok {
+			return errors.New("argument " + arg.Name + " must be a string")
+		}
+		return fs.Set(arg.Name, s)
+	case "boolean":
+		b, ok := val.(bool)
+		if !ok {
+			return errors.New("argument " + arg.Name + " must be a boolean")
+		}
+		return fs.Set(arg.Name, strconv.FormatBool(b))
+	case "integer":
+		switch v := val.(type) {
+		case float64:
+			return fs.Set(arg.Name, strconv.Itoa(int(v)))
+		case int:
+			return fs.Set(arg.Name, strconv.Itoa(v))
+		case int64:
+			return fs.Set(arg.Name, strconv.Itoa(int(v)))
+		default:
+			return errors.New("argument " + arg.Name + " must be an integer")
+		}
+	case "array":
+		switch arr := val.(type) {
+		case []interface{}:
+			for _, item := range arr {
+				s, ok := item.(string)
+				if !ok {
+					return errors.New("argument " + arg.Name + " array items must be strings")
+				}
+				if err := fs.Set(arg.Name, s); err != nil {
+					return err
+				}
+			}
+			return nil
+		case []string:
+			for _, item := range arr {
+				if err := fs.Set(arg.Name, item); err != nil {
+					return err
+				}
+			}
+			return nil
+		default:
+			return errors.New("argument " + arg.Name + " must be an array of strings")
+		}
+	case "object":
+		mp, ok := val.(map[string]interface{})
+		if !ok {
+			return errors.New("argument " + arg.Name + " must be an object")
+		}
+		for k, v := range mp {
+			str, ok := v.(string)
+			if !ok {
+				return errors.New("argument " + arg.Name + " values must be strings")
+			}
+			if err := fs.Set(arg.Name, k+"="+str); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return errors.New("unsupported arg type: " + arg.Type)
+	}
+}
+
+func hasArgInSpec(spec types.ArgSpec, name string) bool {
+	for _, arg := range spec.Args {
+		if arg.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -9,12 +9,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/flowd-org/flowd/internal/events"
 	"github.com/flowd-org/flowd/internal/secrets"
 	"github.com/flowd-org/flowd/internal/types"
 	"github.com/spf13/pflag"
 )
-
-const argsJSONSecretToken = "$$REDACTED$$"
 
 type Binding struct {
 	Values        map[string]interface{}
@@ -182,7 +181,7 @@ func ValidateAndBind(flags *pflag.FlagSet, spec types.ArgSpec) (*Binding, error)
 		}
 	}
 
-	argsJSON, err := marshalCanonicalJSON(redactedArgs(vals, secretNames))
+	argsJSON, err := marshalCanonicalJSON(events.RedactSecrets(vals, secretNames))
 	if err != nil {
 		return nil, fmt.Errorf("encode args json: %w", err)
 	}
@@ -207,21 +206,6 @@ func contains(ss []string, s string) bool {
 		}
 	}
 	return false
-}
-
-func redactedArgs(vals map[string]interface{}, secretNames map[string]struct{}) map[string]interface{} {
-	if len(secretNames) == 0 || len(vals) == 0 {
-		return vals
-	}
-	copy := make(map[string]interface{}, len(vals))
-	for k, v := range vals {
-		if _, ok := secretNames[k]; ok {
-			copy[k] = argsJSONSecretToken
-		} else {
-			copy[k] = v
-		}
-	}
-	return copy
 }
 
 func marshalCanonicalJSON(vals map[string]interface{}) ([]byte, error) {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2,13 +2,18 @@
 package engine
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/flowd-org/flowd/internal/types"
 	"github.com/spf13/pflag"
 )
+
+const argsJSONSecretToken = "$$REDACTED$$"
 
 type Binding struct {
 	Values       map[string]interface{}
@@ -33,6 +38,9 @@ func ValidateAndBind(flags *pflag.FlagSet, spec types.ArgSpec) (*Binding, error)
 	var secretValues []string
 
 	for _, a := range spec.Args {
+		if err := types.ValidateArgName(a.Name); err != nil {
+			return nil, &ArgError{Arg: a.Name, Msg: err.Error()}
+		}
 		name := a.Name
 		provided := flags.Changed(name)
 
@@ -103,23 +111,23 @@ func ValidateAndBind(flags *pflag.FlagSet, spec types.ArgSpec) (*Binding, error)
 			scalars[argEnvName(name)] = fmt.Sprintf("%d", v)
 
 		case "array":
-			// Phase 1: array<string>
 			arr, _ := flags.GetStringArray(name)
 			// default fallback if not provided and default present
 			if len(arr) == 0 && a.Default != nil {
-				// allow default to be []string or comma-separated string
 				switch dv := a.Default.(type) {
 				case []interface{}:
 					for _, it := range dv {
-						if s, ok := it.(string); ok {
-							arr = append(arr, s)
+						s, ok := it.(string)
+						if !ok {
+							return nil, &ArgError{Arg: name, Msg: "default array items must be strings"}
 						}
+						arr = append(arr, s)
 					}
 				case []string:
 					arr = append(arr, dv...)
 				case string:
 					if dv != "" {
-						arr = strings.Split(dv, ",")
+						arr = append(arr, strings.Split(dv, ",")...)
 					}
 				}
 			}
@@ -139,7 +147,6 @@ func ValidateAndBind(flags *pflag.FlagSet, spec types.ArgSpec) (*Binding, error)
 			vals[name] = arr
 
 		case "object":
-			// Accept repeated --name k=v (string values only in Phase 1)
 			pairs, _ := flags.GetStringArray(name)
 			m := map[string]string{}
 			for _, p := range pairs {
@@ -167,7 +174,7 @@ func ValidateAndBind(flags *pflag.FlagSet, spec types.ArgSpec) (*Binding, error)
 		}
 	}
 
-	argsJSON, err := json.Marshal(vals)
+	argsJSON, err := marshalCanonicalJSON(redactedArgs(vals, secretNames))
 	if err != nil {
 		return nil, fmt.Errorf("encode args json: %w", err)
 	}
@@ -189,6 +196,118 @@ func contains(ss []string, s string) bool {
 		}
 	}
 	return false
+}
+
+func redactedArgs(vals map[string]interface{}, secretNames map[string]struct{}) map[string]interface{} {
+	if len(secretNames) == 0 || len(vals) == 0 {
+		return vals
+	}
+	copy := make(map[string]interface{}, len(vals))
+	for k, v := range vals {
+		if _, ok := secretNames[k]; ok {
+			copy[k] = argsJSONSecretToken
+		} else {
+			copy[k] = v
+		}
+	}
+	return copy
+}
+
+func marshalCanonicalJSON(vals map[string]interface{}) ([]byte, error) {
+	buf := &bytes.Buffer{}
+	if err := encodeCanonicalJSON(buf, vals); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func encodeCanonicalJSON(buf *bytes.Buffer, v any) error {
+	switch t := v.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(t))
+		for k := range t {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		buf.WriteByte('{')
+		for i, k := range keys {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			writeJSONString(buf, k)
+			buf.WriteByte(':')
+			if err := encodeCanonicalJSON(buf, t[k]); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte('}')
+	case map[string]string:
+		keys := make([]string, 0, len(t))
+		for k := range t {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		buf.WriteByte('{')
+		for i, k := range keys {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			writeJSONString(buf, k)
+			buf.WriteByte(':')
+			writeJSONString(buf, t[k])
+		}
+		buf.WriteByte('}')
+	case []any:
+		buf.WriteByte('[')
+		for i, elem := range t {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			if err := encodeCanonicalJSON(buf, elem); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte(']')
+	case []string:
+		buf.WriteByte('[')
+		for i, elem := range t {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			writeJSONString(buf, elem)
+		}
+		buf.WriteByte(']')
+	case string:
+		writeJSONString(buf, t)
+	case json.Number:
+		buf.WriteString(t.String())
+	case float64:
+		buf.WriteString(strconv.FormatFloat(t, 'f', -1, 64))
+	case int:
+		buf.WriteString(strconv.Itoa(t))
+	case int64:
+		buf.WriteString(strconv.FormatInt(t, 10))
+	case bool:
+		if t {
+			buf.WriteString("true")
+		} else {
+			buf.WriteString("false")
+		}
+	case nil:
+		buf.WriteString("null")
+	default:
+		b, err := json.Marshal(t)
+		if err != nil {
+			return err
+		}
+		buf.Write(b)
+	}
+	return nil
+}
+
+func writeJSONString(buf *bytes.Buffer, s string) {
+	b, _ := json.Marshal(s)
+	buf.Write(b)
 }
 
 func argEnvName(name string) string {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/flowd-org/flowd/internal/secrets"
 	"github.com/flowd-org/flowd/internal/types"
 	"github.com/spf13/pflag"
 )
@@ -16,11 +17,12 @@ import (
 const argsJSONSecretToken = "$$REDACTED$$"
 
 type Binding struct {
-	Values       map[string]interface{}
-	ArgsJSON     string
-	ScalarEnv    map[string]string // ARG_<UPPER> for scalar types only
-	SecretNames  map[string]struct{}
-	SecretValues []string
+	Values        map[string]interface{}
+	ArgsJSON      string
+	ScalarEnv     map[string]string // ARG_<UPPER> for scalar types only
+	SecretNames   map[string]struct{}
+	SecretValues  []string
+	SecretBuffers map[string]*secrets.Buffer
 }
 
 type ArgError struct {
@@ -36,6 +38,7 @@ func ValidateAndBind(flags *pflag.FlagSet, spec types.ArgSpec) (*Binding, error)
 	scalars := make(map[string]string)
 	secretNames := make(map[string]struct{})
 	var secretValues []string
+	secretBuffers := map[string]*secrets.Buffer{}
 
 	for _, a := range spec.Args {
 		if err := types.ValidateArgName(a.Name); err != nil {
@@ -70,6 +73,7 @@ func ValidateAndBind(flags *pflag.FlagSet, spec types.ArgSpec) (*Binding, error)
 				secretNames[name] = struct{}{}
 				if v != "" {
 					secretValues = append(secretValues, v)
+					secretBuffers[name] = secrets.NewBufferFromString(v)
 				}
 			} else {
 				scalars[argEnvName(name)] = v
@@ -185,6 +189,9 @@ func ValidateAndBind(flags *pflag.FlagSet, spec types.ArgSpec) (*Binding, error)
 	}
 	if len(secretValues) > 0 {
 		b.SecretValues = secretValues
+	}
+	if len(secretBuffers) > 0 {
+		b.SecretBuffers = secretBuffers
 	}
 	return b, nil
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -92,7 +92,9 @@ func ValidateAndBind(flags *pflag.FlagSet, spec types.ArgSpec) (*Binding, error)
 				return nil, &ArgError{Arg: name, Msg: "required"}
 			}
 			vals[name] = v
-			scalars[argEnvName(name)] = fmt.Sprintf("%t", v)
+			if !isSecret(a.Format, a.Secret) {
+				scalars[argEnvName(name)] = fmt.Sprintf("%t", v)
+			}
 
 		case "integer":
 			var v int
@@ -112,7 +114,9 @@ func ValidateAndBind(flags *pflag.FlagSet, spec types.ArgSpec) (*Binding, error)
 				return nil, &ArgError{Arg: name, Msg: "required"}
 			}
 			vals[name] = v
-			scalars[argEnvName(name)] = fmt.Sprintf("%d", v)
+			if !isSecret(a.Format, a.Secret) {
+				scalars[argEnvName(name)] = fmt.Sprintf("%d", v)
+			}
 
 		case "array":
 			arr, _ := flags.GetStringArray(name)

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/flowd-org/flowd/internal/types"
@@ -31,6 +32,35 @@ func TestValidateAndBind_StringEnumRequired(t *testing.T) {
 	}
 	if env := bind.ScalarEnv["ARG_MODE"]; env != "quick" {
 		t.Fatalf("expected ARG_MODE=quick, got %q", env)
+	}
+}
+
+func TestValidateAndBind_ArgsJSONCanonicalAndRedacted(t *testing.T) {
+	spec := types.ArgSpec{Args: []types.Arg{{
+		Name:   "alpha",
+		Type:   "string",
+		Format: "secret",
+	}, {
+		Name: "beta",
+		Type: "string",
+	}}}
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.String("alpha", "", "")
+	flags.String("beta", "", "")
+	_ = flags.Set("alpha", "topsecret")
+	_ = flags.Set("beta", "ok")
+
+	bind, err := ValidateAndBind(flags, spec)
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	var decoded map[string]string
+	if err := json.Unmarshal([]byte(bind.ArgsJSON), &decoded); err != nil {
+		t.Fatalf("decode ArgsJSON: %v", err)
+	}
+	if decoded["alpha"] != "$$REDACTED$$" || decoded["beta"] != "ok" {
+		t.Fatalf("unexpected ArgsJSON values: %+v", decoded)
 	}
 }
 
@@ -95,5 +125,32 @@ func TestValidateAndBind_ObjectRequiresKV(t *testing.T) {
 	_ = flags2.Set("meta", "invalidpair")
 	if _, err := ValidateAndBind(flags2, spec); err == nil {
 		t.Fatalf("expected error for invalid pair")
+	}
+}
+
+func TestValidateAndBind_ReservedName(t *testing.T) {
+	spec := types.ArgSpec{Args: []types.Arg{{
+		Name: "dry-run",
+		Type: "boolean",
+	}}}
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.Bool("dry-run", false, "")
+	if _, err := ValidateAndBind(flags, spec); err == nil {
+		t.Fatalf("expected error for reserved arg name")
+	}
+}
+
+func TestValidateAndBind_DefaultArrayTypeError(t *testing.T) {
+	spec := types.ArgSpec{Args: []types.Arg{{
+		Name:    "tags",
+		Type:    "array",
+		Default: []interface{}{1},
+	}}}
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.StringArray("tags", nil, "")
+	if _, err := ValidateAndBind(flags, spec); err == nil {
+		t.Fatalf("expected error for non-string default array item")
 	}
 }

--- a/internal/engine/exec_mode.go
+++ b/internal/engine/exec_mode.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package engine
+
+import (
+	"strings"
+
+	"github.com/flowd-org/flowd/internal/types"
+)
+
+// ExecutorMode returns the effective execution mode based on config.
+// Defaults to "shell" when no explicit mode is configured.
+func ExecutorMode(cfg *types.Config) string {
+	if cfg == nil {
+		return "shell"
+	}
+	mode := strings.ToLower(strings.TrimSpace(cfg.Executor))
+	interp := strings.ToLower(strings.TrimSpace(cfg.Interpreter))
+	if strings.HasPrefix(interp, "container:") && mode == "" {
+		mode = "container"
+	}
+	if mode == "" {
+		mode = "shell"
+	}
+	return mode
+}

--- a/internal/engine/layering_guard_test.go
+++ b/internal/engine/layering_guard_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package engine
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+type goListPackage struct {
+	ImportPath   string   `json:"ImportPath"`
+	Imports      []string `json:"Imports"`
+	TestImports  []string `json:"TestImports"`
+	XTestImports []string `json:"XTestImports"`
+}
+
+func TestNoCoreImportsServer(t *testing.T) {
+	moduleRoot, err := findModuleRoot()
+	if err != nil {
+		t.Fatalf("find module root: %v", err)
+	}
+
+	cmd := exec.Command(
+		"go",
+		"list",
+		"-json",
+		"./internal/engine/...",
+		"./internal/coredb/...",
+		"./internal/observability/...",
+	)
+	cmd.Dir = moduleRoot
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list failed: %v\n%s", err, string(output))
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(output))
+	var violations []string
+	for decoder.More() {
+		var pkg goListPackage
+		if err := decoder.Decode(&pkg); err != nil {
+			t.Fatalf("decode go list output: %v", err)
+		}
+		for _, imp := range collectImports(pkg) {
+			if strings.HasPrefix(imp, "github.com/flowd-org/flowd/internal/server") {
+				violations = append(violations, fmt.Sprintf("%s imports %s", pkg.ImportPath, imp))
+			}
+		}
+	}
+
+	if len(violations) > 0 {
+		t.Fatalf("core packages must not import internal/server/*:\n%s", strings.Join(violations, "\n"))
+	}
+}
+
+func collectImports(pkg goListPackage) []string {
+	imports := append([]string{}, pkg.Imports...)
+	imports = append(imports, pkg.TestImports...)
+	imports = append(imports, pkg.XTestImports...)
+	return imports
+}
+
+func findModuleRoot() (string, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", errors.New("runtime.Caller failed")
+	}
+
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", errors.New("go.mod not found")
+		}
+		dir = parent
+	}
+}

--- a/internal/engine/orchestrator.go
+++ b/internal/engine/orchestrator.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/flowd-org/flowd/internal/configloader"
+	"github.com/flowd-org/flowd/internal/events"
+	"github.com/flowd-org/flowd/internal/types"
+)
+
+type Orchestrator struct {
+	jobResolver JobResolver
+	loader      ConfigLoader
+	runIDGen    RunIDGenerator
+}
+
+type OrchestratorDeps struct {
+	JobResolver  JobResolver
+	ConfigLoader ConfigLoader
+	RunIDGen     RunIDGenerator
+}
+
+func NewOrchestrator(deps OrchestratorDeps) *Orchestrator {
+	o := &Orchestrator{jobResolver: deps.JobResolver, loader: deps.ConfigLoader, runIDGen: deps.RunIDGen}
+	if o.loader == nil {
+		o.loader = defaultConfigLoader{}
+	}
+	if o.runIDGen == nil {
+		o.runIDGen = defaultRunIDGen{}
+	}
+	return o
+}
+
+type StartRunResult struct {
+	RunID          string
+	JobID          string
+	EffectiveJobID string
+	ScriptDir      string
+	Config         *types.Config
+	Binding        *Binding
+	Plan           types.Plan
+}
+
+func (o *Orchestrator) StartRun(ctx context.Context, req types.StartRunRequest) (StartRunResult, error) {
+	_ = ctx
+	var res StartRunResult
+	if req.JobID == "" {
+		return res, errors.New("job_id required")
+	}
+
+	scriptDir := req.ScriptDir
+	effectiveJobID := req.JobID
+	if scriptDir == "" {
+		if o.jobResolver == nil {
+			return res, errors.New("script_dir required when no job resolver is configured")
+		}
+		dir, eff, err := o.jobResolver.Resolve(ctx, req.JobID)
+		if err != nil {
+			return res, fmt.Errorf("resolve job: %w", err)
+		}
+		scriptDir = dir
+		if eff != "" {
+			effectiveJobID = eff
+		}
+	}
+
+	cfg, err := o.loader.LoadConfig(scriptDir)
+	if err != nil {
+		return res, fmt.Errorf("load config: %w", err)
+	}
+
+	var spec types.ArgSpec
+	if cfg != nil && cfg.ArgSpec != nil {
+		spec = *cfg.ArgSpec
+	}
+
+	bind, err := BindArgs(spec, req.Args)
+	if err != nil {
+		return res, fmt.Errorf("bind args: %w", err)
+	}
+
+	plan := BuildPlan(effectiveJobID, cfg, &spec, bind)
+
+	res.RunID = o.runIDGen.NewRunID()
+	res.JobID = req.JobID
+	res.EffectiveJobID = effectiveJobID
+	res.ScriptDir = scriptDir
+	res.Config = cfg
+	res.Binding = bind
+	res.Plan = plan
+	return res, nil
+}
+
+type defaultConfigLoader struct{}
+
+func (defaultConfigLoader) LoadConfig(scriptDir string) (*types.Config, error) {
+	return configloader.LoadConfig(scriptDir)
+}
+
+type defaultRunIDGen struct{}
+
+func (defaultRunIDGen) NewRunID() string { return events.GenerateRunID() }

--- a/internal/engine/orchestrator.go
+++ b/internal/engine/orchestrator.go
@@ -15,21 +15,26 @@ type Orchestrator struct {
 	jobResolver JobResolver
 	loader      ConfigLoader
 	runIDGen    RunIDGenerator
+	secrets     SecretProvider
 }
 
 type OrchestratorDeps struct {
 	JobResolver  JobResolver
 	ConfigLoader ConfigLoader
 	RunIDGen     RunIDGenerator
+	Secrets      SecretProvider
 }
 
 func NewOrchestrator(deps OrchestratorDeps) *Orchestrator {
-	o := &Orchestrator{jobResolver: deps.JobResolver, loader: deps.ConfigLoader, runIDGen: deps.RunIDGen}
+	o := &Orchestrator{jobResolver: deps.JobResolver, loader: deps.ConfigLoader, runIDGen: deps.RunIDGen, secrets: deps.Secrets}
 	if o.loader == nil {
 		o.loader = defaultConfigLoader{}
 	}
 	if o.runIDGen == nil {
 		o.runIDGen = defaultRunIDGen{}
+	}
+	if o.secrets == nil {
+		o.secrets = DefaultSecretProvider{}
 	}
 	return o
 }
@@ -42,7 +47,11 @@ type StartRunResult struct {
 	Config         *types.Config
 	Binding        *Binding
 	Plan           types.Plan
+	SecretHandles  map[string]string
+	SecretCleanup  func() error
 }
+
+var ErrSecretContainerUnsupported = errors.New("container execution does not support secret args")
 
 func (o *Orchestrator) StartRun(ctx context.Context, req types.StartRunRequest) (StartRunResult, error) {
 	_ = ctx
@@ -84,6 +93,11 @@ func (o *Orchestrator) StartRun(ctx context.Context, req types.StartRunRequest) 
 
 	plan := BuildPlan(effectiveJobID, cfg, &spec, bind)
 
+	executorMode := ExecutorMode(cfg)
+	if executorMode == "container" && bind != nil && len(bind.SecretNames) > 0 {
+		return res, ErrSecretContainerUnsupported
+	}
+
 	res.RunID = o.runIDGen.NewRunID()
 	res.JobID = req.JobID
 	res.EffectiveJobID = effectiveJobID
@@ -91,6 +105,14 @@ func (o *Orchestrator) StartRun(ctx context.Context, req types.StartRunRequest) 
 	res.Config = cfg
 	res.Binding = bind
 	res.Plan = plan
+	if bind != nil && len(bind.SecretNames) > 0 {
+		handles, cleanup, err := o.secrets.Prepare(res.RunID, bind)
+		if err != nil {
+			return res, err
+		}
+		res.SecretHandles = handles
+		res.SecretCleanup = cleanup
+	}
 	return res, nil
 }
 

--- a/internal/engine/orchestrator.go
+++ b/internal/engine/orchestrator.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/flowd-org/flowd/internal/configloader"
 	"github.com/flowd-org/flowd/internal/events"
+	"github.com/flowd-org/flowd/internal/observability/logctx"
 	"github.com/flowd-org/flowd/internal/types"
 )
 
@@ -49,6 +50,7 @@ type StartRunResult struct {
 	Plan           types.Plan
 	SecretHandles  map[string]string
 	SecretCleanup  func() error
+	RequestID      string
 }
 
 var ErrSecretContainerUnsupported = errors.New("container execution does not support secret args")
@@ -81,6 +83,10 @@ func (o *Orchestrator) StartRun(ctx context.Context, req types.StartRunRequest) 
 		return res, fmt.Errorf("load config: %w", err)
 	}
 
+	if req.RequestID != "" {
+		ctx = logctx.WithRequestID(ctx, req.RequestID)
+	}
+
 	var spec types.ArgSpec
 	if cfg != nil && cfg.ArgSpec != nil {
 		spec = *cfg.ArgSpec
@@ -105,6 +111,7 @@ func (o *Orchestrator) StartRun(ctx context.Context, req types.StartRunRequest) 
 	res.Config = cfg
 	res.Binding = bind
 	res.Plan = plan
+	res.RequestID = req.RequestID
 	if bind != nil && len(bind.SecretNames) > 0 {
 		handles, cleanup, err := o.secrets.Prepare(res.RunID, bind)
 		if err != nil {

--- a/internal/engine/orchestrator_interfaces.go
+++ b/internal/engine/orchestrator_interfaces.go
@@ -31,9 +31,8 @@ type PolicyEvaluator interface {
 }
 
 type SecretProvider interface {
-	// Placeholder for later secret-handle tasks.
-	// T-002 does not create or persist secret handles.
-	IsConfigured() bool
+	// Prepare handles for secret args and returns handle paths plus cleanup.
+	Prepare(runID string, binding *Binding) (handles map[string]string, cleanup func() error, err error)
 }
 
 type Executor interface {

--- a/internal/engine/orchestrator_interfaces.go
+++ b/internal/engine/orchestrator_interfaces.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package engine
+
+import (
+	"context"
+	"time"
+
+	"github.com/flowd-org/flowd/internal/events"
+	"github.com/flowd-org/flowd/internal/types"
+)
+
+// NOTE: These interfaces are intentionally minimal in T-002.
+// Follow-up tasks will provide concrete implementations and wire them from CLI/HTTP.
+
+type RunStore interface {
+	Create(ctx context.Context, runID, jobID string, startedAt time.Time) error
+	SetFinished(ctx context.Context, runID string, status string, finishedAt time.Time) error
+}
+
+type JournalStore interface {
+	Append(ctx context.Context, runID string, eventType string, payload []byte, ts time.Time) (int64, error)
+}
+
+type IdempotencyStore interface {
+	Lookup(ctx context.Context, key string) (status int, payload []byte, bodyHash string, ok bool, err error)
+	Store(ctx context.Context, key string, status int, payload []byte, bodyHash string, ttl time.Duration) error
+}
+
+type PolicyEvaluator interface {
+	Evaluate(ctx context.Context, runID string, plan types.Plan) ([]types.Finding, error)
+}
+
+type SecretProvider interface {
+	// Placeholder for later secret-handle tasks.
+	// T-002 does not create or persist secret handles.
+	IsConfigured() bool
+}
+
+type Executor interface {
+	Run(ctx context.Context, runID string, jobID string, scriptDir string, cfg *types.Config, bind *Binding, sink events.Sink) error
+}
+
+type JobResolver interface {
+	Resolve(ctx context.Context, jobID string) (scriptDir string, effectiveJobID string, err error)
+}
+
+type ConfigLoader interface {
+	LoadConfig(scriptDir string) (*types.Config, error)
+}
+
+type RunIDGenerator interface {
+	NewRunID() string
+}

--- a/internal/engine/orchestrator_test.go
+++ b/internal/engine/orchestrator_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/flowd-org/flowd/internal/events"
+	"github.com/flowd-org/flowd/internal/types"
+)
+
+func TestOrchestratorStartRun_NonServerCallable(t *testing.T) {
+	tmp := t.TempDir()
+	cfgDir := filepath.Join(tmp, "config.d")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatalf("mkdir config.d: %v", err)
+	}
+	configPath := filepath.Join(cfgDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(`interpreter: bash
+argspec:
+  args:
+    - name: token
+      type: string
+      format: secret
+`), 0o600); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+
+	o := NewOrchestrator(OrchestratorDeps{RunIDGen: staticRunIDGen("run-test")})
+	res, err := o.StartRun(context.Background(), types.StartRunRequest{
+		JobID:     "jobs.demo",
+		ScriptDir: tmp,
+		Args:      map[string]interface{}{"token": "supersecret"},
+	})
+	if err != nil {
+		t.Fatalf("StartRun error: %v", err)
+	}
+	if res.RunID != "run-test" {
+		t.Fatalf("expected run id, got %q", res.RunID)
+	}
+	if res.Plan.JobID != "jobs.demo" {
+		t.Fatalf("expected job id in plan, got %q", res.Plan.JobID)
+	}
+	if got := res.Plan.ResolvedArgs["token"]; got != events.SecretToken() {
+		t.Fatalf("expected secret redacted, got %v", got)
+	}
+}
+
+type staticRunIDGen string
+
+func (s staticRunIDGen) NewRunID() string { return string(s) }

--- a/internal/engine/orchestrator_test.go
+++ b/internal/engine/orchestrator_test.go
@@ -63,6 +63,15 @@ argspec:
 	if decoded["token"] != "$$REDACTED$$" {
 		t.Fatalf("unexpected ArgsJSON values: %+v", decoded)
 	}
+	if len(res.SecretHandles) == 0 {
+		t.Fatalf("expected secret handles")
+	}
+	if res.SecretCleanup == nil {
+		t.Fatalf("expected secret cleanup")
+	}
+	if err := res.SecretCleanup(); err != nil {
+		t.Fatalf("cleanup secret handles: %v", err)
+	}
 }
 
 type staticRunIDGen string

--- a/internal/engine/orchestrator_test.go
+++ b/internal/engine/orchestrator_test.go
@@ -50,6 +50,12 @@ argspec:
 	if res.Binding == nil {
 		t.Fatalf("expected binding")
 	}
+	if res.Binding.SecretBuffers == nil || len(res.Binding.SecretBuffers) == 0 {
+		t.Fatalf("expected secret buffers populated")
+	}
+	if buf := res.Binding.SecretBuffers["token"]; buf == nil || buf.Len() == 0 {
+		t.Fatalf("expected token buffer populated")
+	}
 	var decoded map[string]string
 	if err := json.Unmarshal([]byte(res.Binding.ArgsJSON), &decoded); err != nil {
 		t.Fatalf("decode ArgsJSON: %v", err)

--- a/internal/engine/orchestrator_test.go
+++ b/internal/engine/orchestrator_test.go
@@ -3,6 +3,7 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -45,6 +46,16 @@ argspec:
 	}
 	if got := res.Plan.ResolvedArgs["token"]; got != events.SecretToken() {
 		t.Fatalf("expected secret redacted, got %v", got)
+	}
+	if res.Binding == nil {
+		t.Fatalf("expected binding")
+	}
+	var decoded map[string]string
+	if err := json.Unmarshal([]byte(res.Binding.ArgsJSON), &decoded); err != nil {
+		t.Fatalf("decode ArgsJSON: %v", err)
+	}
+	if decoded["token"] != "$$REDACTED$$" {
+		t.Fatalf("unexpected ArgsJSON values: %+v", decoded)
 	}
 }
 

--- a/internal/engine/plan.go
+++ b/internal/engine/plan.go
@@ -9,7 +9,7 @@ import (
 )
 
 // BuildPlan produces a minimal Plan object for previews and artifacts.
-// Secrets are redacted (replaced with "[secret]").
+// Secrets are redacted (replaced with "$$REDACTED$$").
 func BuildPlan(jobID string, cfg *types.Config, spec *types.ArgSpec, bind *Binding) types.Plan {
 	plan := types.Plan{JobID: jobID}
 	if spec != nil {

--- a/internal/engine/plan.go
+++ b/internal/engine/plan.go
@@ -11,7 +11,13 @@ import (
 // BuildPlan produces a minimal Plan object for previews and artifacts.
 // Secrets are redacted (replaced with "$$REDACTED$$").
 func BuildPlan(jobID string, cfg *types.Config, spec *types.ArgSpec, bind *Binding) types.Plan {
-	plan := types.Plan{JobID: jobID}
+	plan := types.Plan{
+		JobID:          jobID,
+		Outputs:        map[string]any{},
+		Provenance:     map[string]any{},
+		PolicyFindings: []types.Finding{},
+		Steps:          []types.PlanStepPreview{},
+	}
 	if spec != nil {
 		plan.EffectiveArgSpec = *spec
 	}
@@ -43,6 +49,10 @@ func BuildPlan(jobID string, cfg *types.Config, spec *types.ArgSpec, bind *Bindi
 		if len(resolved) > 0 {
 			plan.ResolvedArgs = resolved
 		}
+	}
+
+	if plan.Outputs == nil {
+		plan.Outputs = map[string]any{}
 	}
 
 	return plan

--- a/internal/engine/plan_test.go
+++ b/internal/engine/plan_test.go
@@ -24,6 +24,12 @@ func TestBuildPlanRedactsSecrets(t *testing.T) {
 	if plan.JobID != "demo.job" {
 		t.Fatalf("unexpected job id %s", plan.JobID)
 	}
+	if plan.Outputs == nil {
+		t.Fatalf("expected outputs to be initialized")
+	}
+	if plan.Provenance == nil {
+		t.Fatalf("expected provenance to be initialized")
+	}
 	if plan.ExecutorPreview["interpreter"] != "/bin/bash" {
 		t.Fatalf("expected interpreter preview")
 	}

--- a/internal/engine/secrets.go
+++ b/internal/engine/secrets.go
@@ -4,6 +4,7 @@ package engine
 import (
 	"fmt"
 
+	"github.com/flowd-org/flowd/internal/metrics"
 	"github.com/flowd-org/flowd/internal/secrets"
 )
 
@@ -69,6 +70,7 @@ func (DefaultSecretProvider) Prepare(runID string, binding *Binding) (map[string
 			closers = append(closers, closeFn)
 		}
 	}
+	metrics.RecordSecretHandleCreated(len(handles))
 
 	cleanup := func() error {
 		var firstErr error
@@ -84,6 +86,8 @@ func (DefaultSecretProvider) Prepare(runID string, binding *Binding) (map[string
 			}
 			binding.SecretValues = nil
 		}
+		success := firstErr == nil
+		metrics.RecordSecretHandleCleanup(len(handles), success)
 		return firstErr
 	}
 	return handles, cleanup, nil

--- a/internal/engine/secrets.go
+++ b/internal/engine/secrets.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package engine
+
+import (
+	"fmt"
+
+	"github.com/flowd-org/flowd/internal/secrets"
+)
+
+// DefaultSecretProvider implements SecretProvider using internal/secrets.
+type DefaultSecretProvider struct{}
+
+func (DefaultSecretProvider) Prepare(runID string, binding *Binding) (map[string]string, func() error, error) {
+	if binding == nil || len(binding.SecretNames) == 0 {
+		return nil, nil, nil
+	}
+	closeBuffers := func() {
+		for name, buf := range binding.SecretBuffers {
+			if _, ok := binding.SecretNames[name]; ok {
+				buf.Close()
+			}
+		}
+	}
+	secretDir, err := secrets.RunDir(runID)
+	if err != nil {
+		closeBuffers()
+		return nil, nil, err
+	}
+	paths := make(map[string]string, len(binding.SecretNames))
+	for name := range binding.SecretNames {
+		value := ""
+		if raw, ok := binding.Values[name]; ok && raw != nil {
+			if s, ok := raw.(string); ok {
+				value = s
+			} else {
+				value = fmt.Sprint(raw)
+			}
+		}
+		if buf, ok := binding.SecretBuffers[name]; ok {
+			path, err := secrets.CreateFile(secretDir, name, buf.Bytes())
+			if err != nil {
+				closeBuffers()
+				return nil, nil, err
+			}
+			paths[name] = path
+			continue
+		}
+		path, err := secrets.CreateFile(secretDir, name, []byte(value))
+		if err != nil {
+			closeBuffers()
+			return nil, nil, err
+		}
+		paths[name] = path
+	}
+
+	handles := make(map[string]string, len(paths))
+	var closers []func() error
+	for name, path := range paths {
+		handlePath, closeFn, err := secrets.ReadHandle(path)
+		if err != nil {
+			for _, closeFn := range closers {
+				_ = closeFn()
+			}
+			closeBuffers()
+			return nil, nil, err
+		}
+		handles[name] = handlePath
+		if closeFn != nil {
+			closers = append(closers, closeFn)
+		}
+	}
+
+	cleanup := func() error {
+		var firstErr error
+		for _, closeFn := range closers {
+			if err := closeFn(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		closeBuffers()
+		if len(binding.SecretValues) > 0 {
+			for i := range binding.SecretValues {
+				binding.SecretValues[i] = ""
+			}
+			binding.SecretValues = nil
+		}
+		return firstErr
+	}
+	return handles, cleanup, nil
+}

--- a/internal/events/emitter.go
+++ b/internal/events/emitter.go
@@ -10,11 +10,11 @@ import (
 )
 
 const (
-	TypeRunStart   = "run.start"
-	TypeRunFinish  = "run.finish"
-	TypeStepStart  = "step.start"
-	TypeStepLog    = "step.log"
-	TypeStepFinish = "step.finish"
+	TypeRunStart   = "run.started"
+	TypeRunFinish  = "run.finished"
+	TypeStepStart  = "step.started"
+	TypeStepLog    = "step.output"
+	TypeStepFinish = "step.finished"
 )
 
 type RunEvent struct {

--- a/internal/events/journal_sink.go
+++ b/internal/events/journal_sink.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package events
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/flowd-org/flowd/internal/coredb"
+)
+
+type JournalSink struct {
+	journal *coredb.Journal
+	nowFn   func() time.Time
+}
+
+func NewJournalSink(journal *coredb.Journal) *JournalSink {
+	if journal == nil {
+		return nil
+	}
+	return &JournalSink{
+		journal: journal,
+		nowFn: func() time.Time {
+			return time.Now().UTC()
+		},
+	}
+}
+
+func (s *JournalSink) EmitRunStart(runID, jobID string) {
+	payload := s.basePayload(runID)
+	payload["job_id"] = jobID
+	payload["status"] = "running"
+	s.append(runID, TypeRunStart, payload)
+}
+
+func (s *JournalSink) EmitRunFinish(runID, status string, err error) {
+	payload := s.basePayload(runID)
+	payload["status"] = status
+	if err != nil {
+		payload["error"] = err.Error()
+	}
+	s.append(runID, TypeRunFinish, payload)
+}
+
+func (s *JournalSink) EmitStepStart(runID, step string) {
+	payload := s.basePayload(runID)
+	payload["step"] = step
+	s.append(runID, TypeStepStart, payload)
+}
+
+func (s *JournalSink) EmitStepLog(runID, step, channel, message string) {
+	if message == "" {
+		return
+	}
+	payload := s.basePayload(runID)
+	payload["step"] = step
+	payload["channel"] = channel
+	payload["message"] = message
+	s.append(runID, TypeStepLog, payload)
+}
+
+func (s *JournalSink) EmitStepFinish(runID, step string, exitCode int, err error) {
+	payload := s.basePayload(runID)
+	payload["step"] = step
+	payload["exit_code"] = exitCode
+	status := "completed"
+	if exitCode != 0 || err != nil {
+		status = "failed"
+	}
+	payload["status"] = status
+	if err != nil {
+		payload["error"] = err.Error()
+	}
+	s.append(runID, TypeStepFinish, payload)
+}
+
+func (s *JournalSink) basePayload(runID string) map[string]any {
+	payload := map[string]any{}
+	if runID != "" {
+		payload["run_id"] = runID
+	}
+	payload["timestamp"] = s.nowFn()
+	return payload
+}
+
+func (s *JournalSink) append(runID, eventType string, payload map[string]any) {
+	if s == nil || s.journal == nil {
+		return
+	}
+	if runID == "" {
+		return
+	}
+	if payload == nil {
+		payload = map[string]any{}
+	}
+	ts, _ := payload["timestamp"].(time.Time)
+	bytes, err := json.Marshal(payload)
+	if err != nil {
+		bytes = []byte("{}")
+	}
+	_, _ = s.journal.Append(context.Background(), runID, eventType, bytes, ts)
+}

--- a/internal/events/redact.go
+++ b/internal/events/redact.go
@@ -2,11 +2,11 @@ package events
 
 import "strings"
 
-const secretToken = "[secret]"
+const secretToken = "$$REDACTED$$"
 
 func SecretToken() string { return secretToken }
 
-// RedactSecrets returns a copy of the args map with secret values replaced by [secret].
+// RedactSecrets returns a copy of the args map with secret values replaced by $$REDACTED$$.
 func RedactSecrets(values map[string]interface{}, secretNames map[string]struct{}) map[string]interface{} {
 	if len(secretNames) == 0 || len(values) == 0 {
 		return values

--- a/internal/events/redact_test.go
+++ b/internal/events/redact_test.go
@@ -6,11 +6,17 @@ func TestRedactSecrets(t *testing.T) {
 	vals := map[string]interface{}{"a": "1", "secret": "value"}
 	secrets := map[string]struct{}{"secret": {}}
 	redacted := RedactSecrets(vals, secrets)
-	if redacted["secret"] != secretToken {
+	if redacted["secret"] != "$$REDACTED$$" {
 		t.Fatalf("expected secret redacted, got %v", redacted["secret"])
 	}
 	if redacted["a"] != "1" {
 		t.Fatalf("expected non secret preserved")
+	}
+}
+
+func TestSecretTokenValue(t *testing.T) {
+	if SecretToken() != "$$REDACTED$$" {
+		t.Fatalf("expected $$REDACTED$$ token, got %s", SecretToken())
 	}
 }
 

--- a/internal/events/redact_test.go
+++ b/internal/events/redact_test.go
@@ -20,7 +20,7 @@ func TestNewLineRedactor(t *testing.T) {
 		t.Fatalf("expected redactor")
 	}
 	line := redactor("value token here")
-	if line != "value [secret] here" {
+	if line != "value $$REDACTED$$ here" {
 		t.Fatalf("expected redaction, got %s", line)
 	}
 	if NewLineRedactor(nil) != nil {

--- a/internal/executor/env_test.go
+++ b/internal/executor/env_test.go
@@ -1,9 +1,12 @@
 package executor
 
 import (
+	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/flowd-org/flowd/internal/events"
 	"github.com/flowd-org/flowd/internal/types"
 )
 
@@ -102,5 +105,70 @@ func TestBuildSecureEnvArgsJSONAliases(t *testing.T) {
 	}
 	if flwdValue == "" {
 		t.Fatalf("expected FLWD_ARGS_JSON alias to be set in env: %v", env)
+	}
+}
+
+func TestExecutorEnvDoesNotExposeSecrets(t *testing.T) {
+	secretValue := "supersecret"
+	argsPayload := map[string]string{
+		"token": events.SecretToken(),
+		"name":  "alice",
+	}
+	argsBytes, err := json.Marshal(argsPayload)
+	if err != nil {
+		t.Fatalf("marshal args payload: %v", err)
+	}
+	argsJSON := string(argsBytes)
+
+	env := buildSecureEnv(nil, map[string]string{"ARG_NAME": "alice"}, argsJSON, false)
+	env = injectSecretHandles(env, ExecutorConfig{SecretHandles: map[string]string{
+		"token": "/run/secrets/token",
+	}})
+
+	envMap := make(map[string]string, len(env))
+	for _, kv := range env {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) == 2 {
+			envMap[parts[0]] = parts[1]
+		}
+	}
+
+	if envMap["FLOWD_ARGS_JSON"] != argsJSON {
+		t.Fatalf("expected FLOWD_ARGS_JSON to be set to redacted args JSON")
+	}
+	if envMap["FLWD_ARGS_JSON"] != argsJSON {
+		t.Fatalf("expected FLWD_ARGS_JSON alias to be set to redacted args JSON")
+	}
+
+	handlesJSON := envMap[secretHandlesEnv]
+	if handlesJSON == "" {
+		t.Fatalf("expected %s to be set", secretHandlesEnv)
+	}
+	if strings.Contains(handlesJSON, secretValue) {
+		t.Fatalf("secret value leaked into %s", secretHandlesEnv)
+	}
+
+	var handles map[string]map[string]string
+	if err := json.Unmarshal([]byte(handlesJSON), &handles); err != nil {
+		t.Fatalf("decode %s: %v", secretHandlesEnv, err)
+	}
+	h, ok := handles["token"]
+	if !ok {
+		t.Fatalf("expected token handle in %s payload", secretHandlesEnv)
+	}
+	if h["type"] != "file" {
+		t.Fatalf("expected handle type 'file', got %q", h["type"])
+	}
+	if h["path"] != "/run/secrets/token" {
+		t.Fatalf("expected handle path, got %q", h["path"])
+	}
+	if len(h) != 2 {
+		t.Fatalf("expected handle payload to contain only type/path, got %v", h)
+	}
+
+	for key, val := range envMap {
+		if strings.Contains(val, secretValue) {
+			t.Fatalf("secret value leaked into env var %s", key)
+		}
 	}
 }

--- a/internal/executor/env_test.go
+++ b/internal/executor/env_test.go
@@ -84,3 +84,23 @@ func TestBuildSecureEnvInheritHost(t *testing.T) {
 		t.Fatalf("expected inherited env %s in %v", key, env)
 	}
 }
+
+func TestBuildSecureEnvArgsJSONAliases(t *testing.T) {
+	argsJSON := `{"name":"alice"}`
+	env := buildSecureEnv(nil, nil, argsJSON, false)
+	var flowdValue, flwdValue string
+	for _, e := range env {
+		switch e {
+		case "FLOWD_ARGS_JSON=" + argsJSON:
+			flowdValue = argsJSON
+		case "FLWD_ARGS_JSON=" + argsJSON:
+			flwdValue = argsJSON
+		}
+	}
+	if flowdValue == "" {
+		t.Fatalf("expected FLOWD_ARGS_JSON to be set in env: %v", env)
+	}
+	if flwdValue == "" {
+		t.Fatalf("expected FLWD_ARGS_JSON alias to be set in env: %v", env)
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -29,7 +29,7 @@ type ExecutorConfig struct {
 	Strict    bool
 	// Engine bindings
 	ArgEnv                  map[string]string // ARG_<UPPER>=value (scalars only)
-	ArgsJSON                string            // FLWD_ARGS_JSON content
+	ArgsJSON                string            // FLOWD_ARGS_JSON content
 	ArgValues               map[string]interface{}
 	RunID                   string
 	JobID                   string
@@ -508,6 +508,7 @@ func buildSecureEnv(cfg *types.Config, argEnv map[string]string, argsJSON string
 		set(k, v)
 	}
 	if argsJSON != "" {
+		set("FLOWD_ARGS_JSON", argsJSON)
 		set("FLWD_ARGS_JSON", argsJSON)
 	}
 	if inherit {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -3,6 +3,7 @@ package executor
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -46,6 +47,8 @@ type ExecutorConfig struct {
 	SecretsDir              string
 	SecretHandles           map[string]string
 }
+
+const secretHandlesEnv = "FLOWD_SECRET_HANDLES"
 
 // ScriptResult holds per-script run outcome.
 type ScriptResult struct {
@@ -536,12 +539,15 @@ func injectSecretHandles(env []string, ecfg ExecutorConfig) []string {
 	if len(ecfg.SecretHandles) == 0 {
 		return env
 	}
+	handlePayload := make(map[string]map[string]string, len(ecfg.SecretHandles))
 	for name, handlePath := range ecfg.SecretHandles {
-		varName := "FLOWD_SECRET_" + strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
-		if ecfg.Verbosity >= 2 {
-			fmt.Fprintf(os.Stderr, "[DEBUG] injecting secret handle for %s\n", name)
+		handlePayload[name] = map[string]string{
+			"type": "file",
+			"path": handlePath,
 		}
-		env = upsertEnv(env, varName, handlePath)
+	}
+	if payload, err := json.Marshal(handlePayload); err == nil {
+		env = upsertEnv(env, secretHandlesEnv, string(payload))
 	}
 	return env
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -44,6 +44,7 @@ type ExecutorConfig struct {
 	ContainerRootfsWritable bool
 	ContainerCapabilities   []string
 	SecretsDir              string
+	SecretHandles           map[string]string
 }
 
 // ScriptResult holds per-script run outcome.
@@ -350,9 +351,10 @@ func executeProcessStep(ctx context.Context, cfg *types.Config, ecfg ExecutorCon
 		env = upsertEnv(env, "RUN_DIR", runDir)
 		env = upsertEnv(env, "FLWD_RUN_DIR", runDir)
 		if strings.Contains(interpreter, "bash") {
+			env = injectSecretHandles(env, ecfg)
 			cmd.Env = append(env, fmt.Sprintf("BASH_ENV=%s", profilePath))
 		} else {
-			cmd.Env = env
+			cmd.Env = injectSecretHandles(env, ecfg)
 		}
 
 		restoreUmask := applySecureUmask()
@@ -526,6 +528,20 @@ func buildSecureEnv(cfg *types.Config, argEnv map[string]string, argsJSON string
 	env := make([]string, 0, len(ordered))
 	for _, e := range ordered {
 		env = append(env, fmt.Sprintf("%s=%s", e.key, envSet[e.key]))
+	}
+	return env
+}
+
+func injectSecretHandles(env []string, ecfg ExecutorConfig) []string {
+	if len(ecfg.SecretHandles) == 0 {
+		return env
+	}
+	for name, handlePath := range ecfg.SecretHandles {
+		varName := "FLOWD_SECRET_" + strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
+		if ecfg.Verbosity >= 2 {
+			fmt.Fprintf(os.Stderr, "[DEBUG] injecting secret handle for %s\n", name)
+		}
+		env = upsertEnv(env, varName, handlePath)
 	}
 	return env
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -694,7 +694,6 @@ func runContainerStep(ctx context.Context, cfg *types.Config, ecfg ExecutorConfi
 		_ = container.RemoveContainer(cancelCtx, runtime, containerName)
 	}
 	metrics.Default.RecordContainerRun(dur)
-	metrics.Default.RecordContainerPull(dur)
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/internal/executor/profile.go
+++ b/internal/executor/profile.go
@@ -13,6 +13,14 @@ import (
 
 func GenerateRunnerProfile(scriptDir string, interp string, verbosity int, spec *types.ArgSpec, argValues map[string]interface{}) (string, func(), error) {
 	var ext, profileHeader string
+	var secretArgs []string
+	if spec != nil {
+		for _, arg := range spec.Args {
+			if arg.Format == "secret" || arg.Secret {
+				secretArgs = append(secretArgs, arg.Name)
+			}
+		}
+	}
 	switch {
 	case strings.Contains(interp, "bash"):
 		ext = ".sh"
@@ -103,6 +111,9 @@ param (
 			if !ok {
 				continue
 			}
+			if arg.Format == "secret" || arg.Secret {
+				continue
+			}
 			varName := sanitizeVarName(arg.Name)
 			switch arg.Type {
 			case "string", "boolean", "integer":
@@ -133,16 +144,24 @@ param (
 	}
 
 	if ext == ".ps1" {
+		lines = append(lines, "", "# Secret args (do not export to env)")
+		lines = append(lines, "$secretArgs = @{")
+		for _, name := range secretArgs {
+			lines = append(lines, fmt.Sprintf("  \"%s\" = $true", name))
+		}
+		lines = append(lines, "}")
 		lines = append(lines,
 			"",
 			"# Export --arg[=value] pairs to environment variables",
 			`foreach ($arg in $ScriptArgs) {`,
 			`  if ($arg -match "^--([^=]+)=(.+)$") {`,
 			`    $name = $matches[1]`,
+			`    if ($secretArgs.ContainsKey($name)) { continue }`,
 			`    $value = $matches[2]`,
 			`    Set-Item -Path "env:$name" -Value $value`,
 			`  } elseif ($arg -match "^--(.+)$") {`,
 			`    $name = $matches[1]`,
+			`    if ($secretArgs.ContainsKey($name)) { continue }`,
 			`    Set-Item -Path "env:$name" -Value "true"`,
 			`  }`,
 			`}`,

--- a/internal/executor/profile.go
+++ b/internal/executor/profile.go
@@ -96,6 +96,9 @@ param (
 	if ext == ".sh" && spec != nil && len(spec.Args) > 0 {
 		lines = append(lines, "", "# ArgSpec bindings (auto-generated)")
 		for _, arg := range spec.Args {
+			if err := types.ValidateArgName(arg.Name); err != nil {
+				return "", nil, fmt.Errorf("invalid argspec name %q: %w", arg.Name, err)
+			}
 			value, ok := argValues[arg.Name]
 			if !ok {
 				continue

--- a/internal/metrics/persistence.go
+++ b/internal/metrics/persistence.go
@@ -96,6 +96,65 @@ func RecordPersistenceEviction(kind string, bytes int64) {
 	getSink().RecordPersistenceEviction(k, bytes)
 }
 
+// RecordIdempotencyLookup records an idempotency lookup outcome.
+func RecordIdempotencyLookup(outcome string) {
+	o := sanitize(outcome)
+	if o == "" {
+		o = PersistenceOutcomeError
+	}
+	getSink().RecordIdempotencyLookup(o)
+}
+
+// RecordIdempotencyReplay increments the idempotency replay counter.
+func RecordIdempotencyReplay() {
+	getSink().RecordIdempotencyReplay()
+}
+
+// RecordIdempotencyConflict increments the idempotency conflict counter.
+func RecordIdempotencyConflict() {
+	getSink().RecordIdempotencyConflict()
+}
+
+// RecordIdempotencyInFlight increments the idempotency in-flight counter.
+func RecordIdempotencyInFlight() {
+	getSink().RecordIdempotencyInFlight()
+}
+
+// RecordRunStarted increments the run started counter.
+func RecordRunStarted() {
+	getSink().RecordRunStarted()
+}
+
+// RecordRunFinished increments the run finished counter for the provided status.
+func RecordRunFinished(status string) {
+	s := sanitize(status)
+	if s == "" {
+		s = "unknown"
+	}
+	getSink().RecordRunFinished(s)
+}
+
+// RecordSecretHandleCreated records secret handle creation count.
+func RecordSecretHandleCreated(count int) {
+	if count < 0 {
+		count = 0
+	}
+	getSink().RecordSecretHandleCreated(count)
+}
+
+// RecordSecretHandleCleanup records secret handle cleanup count and success.
+func RecordSecretHandleCleanup(count int, success bool) {
+	if count < 0 {
+		count = 0
+	}
+	getSink().RecordSecretHandleCleanup(count, success)
+}
+
+// RecordSecretContainerRejected increments the container secret rejection counter.
+func RecordSecretContainerRejected() {
+	getSink().RecordSecretContainerRejected()
+}
+
 func seedPersistenceDefaults(s Sink) {
 	if s == nil {
 		return

--- a/internal/metrics/persistence.go
+++ b/internal/metrics/persistence.go
@@ -5,8 +5,6 @@ package metrics
 import (
 	"strings"
 	"time"
-
-	servermetrics "github.com/flowd-org/flowd/internal/server/metrics"
 )
 
 const (
@@ -53,11 +51,7 @@ var latencyDefaults = map[string][]string{
 }
 
 func init() {
-	for operation, outcomes := range latencyDefaults {
-		for _, outcome := range outcomes {
-			servermetrics.Default.EnsurePersistenceLatency(operation, outcome)
-		}
-	}
+	seedPersistenceDefaults(getSink())
 }
 
 // PersistenceTimer records elapsed time for a persistence operation and
@@ -90,7 +84,7 @@ func (t *PersistenceTimer) Observe(outcome string) {
 	if o == "" {
 		o = PersistenceOutcomeOK
 	}
-	servermetrics.Default.RecordPersistenceLatency(t.operation, o, time.Since(t.start))
+	getSink().RecordPersistenceLatency(t.operation, o, time.Since(t.start))
 }
 
 // RecordPersistenceEviction increments counters for persistence evictions.
@@ -99,7 +93,18 @@ func RecordPersistenceEviction(kind string, bytes int64) {
 	if k == "" {
 		k = persistenceKindUnknown
 	}
-	servermetrics.Default.RecordPersistenceEviction(k, bytes)
+	getSink().RecordPersistenceEviction(k, bytes)
+}
+
+func seedPersistenceDefaults(s Sink) {
+	if s == nil {
+		return
+	}
+	for operation, outcomes := range latencyDefaults {
+		for _, outcome := range outcomes {
+			s.EnsurePersistenceLatency(operation, outcome)
+		}
+	}
 }
 
 func sanitize(v string) string {

--- a/internal/metrics/sink.go
+++ b/internal/metrics/sink.go
@@ -12,9 +12,20 @@ type Sink interface {
 	EnsurePersistenceLatency(operation, outcome string)
 	RecordPersistenceLatency(operation, outcome string, duration time.Duration)
 	RecordPersistenceEviction(kind string, bytes int64)
+	RecordIdempotencyLookup(outcome string)
+	RecordIdempotencyReplay()
+	RecordIdempotencyConflict()
+	RecordIdempotencyInFlight()
 	RecordSSEActiveDelta(transport string, delta int64)
+	RecordSSEStreamStart(transport string)
+	RecordSSEStreamEnd(transport string)
 	RecordSSEResumeAttempt()
 	RecordSSECursorExpired()
+	RecordRunStarted()
+	RecordRunFinished(status string)
+	RecordSecretHandleCreated(count int)
+	RecordSecretHandleCleanup(count int, success bool)
+	RecordSecretContainerRejected()
 }
 
 type noopSink struct{}
@@ -22,9 +33,20 @@ type noopSink struct{}
 func (noopSink) EnsurePersistenceLatency(string, string)                {}
 func (noopSink) RecordPersistenceLatency(string, string, time.Duration) {}
 func (noopSink) RecordPersistenceEviction(string, int64)                {}
+func (noopSink) RecordIdempotencyLookup(string)                         {}
+func (noopSink) RecordIdempotencyReplay()                               {}
+func (noopSink) RecordIdempotencyConflict()                             {}
+func (noopSink) RecordIdempotencyInFlight()                             {}
 func (noopSink) RecordSSEActiveDelta(string, int64)                     {}
+func (noopSink) RecordSSEStreamStart(string)                            {}
+func (noopSink) RecordSSEStreamEnd(string)                              {}
 func (noopSink) RecordSSEResumeAttempt()                                {}
 func (noopSink) RecordSSECursorExpired()                                {}
+func (noopSink) RecordRunStarted()                                      {}
+func (noopSink) RecordRunFinished(string)                               {}
+func (noopSink) RecordSecretHandleCreated(int)                          {}
+func (noopSink) RecordSecretHandleCleanup(int, bool)                    {}
+func (noopSink) RecordSecretContainerRejected()                         {}
 
 var (
 	sinkMu sync.RWMutex

--- a/internal/metrics/sink.go
+++ b/internal/metrics/sink.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package metrics
+
+import (
+	"sync"
+	"time"
+)
+
+// Sink receives core metrics events without depending on server packages.
+type Sink interface {
+	EnsurePersistenceLatency(operation, outcome string)
+	RecordPersistenceLatency(operation, outcome string, duration time.Duration)
+	RecordPersistenceEviction(kind string, bytes int64)
+	RecordSSEActiveDelta(transport string, delta int64)
+	RecordSSEResumeAttempt()
+	RecordSSECursorExpired()
+}
+
+type noopSink struct{}
+
+func (noopSink) EnsurePersistenceLatency(string, string)                {}
+func (noopSink) RecordPersistenceLatency(string, string, time.Duration) {}
+func (noopSink) RecordPersistenceEviction(string, int64)                {}
+func (noopSink) RecordSSEActiveDelta(string, int64)                     {}
+func (noopSink) RecordSSEResumeAttempt()                                {}
+func (noopSink) RecordSSECursorExpired()                                {}
+
+var (
+	sinkMu sync.RWMutex
+	sink   Sink = noopSink{}
+)
+
+// SetSink installs the metrics sink used by core packages.
+// Passing nil resets the sink to a no-op implementation.
+func SetSink(s Sink) {
+	if s == nil {
+		s = noopSink{}
+	}
+	sinkMu.Lock()
+	sink = s
+	sinkMu.Unlock()
+	seedPersistenceDefaults(s)
+}
+
+func getSink() Sink {
+	sinkMu.RLock()
+	defer sinkMu.RUnlock()
+	return sink
+}

--- a/internal/metrics/sse.go
+++ b/internal/metrics/sse.go
@@ -2,10 +2,6 @@
 
 package metrics
 
-import (
-	servermetrics "github.com/flowd-org/flowd/internal/server/metrics"
-)
-
 const (
 	// SSETransportDefault is the transport label for standard SSE streams.
 	SSETransportDefault = "sse"
@@ -13,18 +9,18 @@ const (
 
 // SSEStreamStarted increments the active stream gauge and returns a function to decrement it.
 func SSEStreamStarted() func() {
-	servermetrics.Default.RecordSSEActiveDelta(SSETransportDefault, 1)
+	getSink().RecordSSEActiveDelta(SSETransportDefault, 1)
 	return func() {
-		servermetrics.Default.RecordSSEActiveDelta(SSETransportDefault, -1)
+		getSink().RecordSSEActiveDelta(SSETransportDefault, -1)
 	}
 }
 
 // RecordSSEResumeAttempt increments the SSE resume counter.
 func RecordSSEResumeAttempt() {
-	servermetrics.Default.RecordSSEResumeAttempt()
+	getSink().RecordSSEResumeAttempt()
 }
 
 // RecordSSECursorExpired increments the SSE cursor expired counter.
 func RecordSSECursorExpired() {
-	servermetrics.Default.RecordSSECursorExpired()
+	getSink().RecordSSECursorExpired()
 }

--- a/internal/metrics/sse.go
+++ b/internal/metrics/sse.go
@@ -10,8 +10,10 @@ const (
 // SSEStreamStarted increments the active stream gauge and returns a function to decrement it.
 func SSEStreamStarted() func() {
 	getSink().RecordSSEActiveDelta(SSETransportDefault, 1)
+	getSink().RecordSSEStreamStart(SSETransportDefault)
 	return func() {
 		getSink().RecordSSEActiveDelta(SSETransportDefault, -1)
+		getSink().RecordSSEStreamEnd(SSETransportDefault)
 	}
 }
 
@@ -23,4 +25,14 @@ func RecordSSEResumeAttempt() {
 // RecordSSECursorExpired increments the SSE cursor expired counter.
 func RecordSSECursorExpired() {
 	getSink().RecordSSECursorExpired()
+}
+
+// RecordSSEStreamStart increments the SSE stream start counter for the transport.
+func RecordSSEStreamStart(transport string) {
+	getSink().RecordSSEStreamStart(transport)
+}
+
+// RecordSSEStreamEnd increments the SSE stream end counter for the transport.
+func RecordSSEStreamEnd(transport string) {
+	getSink().RecordSSEStreamEnd(transport)
 }

--- a/internal/observability/logctx/logctx.go
+++ b/internal/observability/logctx/logctx.go
@@ -8,8 +8,10 @@ import (
 )
 
 type loggerKey struct{}
+type requestIDKey struct{}
 
 var ctxLoggerKey = &loggerKey{}
+var ctxRequestIDKey = &requestIDKey{}
 
 // WithLogger stores the logger in the context for downstream consumers.
 func WithLogger(ctx context.Context, logger *slog.Logger) context.Context {
@@ -26,6 +28,26 @@ func Logger(ctx context.Context) *slog.Logger {
 	}
 	logger, _ := ctx.Value(ctxLoggerKey).(*slog.Logger)
 	return logger
+}
+
+// WithRequestID stores a request/correlation identifier in the context.
+func WithRequestID(ctx context.Context, requestID string) context.Context {
+	if ctx == nil || requestID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxRequestIDKey, requestID)
+}
+
+// RequestID extracts the request/correlation identifier from context, if present.
+func RequestID(ctx context.Context) (string, bool) {
+	if ctx == nil {
+		return "", false
+	}
+	requestID, _ := ctx.Value(ctxRequestIDKey).(string)
+	if requestID == "" {
+		return "", false
+	}
+	return requestID, true
 }
 
 // WrapLogger returns a logger that applies the supplied scrubber to message and string attributes.

--- a/internal/observability/logctx/logctx.go
+++ b/internal/observability/logctx/logctx.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package logctx
+
+import (
+	"context"
+	"log/slog"
+)
+
+type loggerKey struct{}
+
+var ctxLoggerKey = &loggerKey{}
+
+// WithLogger stores the logger in the context for downstream consumers.
+func WithLogger(ctx context.Context, logger *slog.Logger) context.Context {
+	if ctx == nil || logger == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxLoggerKey, logger)
+}
+
+// Logger extracts a logger from context, if present.
+func Logger(ctx context.Context) *slog.Logger {
+	if ctx == nil {
+		return nil
+	}
+	logger, _ := ctx.Value(ctxLoggerKey).(*slog.Logger)
+	return logger
+}

--- a/internal/observability/logctx/logctx.go
+++ b/internal/observability/logctx/logctx.go
@@ -27,3 +27,84 @@ func Logger(ctx context.Context) *slog.Logger {
 	logger, _ := ctx.Value(ctxLoggerKey).(*slog.Logger)
 	return logger
 }
+
+// WrapLogger returns a logger that applies the supplied scrubber to message and string attributes.
+// If logger is nil or scrub is nil, it returns the original logger.
+func WrapLogger(logger *slog.Logger, scrub func(string) string) *slog.Logger {
+	if logger == nil || scrub == nil {
+		return logger
+	}
+	return slog.New(&scrubHandler{next: logger.Handler(), scrub: scrub})
+}
+
+type scrubHandler struct {
+	next  slog.Handler
+	scrub func(string) string
+}
+
+func (h *scrubHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.next.Enabled(ctx, level)
+}
+
+func (h *scrubHandler) Handle(ctx context.Context, r slog.Record) error {
+	if h == nil || h.scrub == nil {
+		return h.next.Handle(ctx, r)
+	}
+	msg := h.scrub(r.Message)
+	copy := slog.NewRecord(r.Time, r.Level, msg, r.PC)
+	r.Attrs(func(attr slog.Attr) bool {
+		copy.AddAttrs(scrubAttr(attr, h.scrub))
+		return true
+	})
+	return h.next.Handle(ctx, copy)
+}
+
+func (h *scrubHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	clean := make([]slog.Attr, 0, len(attrs))
+	for _, attr := range attrs {
+		clean = append(clean, scrubAttr(attr, h.scrub))
+	}
+	return &scrubHandler{next: h.next.WithAttrs(clean), scrub: h.scrub}
+}
+
+func (h *scrubHandler) WithGroup(name string) slog.Handler {
+	return &scrubHandler{next: h.next.WithGroup(name), scrub: h.scrub}
+}
+
+func scrubAttr(attr slog.Attr, scrub func(string) string) slog.Attr {
+	if scrub == nil {
+		return attr
+	}
+	attr.Value = scrubValue(attr.Value, scrub)
+	return attr
+}
+
+func scrubValue(val slog.Value, scrub func(string) string) slog.Value {
+	if scrub == nil {
+		return val
+	}
+	switch val.Kind() {
+	case slog.KindString:
+		return slog.StringValue(scrub(val.String()))
+	case slog.KindAny:
+		if s, ok := val.Any().(string); ok {
+			return slog.StringValue(scrub(s))
+		}
+		return val
+	case slog.KindGroup:
+		attrs := val.Group()
+		if len(attrs) == 0 {
+			return val
+		}
+		clean := make([]slog.Attr, 0, len(attrs))
+		for _, attr := range attrs {
+			clean = append(clean, scrubAttr(attr, scrub))
+		}
+		return slog.GroupValue(clean...)
+	default:
+		return val
+	}
+}

--- a/internal/observability/logctx/logctx_test.go
+++ b/internal/observability/logctx/logctx_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package logctx
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"log/slog"
+)
+
+type testHandler struct {
+	records []slog.Record
+}
+
+func (h *testHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *testHandler) Handle(_ context.Context, r slog.Record) error {
+	copy := slog.NewRecord(r.Time, r.Level, r.Message, r.PC)
+	r.Attrs(func(attr slog.Attr) bool {
+		copy.AddAttrs(attr)
+		return true
+	})
+	h.records = append(h.records, copy)
+	return nil
+}
+
+func (h *testHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	clone := &testHandler{records: append([]slog.Record{}, h.records...)}
+	return &testHandlerWithAttrs{base: clone, attrs: attrs}
+}
+
+func (h *testHandler) WithGroup(string) slog.Handler { return h }
+
+type testHandlerWithAttrs struct {
+	base  *testHandler
+	attrs []slog.Attr
+}
+
+func (h *testHandlerWithAttrs) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.base.Enabled(ctx, level)
+}
+
+func (h *testHandlerWithAttrs) Handle(ctx context.Context, r slog.Record) error {
+	copy := slog.NewRecord(r.Time, r.Level, r.Message, r.PC)
+	for _, attr := range h.attrs {
+		copy.AddAttrs(attr)
+	}
+	r.Attrs(func(attr slog.Attr) bool {
+		copy.AddAttrs(attr)
+		return true
+	})
+	h.base.records = append(h.base.records, copy)
+	return nil
+}
+
+func (h *testHandlerWithAttrs) WithAttrs(attrs []slog.Attr) slog.Handler {
+	combined := append([]slog.Attr{}, h.attrs...)
+	combined = append(combined, attrs...)
+	return &testHandlerWithAttrs{base: h.base, attrs: combined}
+}
+
+func (h *testHandlerWithAttrs) WithGroup(name string) slog.Handler {
+	return h.base.WithGroup(name)
+}
+
+func TestWrapLoggerScrubsMessageAndAttrs(t *testing.T) {
+	handler := &testHandler{}
+	logger := slog.New(handler)
+
+	scrubbed := WrapLogger(logger, func(msg string) string {
+		return strings.ReplaceAll(msg, "secret", "$$REDACTED$$")
+	})
+
+	group := slog.Group("meta",
+		slog.String("detail", "secret-value"),
+		slog.String("ok", "visible"),
+	)
+
+	scrubbed.Info("secret message", slog.String("error", "secret path"), group)
+
+	if len(handler.records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(handler.records))
+	}
+	rec := handler.records[0]
+	if rec.Message != "$$REDACTED$$ message" {
+		t.Fatalf("expected scrubbed message, got %q", rec.Message)
+	}
+
+	attrs := map[string]string{}
+	rec.Attrs(func(attr slog.Attr) bool {
+		if attr.Value.Kind() == slog.KindString {
+			attrs[attr.Key] = attr.Value.String()
+		}
+		if attr.Value.Kind() == slog.KindGroup {
+			for _, g := range attr.Value.Group() {
+				if g.Value.Kind() == slog.KindString {
+					attrs["meta."+g.Key] = g.Value.String()
+				}
+			}
+		}
+		return true
+	})
+
+	if attrs["error"] != "$$REDACTED$$ path" {
+		t.Fatalf("expected scrubbed error attr, got %q", attrs["error"])
+	}
+	if attrs["meta.detail"] != "$$REDACTED$$-value" {
+		t.Fatalf("expected scrubbed group attr, got %q", attrs["meta.detail"])
+	}
+	if attrs["meta.ok"] != "visible" {
+		t.Fatalf("expected non-secret attr preserved, got %q", attrs["meta.ok"])
+	}
+}

--- a/internal/observability/tracing/tracing.go
+++ b/internal/observability/tracing/tracing.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/flowd-org/flowd/internal/server/requestctx"
+	"github.com/flowd-org/flowd/internal/observability/logctx"
 )
 
 // Attribute represents a key/value pair attached to a span.
@@ -83,7 +83,7 @@ func Start(ctx context.Context, name string, attrs ...Attribute) (context.Contex
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	logger := requestctx.Logger(ctx)
+	logger := logctx.Logger(ctx)
 	if logger == nil {
 		logger = slog.Default()
 	}

--- a/internal/secrets/buffer.go
+++ b/internal/secrets/buffer.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package secrets
+
+// Buffer holds secret bytes that can be explicitly zeroed on cleanup.
+// Call Close() to overwrite the underlying bytes.
+type Buffer struct {
+	data []byte
+}
+
+// NewBufferFromString copies s into a new zeroizable buffer.
+func NewBufferFromString(s string) *Buffer {
+	if s == "" {
+		return &Buffer{data: nil}
+	}
+	buf := make([]byte, len(s))
+	copy(buf, s)
+	return &Buffer{data: buf}
+}
+
+// Bytes returns the underlying secret bytes.
+func (b *Buffer) Bytes() []byte {
+	if b == nil {
+		return nil
+	}
+	return b.data
+}
+
+// Len returns the length of the underlying secret bytes.
+func (b *Buffer) Len() int {
+	if b == nil {
+		return 0
+	}
+	return len(b.data)
+}
+
+// Close zeroes the underlying bytes and releases the buffer.
+func (b *Buffer) Close() {
+	if b == nil {
+		return
+	}
+	for i := range b.data {
+		b.data[i] = 0
+	}
+	b.data = nil
+}

--- a/internal/secrets/buffer_test.go
+++ b/internal/secrets/buffer_test.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package secrets
+
+import "testing"
+
+func TestBufferZeroizesOnClose(t *testing.T) {
+	buf := NewBufferFromString("topsecret")
+	if buf == nil {
+		t.Fatalf("expected buffer")
+	}
+	raw := buf.Bytes()
+	if len(raw) == 0 {
+		t.Fatalf("expected buffer data")
+	}
+	buf.Close()
+	for i, b := range raw {
+		if b != 0 {
+			t.Fatalf("expected zeroed byte at %d", i)
+		}
+	}
+	if buf.Bytes() != nil {
+		t.Fatalf("expected buffer released")
+	}
+}

--- a/internal/secrets/errors.go
+++ b/internal/secrets/errors.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package secrets
+
+import "fmt"
+
+type safeError struct {
+	op  string
+	err error
+}
+
+func (e *safeError) Error() string {
+	if e == nil {
+		return "secrets: operation failed"
+	}
+	if e.op == "" {
+		return "secrets: operation failed"
+	}
+	return fmt.Sprintf("secrets: %s failed", e.op)
+}
+
+func (e *safeError) Unwrap() error { return e.err }
+
+func wrapErr(op string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &safeError{op: op, err: err}
+}
+
+func opError(op string) error {
+	return &safeError{op: op}
+}

--- a/internal/secrets/handle_posix.go
+++ b/internal/secrets/handle_posix.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//go:build !windows
+
+package secrets
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+// Handle represents an open secret handle backed by a file descriptor.
+// The original on-disk path is unlinked immediately after opening.
+// Close must be called when the handle is no longer needed.
+type Handle struct {
+	Path string
+	file *os.File
+}
+
+// Close closes the underlying file descriptor.
+func (h *Handle) Close() error {
+	if h == nil || h.file == nil {
+		return nil
+	}
+	return h.file.Close()
+}
+
+// OpenHandle opens a secret file for read, unlinks it immediately, and returns
+// an fd-backed path suitable for passing to a child process. The caller must
+// keep the returned handle open for the duration of use.
+func OpenHandle(path string) (*Handle, error) {
+	if path == "" {
+		return nil, opError("open secret handle")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, wrapErr("open secret file", err)
+	}
+	if err := os.Remove(path); err != nil {
+		_ = file.Close()
+		return nil, wrapErr("unlink secret file", err)
+	}
+	fdPath, err := fdPathFor(file)
+	if err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return &Handle{Path: fdPath, file: file}, nil
+}
+
+func fdPathFor(file *os.File) (string, error) {
+	if file == nil {
+		return "", opError("resolve fd path")
+	}
+	fd := file.Fd()
+	for _, candidate := range fdPathCandidates(fd) {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	return "", opError("resolve fd path")
+}
+
+func fdPathCandidates(fd uintptr) []string {
+	switch runtime.GOOS {
+	case "linux":
+		return []string{
+			fmt.Sprintf("/proc/self/fd/%d", fd),
+			fmt.Sprintf("/dev/fd/%d", fd),
+		}
+	case "darwin":
+		return []string{
+			fmt.Sprintf("/dev/fd/%d", fd),
+			fmt.Sprintf("/proc/self/fd/%d", fd),
+		}
+	default:
+		return []string{
+			fmt.Sprintf("/dev/fd/%d", fd),
+			fmt.Sprintf("/proc/self/fd/%d", fd),
+		}
+	}
+}

--- a/internal/secrets/handle_posix_test.go
+++ b/internal/secrets/handle_posix_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//go:build !windows
+
+package secrets
+
+import (
+	"os"
+	"testing"
+)
+
+func TestReadHandleUnlinksOriginalPath(t *testing.T) {
+	withTempDataDir(t)
+
+	runDir, err := RunDir("posix-run")
+	if err != nil {
+		t.Fatalf("run dir: %v", err)
+	}
+	path, err := CreateFile(runDir, "token", []byte("secret"))
+	if err != nil {
+		t.Fatalf("create file: %v", err)
+	}
+	handlePath, closeFn, err := ReadHandle(path)
+	if err != nil {
+		t.Fatalf("read handle: %v", err)
+	}
+	if closeFn == nil {
+		t.Fatalf("expected close function")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected original path unlinked, stat err=%v", err)
+	}
+	if handlePath == "" {
+		t.Fatalf("expected handle path")
+	}
+	if _, err := os.Stat(handlePath); err != nil {
+		t.Fatalf("expected handle path to be readable, stat err=%v", err)
+	}
+	if err := closeFn(); err != nil {
+		t.Fatalf("close handle: %v", err)
+	}
+}

--- a/internal/secrets/handle_windows.go
+++ b/internal/secrets/handle_windows.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//go:build windows
+
+package secrets
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// Handle represents an open secret handle backed by a file descriptor.
+// The file is marked delete-on-close to enforce lifecycle semantics.
+// Close must be called when the handle is no longer needed.
+type Handle struct {
+	Path string
+	file *os.File
+}
+
+// Close closes the underlying file descriptor.
+func (h *Handle) Close() error {
+	if h == nil || h.file == nil {
+		return nil
+	}
+	return h.file.Close()
+}
+
+// OpenHandle opens a secret file for read and marks it delete-on-close,
+// returning a handle path suitable for passing to a child process. The caller
+// must keep the returned handle open for the duration of use.
+func OpenHandle(path string) (*Handle, error) {
+	if path == "" {
+		return nil, opError("open secret handle")
+	}
+	p, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, opError("open secret handle")
+	}
+	handle, err := windows.CreateFile(
+		p,
+		windows.GENERIC_READ,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_DELETE_ON_CLOSE,
+		0,
+	)
+	if err != nil {
+		return nil, wrapErr("open secret file", err)
+	}
+	file := os.NewFile(uintptr(handle), path)
+	if file == nil {
+		_ = windows.CloseHandle(handle)
+		return nil, opError("open secret handle")
+	}
+	return &Handle{Path: path, file: file}, nil
+}

--- a/internal/secrets/handle_windows_test.go
+++ b/internal/secrets/handle_windows_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//go:build windows
+
+package secrets
+
+import (
+	"os"
+	"testing"
+)
+
+func TestReadHandleDeleteOnClose(t *testing.T) {
+	withTempDataDir(t)
+
+	runDir, err := RunDir("win-run")
+	if err != nil {
+		t.Fatalf("run dir: %v", err)
+	}
+	path, err := CreateFile(runDir, "token", []byte("secret"))
+	if err != nil {
+		t.Fatalf("create file: %v", err)
+	}
+	handlePath, closeFn, err := ReadHandle(path)
+	if err != nil {
+		t.Fatalf("read handle: %v", err)
+	}
+	if closeFn == nil {
+		t.Fatalf("expected close function")
+	}
+	if handlePath == "" {
+		t.Fatalf("expected handle path")
+	}
+	if err := closeFn(); err != nil {
+		t.Fatalf("close handle: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected path removed on close, stat err=%v", err)
+	}
+}

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package secrets
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/flowd-org/flowd/internal/paths"
+)
+
+const (
+	baseDirName = "secrets"
+	janitorTTL  = 72 * time.Hour
+)
+
+// BaseDir returns the resolved base directory for secret handles.
+// This location is intentionally under the flowd data directory.
+func BaseDir() string {
+	return paths.DataPath(baseDirName)
+}
+
+// EnsureBaseDir ensures the base secrets directory exists with restrictive permissions.
+func EnsureBaseDir() (string, error) {
+	base := BaseDir()
+	if base == "" {
+		return "", opError("resolve base dir")
+	}
+	if err := os.MkdirAll(base, 0o700); err != nil {
+		return "", wrapErr("mkdir base dir", err)
+	}
+	return base, nil
+}
+
+// RunDir creates a per-run secrets directory with restrictive permissions.
+func RunDir(runID string) (string, error) {
+	if strings.TrimSpace(runID) == "" {
+		return "", opError("create run dir")
+	}
+	base, err := EnsureBaseDir()
+	if err != nil {
+		return "", err
+	}
+	runDir := filepath.Join(base, runID)
+	if err := os.MkdirAll(runDir, 0o700); err != nil {
+		return "", wrapErr("mkdir run dir", err)
+	}
+	return runDir, nil
+}
+
+// CreateFile writes a secret value to a file under runDir with restrictive permissions.
+// The returned path should be treated as sensitive and must not be logged or persisted.
+func CreateFile(runDir string, name string, value []byte) (string, error) {
+	if strings.TrimSpace(runDir) == "" {
+		return "", opError("create secret file")
+	}
+	if strings.TrimSpace(name) == "" {
+		return "", opError("create secret file")
+	}
+	if err := os.MkdirAll(runDir, 0o700); err != nil {
+		return "", wrapErr("mkdir run dir", err)
+	}
+	path := filepath.Join(runDir, sanitizeName(name))
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return "", wrapErr("open secret file", err)
+	}
+	_, writeErr := file.Write(value)
+	closeErr := file.Close()
+	if writeErr != nil {
+		return "", wrapErr("write secret file", writeErr)
+	}
+	if closeErr != nil {
+		return "", wrapErr("close secret file", closeErr)
+	}
+	return path, nil
+}
+
+// Janitor removes secret run directories older than the janitor TTL.
+// It only operates within the base secrets directory.
+func Janitor(now time.Time) (removed int, err error) {
+	base, err := EnsureBaseDir()
+	if err != nil {
+		return 0, err
+	}
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, wrapErr("read base dir", err)
+	}
+	cutoff := now.Add(-janitorTTL)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			continue
+		}
+		if info.ModTime().After(cutoff) {
+			continue
+		}
+		target := filepath.Join(base, entry.Name())
+		if removeErr := os.RemoveAll(target); removeErr != nil {
+			return removed, wrapErr("remove stale run dir", removeErr)
+		}
+		removed++
+	}
+	return removed, nil
+}
+
+func sanitizeName(name string) string {
+	if name == "" {
+		return "secret"
+	}
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-' || r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	if b.Len() == 0 {
+		return "secret"
+	}
+	return b.String()
+}

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -79,6 +79,20 @@ func CreateFile(runDir string, name string, value []byte) (string, error) {
 	return path, nil
 }
 
+// ReadHandle opens a secret file for read, unlinks it immediately, and returns
+// an fd-backed handle path plus a close function. The caller must keep the handle
+// open for the duration of use and invoke close when done.
+func ReadHandle(path string) (string, func() error, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", nil, opError("open secret handle")
+	}
+	h, err := OpenHandle(path)
+	if err != nil {
+		return "", nil, err
+	}
+	return h.Path, h.Close, nil
+}
+
 // Janitor removes secret run directories older than the janitor TTL.
 // It only operates within the base secrets directory.
 func Janitor(now time.Time) (removed int, err error) {

--- a/internal/secrets/secrets_test.go
+++ b/internal/secrets/secrets_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package secrets
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/flowd-org/flowd/internal/paths"
+)
+
+func withTempDataDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	paths.SetDataDirOverride(dir)
+	t.Cleanup(func() {
+		paths.SetDataDirOverride("")
+	})
+	return dir
+}
+
+func TestJanitorRemovesOldDirs(t *testing.T) {
+	withTempDataDir(t)
+
+	now := time.Now()
+	oldDir, err := RunDir("old-run")
+	if err != nil {
+		t.Fatalf("run dir: %v", err)
+	}
+	freshDir, err := RunDir("fresh-run")
+	if err != nil {
+		t.Fatalf("run dir: %v", err)
+	}
+	if err := os.Chtimes(oldDir, now.Add(-73*time.Hour), now.Add(-73*time.Hour)); err != nil {
+		t.Fatalf("chtimes old dir: %v", err)
+	}
+	if err := os.Chtimes(freshDir, now.Add(-1*time.Hour), now.Add(-1*time.Hour)); err != nil {
+		t.Fatalf("chtimes fresh dir: %v", err)
+	}
+
+	removed, err := Janitor(now)
+	if err != nil {
+		t.Fatalf("janitor: %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("expected 1 removed dir, got %d", removed)
+	}
+	if _, err := os.Stat(oldDir); !os.IsNotExist(err) {
+		t.Fatalf("expected old dir removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(freshDir); err != nil {
+		t.Fatalf("expected fresh dir retained, stat err=%v", err)
+	}
+
+	// Ensure janitor only touches the secrets base directory.
+	outside := filepath.Join(t.TempDir(), "other")
+	if err := os.MkdirAll(outside, 0o700); err != nil {
+		t.Fatalf("create outside dir: %v", err)
+	}
+	if err := os.Chtimes(outside, now.Add(-100*time.Hour), now.Add(-100*time.Hour)); err != nil {
+		t.Fatalf("chtimes outside dir: %v", err)
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Fatalf("outside dir missing unexpectedly: %v", err)
+	}
+}
+
+func TestCreateFilePermissionsAndCleanup(t *testing.T) {
+	withTempDataDir(t)
+
+	runDir, err := RunDir("perm-run")
+	if err != nil {
+		t.Fatalf("run dir: %v", err)
+	}
+	if info, err := os.Stat(runDir); err != nil {
+		t.Fatalf("stat run dir: %v", err)
+	} else if info.Mode().Perm()&0o077 != 0 {
+		t.Fatalf("expected run dir perms to restrict group/other, got %v", info.Mode().Perm())
+	}
+	path, err := CreateFile(runDir, "token", []byte("secret"))
+	if err != nil {
+		t.Fatalf("create file: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat secret file: %v", err)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		t.Fatalf("expected file perms to restrict group/other, got %v", info.Mode().Perm())
+	}
+
+	if err := os.RemoveAll(runDir); err != nil {
+		t.Fatalf("cleanup run dir: %v", err)
+	}
+	if _, err := os.Stat(runDir); !os.IsNotExist(err) {
+		t.Fatalf("expected run dir removed, stat err=%v", err)
+	}
+}
+
+func TestErrorsDoNotLeakPaths(t *testing.T) {
+	_, err := CreateFile("", "secret", []byte("value"))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if err.Error() != "secrets: create secret file failed" {
+		t.Fatalf("unexpected error message: %q", err.Error())
+	}
+}

--- a/internal/server/authz/scopes.go
+++ b/internal/server/authz/scopes.go
@@ -39,6 +39,8 @@ func RequiredScopes(method, path string) []string {
 			return []string{ScopeSourcesRead}
 		case path == "/events":
 			return []string{ScopeEventsRead}
+		case path == "/events/stream":
+			return []string{ScopeEventsRead}
 		case strings.HasPrefix(path, "/kv/"):
 			return []string{ScopeRuleYRead}
 		case path == "/health/storage":

--- a/internal/server/authz/scopes_test.go
+++ b/internal/server/authz/scopes_test.go
@@ -20,6 +20,7 @@ func TestRequiredScopes(t *testing.T) {
 		{method: "POST", path: "/sources", want: []string{ScopeSourcesWrite}},
 		{method: "DELETE", path: "/sources/main", want: []string{ScopeSourcesWrite}},
 		{method: "GET", path: "/events", want: []string{ScopeEventsRead}},
+		{method: "GET", path: "/events/stream", want: []string{ScopeEventsRead}},
 		{method: "GET", path: "/health/storage", want: []string{ScopeJobsRead}},
 	}
 

--- a/internal/server/handlers/alias_problem.go
+++ b/internal/server/handlers/alias_problem.go
@@ -27,6 +27,7 @@ func aliasCollisionProblem(aliasName string, contenders []indexer.AliasInfo) *re
 		response.WithExtension("alias", aliasName),
 		response.WithExtension("contenders", payload),
 		response.WithDetail(detail))
+	prob = scrubProblemResponse(&prob, newProblemScrubber(nil, map[string]any{"alias": aliasName}, nil, nil), nil, nil, nil)
 	return &prob
 }
 
@@ -39,5 +40,6 @@ func aliasValidationProblem(aliasName string, validation indexer.AliasValidation
 		response.WithExtension("code", validation.Code),
 		response.WithExtension("alias", aliasName),
 		response.WithDetail(detail))
+	prob = scrubProblemResponse(&prob, newProblemScrubber(nil, map[string]any{"alias": aliasName}, nil, nil), nil, nil, nil)
 	return &prob
 }

--- a/internal/server/handlers/dag_plan.go
+++ b/internal/server/handlers/dag_plan.go
@@ -30,6 +30,18 @@ func buildDAGPlan(ctx context.Context, jobID string, cfgObj *types.Config, spec 
 		plan.ExecutorPreview["container_image"] = strings.TrimSpace(cfgObj.Container.Image)
 	}
 	plan.SecurityProfile = effProfile
+	if plan.Outputs == nil {
+		plan.Outputs = map[string]any{}
+	}
+	if plan.Provenance == nil {
+		plan.Provenance = map[string]any{}
+	}
+	if plan.PolicyFindings == nil {
+		plan.PolicyFindings = []types.Finding{}
+	}
+	if plan.Steps == nil {
+		plan.Steps = []types.PlanStepPreview{}
+	}
 
 	var stepPreviews []types.PlanStepPreview
 	var allFindings []types.Finding

--- a/internal/server/handlers/dag_plan.go
+++ b/internal/server/handlers/dag_plan.go
@@ -16,8 +16,9 @@ import (
 	"github.com/flowd-org/flowd/internal/types"
 )
 
-func buildDAGPlan(ctx context.Context, jobID string, cfgObj *types.Config, spec *types.ArgSpec, binding *engine.Binding, effProfile string, policyCtx *policy.Context, verifier policyverify.ImageVerifier, runtime string) (types.Plan, []any, *response.Problem, error) {
+func buildDAGPlan(ctx context.Context, jobID string, cfgObj *types.Config, spec *types.ArgSpec, binding *engine.Binding, effProfile string, policyCtx *policy.Context, verifier policyverify.ImageVerifier, runtime string, requestID string) (types.Plan, []any, *response.Problem, error) {
 	plan := engine.BuildPlan(jobID, cfgObj, spec, binding)
+	plan.RequestID = requestID
 	if plan.ExecutorPreview == nil {
 		plan.ExecutorPreview = map[string]interface{}{}
 	}

--- a/internal/server/handlers/events_global.go
+++ b/internal/server/handlers/events_global.go
@@ -1,10 +1,17 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
+	"github.com/flowd-org/flowd/internal/coredb"
+	"github.com/flowd-org/flowd/internal/metrics"
+	"github.com/flowd-org/flowd/internal/observability/tracing"
 	"github.com/flowd-org/flowd/internal/server/response"
 	"github.com/flowd-org/flowd/internal/server/runstore"
 	"github.com/flowd-org/flowd/internal/server/sse"
@@ -15,9 +22,10 @@ type EventsConfig struct {
 	RunStore  *runstore.Store
 	RunHub    *sse.Hub
 	GlobalHub *sse.Hub
+	Journal   *coredb.Journal
 }
 
-// NewEventsHandler returns an SSE handler for GET /events.
+// NewEventsHandler returns an SSE handler for global events streams (GET /events/stream, GET /events).
 func NewEventsHandler(cfg EventsConfig) http.Handler {
 	store := cfg.RunStore
 	if store == nil {
@@ -31,6 +39,7 @@ func NewEventsHandler(cfg EventsConfig) http.Handler {
 	if globalHub == nil {
 		globalHub = sse.New(sse.Config{})
 	}
+	journal := cfg.Journal
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
@@ -43,9 +52,9 @@ func NewEventsHandler(cfg EventsConfig) http.Handler {
 		if lastEventID == "" {
 			lastEventID = r.URL.Query().Get("last_event_id")
 		}
-
 		var hub *sse.Hub
 		contextID := "global"
+		resumeRequested := strings.TrimSpace(lastEventID) != ""
 
 		if runID != "" {
 			if _, ok := store.Get(runID); !ok {
@@ -59,17 +68,136 @@ func NewEventsHandler(cfg EventsConfig) http.Handler {
 		}
 
 		ctx := r.Context()
+		if resumeRequested {
+			metrics.RecordSSEResumeAttempt()
+		}
+
+		var lastSeq int64
+		if resumeRequested {
+			parsedSeq, err := coredb.ParseEventID(lastEventID)
+			if err != nil {
+				response.Write(w, response.New(http.StatusBadRequest, "invalid Last-Event-ID", response.WithDetail(err.Error())))
+				return
+			}
+			lastSeq = parsedSeq
+		}
+
+		if journal != nil && resumeRequested {
+			var resumeErr error
+			resumeOutcome := "ok"
+			ctx, resumeSpan := tracing.Start(ctx, "server.sse.resume",
+				tracing.PersistDriver("sqlite"),
+				tracing.PersistOp("resume"),
+				tracing.PersistKeyspace("core_run_journal"),
+				tracing.Int64("sse.last_seq", lastSeq),
+			)
+			defer func() {
+				if resumeSpan != nil {
+					resumeSpan.SetAttributes(tracing.String("sse.resume.outcome", resumeOutcome))
+					tracing.End(resumeSpan, &resumeErr)
+				}
+			}()
+
+			var earliest, latest int64
+			if runID != "" {
+				earliest, latest, resumeErr = journal.Bounds(ctx, runID)
+			} else {
+				earliest, latest, resumeErr = journal.BoundsAll(ctx)
+			}
+			if resumeErr != nil {
+				resumeOutcome = "error"
+				response.Write(w, response.New(http.StatusInternalServerError, "journal lookup failed"))
+				return
+			}
+			if earliest == 0 {
+				resumeOutcome = "expired"
+				metrics.RecordSSECursorExpired()
+				response.Write(w, response.New(http.StatusGone, "cursor expired",
+					response.WithType("https://flowd.org/problems/sse/stale-cursor"),
+					response.WithDetail("run events are no longer retained"),
+				))
+				return
+			}
+			if latest > 0 && lastSeq > latest {
+				resumeOutcome = "invalid"
+				response.Write(w, response.New(http.StatusBadRequest, "invalid Last-Event-ID",
+					response.WithDetail(fmt.Sprintf("cursor %d beyond latest %d", lastSeq, latest)),
+				))
+				return
+			}
+			if lastSeq < earliest {
+				resumeOutcome = "expired"
+				metrics.RecordSSECursorExpired()
+				response.Write(w, response.New(http.StatusGone, "cursor expired",
+					response.WithType("https://flowd.org/problems/sse/stale-cursor"),
+					response.WithDetail(fmt.Sprintf("cursor %d no longer retained", lastSeq)),
+				))
+				return
+			}
+		}
 		sub := hub.Subscribe(ctx, contextID, lastEventID)
 		defer sub.Close()
 
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("Cache-Control", "no-store")
 		w.Header().Set("Connection", "keep-alive")
-		// Explicitly send 200 headers and an initial comment
+		// Explicitly send 200 headers, retry directive, and an initial heartbeat
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(":connected\n\n"))
+		_, _ = w.Write([]byte("retry: 3000\n"))
+		_, _ = w.Write(sse.FormatHeartbeat(time.Now().UTC()))
 		if flusher, ok := w.(http.Flusher); ok {
 			flusher.Flush()
+		}
+
+		endStream := metrics.SSEStreamStarted()
+		defer func() {
+			if endStream != nil {
+				endStream()
+			}
+		}()
+
+		if journal != nil {
+			var replayErr error
+			if runID != "" {
+				replayErr = journal.ForEach(ctx, runID, lastSeq, func(entry coredb.JournalEntry) error {
+					payload, err := sse.EncodeEvent(sse.Event{
+						ID:        fmt.Sprintf("%d", entry.Seq),
+						Event:     entry.EventType,
+						Data:      string(entry.Payload),
+						Timestamp: entry.Timestamp,
+						RunID:     runID,
+					})
+					if err != nil {
+						return err
+					}
+					if err := writeSSEPayload(ctx, w, runID, payload, entry.Seq); err != nil {
+						return err
+					}
+					lastSeq = entry.Seq
+					return nil
+				})
+			} else {
+				replayErr = journal.ForEachAll(ctx, lastSeq, func(entry coredb.JournalEntry) error {
+					wrapped := WrapGlobalEvent(entry.RunID, sse.Event{
+						ID:        fmt.Sprintf("%d", entry.Seq),
+						Event:     entry.EventType,
+						Data:      string(entry.Payload),
+						Timestamp: entry.Timestamp,
+					})
+					payload, err := sse.EncodeEvent(wrapped)
+					if err != nil {
+						return err
+					}
+					if err := writeSSEPayload(ctx, w, entry.RunID, payload, entry.Seq); err != nil {
+						return err
+					}
+					lastSeq = entry.Seq
+					return nil
+				})
+			}
+			if replayErr != nil && !errors.Is(replayErr, context.Canceled) {
+				return
+			}
 		}
 
 		for {
@@ -80,11 +208,15 @@ func NewEventsHandler(cfg EventsConfig) http.Handler {
 				if !ok {
 					return
 				}
-				if _, err := w.Write(msg); err != nil {
-					return
+				msgSeq := extractEventID(msg)
+				if msgSeq > 0 && msgSeq <= lastSeq {
+					continue
 				}
-				if flusher, ok := w.(http.Flusher); ok {
-					flusher.Flush()
+				if msgSeq > lastSeq {
+					lastSeq = msgSeq
+				}
+				if err := writeSSEPayload(ctx, w, runID, msg, msgSeq); err != nil {
+					return
 				}
 			}
 		}
@@ -96,6 +228,7 @@ func WrapGlobalEvent(runID string, ev sse.Event) sse.Event {
 	if runID == "" {
 		return ev
 	}
+	ev.RunID = runID
 	var payload map[string]any
 	if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil || payload == nil {
 		payload = map[string]any{

--- a/internal/server/handlers/events_global_test.go
+++ b/internal/server/handlers/events_global_test.go
@@ -244,3 +244,50 @@ func TestEventsHandlerGlobalStreamInvalidLastEventID(t *testing.T) {
 		})
 	}
 }
+
+func TestEventsHandlerGlobalStreamStaleCursorAfterEviction(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "stream", path: "/events/stream"},
+		{name: "alias", path: "/events"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := runstore.New()
+			runHub := sse.New(sse.Config{KeepAliveInterval: time.Hour})
+			globalHub := sse.New(sse.Config{KeepAliveInterval: time.Hour})
+			journal := newTestJournalWithLimit(t, 20)
+			sink := NewJournalEventSink(journal, EventSinkFunc(func(runID string, ev sse.Event) {
+				globalHub.Publish("global", WrapGlobalEvent(runID, ev))
+			}))
+
+			sink.Publish("run-old", sse.Event{Event: "step.output", Data: "{\"msg\":\"old\"}"})
+			sink.Publish("run-new", sse.Event{Event: "step.output", Data: "{\"msg\":\"new\"}"})
+
+			handler := NewEventsHandler(EventsConfig{
+				RunStore:  store,
+				RunHub:    runHub,
+				GlobalHub: globalHub,
+				Journal:   journal,
+			})
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			req.Header.Set("Last-Event-ID", "1")
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+			if rec.Code != http.StatusGone {
+				t.Fatalf("expected 410 Gone, got %d", rec.Code)
+			}
+			if ct := rec.Header().Get("Content-Type"); ct != "application/problem+json" {
+				t.Fatalf("expected problem+json content type, got %q", ct)
+			}
+			if !strings.Contains(rec.Body.String(), "https://flowd.org/problems/sse/stale-cursor") {
+				t.Fatalf("expected stale-cursor problem type, got %q", rec.Body.String())
+			}
+		})
+	}
+}

--- a/internal/server/handlers/events_global_test.go
+++ b/internal/server/handlers/events_global_test.go
@@ -21,7 +21,7 @@ func TestEventsHandlerGlobalStream(t *testing.T) {
 	handler := NewEventsHandler(EventsConfig{RunStore: store, RunHub: runHub, GlobalHub: globalHub})
 
 	ctx, cancel := context.WithCancel(context.Background())
-	req := httptest.NewRequest(http.MethodGet, "/events", nil).WithContext(ctx)
+	req := httptest.NewRequest(http.MethodGet, "/events/stream", nil).WithContext(ctx)
 	rec := httptest.NewRecorder()
 
 	done := make(chan struct{})
@@ -31,7 +31,7 @@ func TestEventsHandlerGlobalStream(t *testing.T) {
 	}()
 
 	time.Sleep(10 * time.Millisecond)
-	globalHub.Publish("global", WrapGlobalEvent("run-1", sse.Event{ID: "1", Event: "run.start", Data: "{}"}))
+	globalHub.Publish("global", WrapGlobalEvent("run-1", sse.Event{ID: "1", Event: "run.started", Data: "{}"}))
 	time.Sleep(10 * time.Millisecond)
 	cancel()
 	<-done
@@ -40,8 +40,8 @@ func TestEventsHandlerGlobalStream(t *testing.T) {
 	if len(body) == 0 {
 		t.Fatalf("expected SSE payload")
 	}
-	if !bytes.Contains(body, []byte("run.start")) {
-		t.Fatalf("expected run.start in stream, got %q", body)
+	if !bytes.Contains(body, []byte("\"type\":\"run.started\"")) {
+		t.Fatalf("expected run.started in stream, got %q", body)
 	}
 	if !bytes.Contains(body, []byte("run-1")) {
 		t.Fatalf("expected run_id in stream")
@@ -56,7 +56,7 @@ func TestEventsHandlerRunScopedQuery(t *testing.T) {
 	handler := NewEventsHandler(EventsConfig{RunStore: store, RunHub: runHub, GlobalHub: globalHub})
 
 	ctx, cancel := context.WithCancel(context.Background())
-	req := httptest.NewRequest(http.MethodGet, "/events?run_id=run-2", nil).WithContext(ctx)
+	req := httptest.NewRequest(http.MethodGet, "/events/stream?run_id=run-2", nil).WithContext(ctx)
 	rec := httptest.NewRecorder()
 	done := make(chan struct{})
 	go func() {
@@ -65,12 +65,12 @@ func TestEventsHandlerRunScopedQuery(t *testing.T) {
 	}()
 
 	time.Sleep(10 * time.Millisecond)
-	runHub.Publish("run-2", sse.Event{ID: "1", Event: "run.start", Data: "{}"})
+	runHub.Publish("run-2", sse.Event{ID: "1", Event: "run.started", Data: "{}"})
 	time.Sleep(10 * time.Millisecond)
 	cancel()
 	<-done
 
-	if !bytes.Contains(rec.Body.Bytes(), []byte("run.start")) {
-		t.Fatalf("expected run.start event for run_id filter")
+	if !bytes.Contains(rec.Body.Bytes(), []byte("\"type\":\"run.started\"")) {
+		t.Fatalf("expected run.started event for run_id filter")
 	}
 }

--- a/internal/server/handlers/events_global_test.go
+++ b/internal/server/handlers/events_global_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -72,5 +73,174 @@ func TestEventsHandlerRunScopedQuery(t *testing.T) {
 
 	if !bytes.Contains(rec.Body.Bytes(), []byte("\"type\":\"run.started\"")) {
 		t.Fatalf("expected run.started event for run_id filter")
+	}
+}
+
+func TestEventsHandlerGlobalStreamResume(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "stream", path: "/events/stream"},
+		{name: "alias", path: "/events"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := runstore.New()
+			runHub := sse.New(sse.Config{KeepAliveInterval: time.Hour})
+			globalHub := sse.New(sse.Config{KeepAliveInterval: time.Hour})
+			journal := newTestJournal(t)
+			sink := NewJournalEventSink(journal, EventSinkFunc(func(runID string, ev sse.Event) {
+				globalHub.Publish("global", WrapGlobalEvent(runID, ev))
+			}))
+
+			sink.Publish("run-1", sse.Event{Event: "run.started", Data: "{\"msg\":\"one\"}"})
+			sink.Publish("run-2", sse.Event{Event: "step.output", Data: "{\"msg\":\"two\"}"})
+
+			handler := NewEventsHandler(EventsConfig{
+				RunStore:  store,
+				RunHub:    runHub,
+				GlobalHub: globalHub,
+				Journal:   journal,
+			})
+
+			ctx, cancel := context.WithCancel(context.Background())
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil).WithContext(ctx)
+			req.Header.Set("Last-Event-ID", "1")
+			rec := httptest.NewRecorder()
+
+			done := make(chan struct{})
+			go func() {
+				handler.ServeHTTP(rec, req)
+				close(done)
+			}()
+
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+			<-done
+
+			body := rec.Body.String()
+			if !strings.Contains(body, "retry: 3000") {
+				t.Fatalf("expected retry directive, got %q", body)
+			}
+			if !strings.Contains(body, "event: flowd") {
+				t.Fatalf("expected flowd event envelope, got %q", body)
+			}
+			if strings.Count(body, "id: 2") != 1 {
+				t.Fatalf("expected single replay of event id 2, got %q", body)
+			}
+			if !strings.Contains(body, "\"type\":\"step.output\"") {
+				t.Fatalf("expected step.output event, got %q", body)
+			}
+			if !strings.Contains(body, "\"run_id\":\"run-2\"") {
+				t.Fatalf("expected run_id in stream, got %q", body)
+			}
+		})
+	}
+}
+
+func TestEventsHandlerGlobalStreamStaleCursor(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "stream", path: "/events/stream"},
+		{name: "alias", path: "/events"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := runstore.New()
+			runHub := sse.New(sse.Config{KeepAliveInterval: time.Hour})
+			globalHub := sse.New(sse.Config{KeepAliveInterval: time.Hour})
+			journal := newTestJournalWithLimit(t, 20)
+			sink := NewJournalEventSink(journal, EventSinkFunc(func(runID string, ev sse.Event) {
+				globalHub.Publish("global", WrapGlobalEvent(runID, ev))
+			}))
+
+			sink.Publish("run-old", sse.Event{Event: "step.output", Data: "{\"msg\":\"old\"}"})
+			sink.Publish("run-new", sse.Event{Event: "step.output", Data: "{\"msg\":\"new\"}"})
+
+			handler := NewEventsHandler(EventsConfig{
+				RunStore:  store,
+				RunHub:    runHub,
+				GlobalHub: globalHub,
+				Journal:   journal,
+			})
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			req.Header.Set("Last-Event-ID", "1")
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+			if rec.Code != http.StatusGone {
+				t.Fatalf("expected 410 Gone, got %d", rec.Code)
+			}
+			if ct := rec.Header().Get("Content-Type"); ct != "application/problem+json" {
+				t.Fatalf("expected problem+json content type, got %q", ct)
+			}
+			if !strings.Contains(rec.Body.String(), "https://flowd.org/problems/sse/stale-cursor") {
+				t.Fatalf("expected stale-cursor problem type, got %q", rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestEventsHandlerGlobalStreamInvalidLastEventID(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "stream", path: "/events/stream"},
+		{name: "alias", path: "/events"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Run("non-integer", func(t *testing.T) {
+				store := runstore.New()
+				runHub := sse.New(sse.Config{KeepAliveInterval: time.Hour})
+				globalHub := sse.New(sse.Config{KeepAliveInterval: time.Hour})
+				handler := NewEventsHandler(EventsConfig{RunStore: store, RunHub: runHub, GlobalHub: globalHub})
+
+				req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+				req.Header.Set("Last-Event-ID", "not-a-number")
+				rec := httptest.NewRecorder()
+
+				handler.ServeHTTP(rec, req)
+				if rec.Code != http.StatusBadRequest {
+					t.Fatalf("expected 400 Bad Request, got %d", rec.Code)
+				}
+			})
+
+			t.Run("beyond-latest", func(t *testing.T) {
+				store := runstore.New()
+				runHub := sse.New(sse.Config{KeepAliveInterval: time.Hour})
+				globalHub := sse.New(sse.Config{KeepAliveInterval: time.Hour})
+				journal := newTestJournal(t)
+				sink := NewJournalEventSink(journal, EventSinkFunc(func(runID string, ev sse.Event) {
+					globalHub.Publish("global", WrapGlobalEvent(runID, ev))
+				}))
+
+				sink.Publish("run-1", sse.Event{Event: "run.started", Data: "{}"})
+
+				handler := NewEventsHandler(EventsConfig{
+					RunStore:  store,
+					RunHub:    runHub,
+					GlobalHub: globalHub,
+					Journal:   journal,
+				})
+
+				req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+				req.Header.Set("Last-Event-ID", "2")
+				rec := httptest.NewRecorder()
+
+				handler.ServeHTTP(rec, req)
+				if rec.Code != http.StatusBadRequest {
+					t.Fatalf("expected 400 Bad Request, got %d", rec.Code)
+				}
+			})
+		})
 	}
 }

--- a/internal/server/handlers/health_storage.go
+++ b/internal/server/handlers/health_storage.go
@@ -34,7 +34,7 @@ func (h *storageHealthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	stats, err := h.stats(r)
 	if err != nil {
 		response.Write(w, response.New(http.StatusServiceUnavailable, "storage degraded",
-			response.WithType("https://flowd.dev/problems/storage-degraded"),
+			response.WithType("https://flowd.org/problems/storage-degraded"),
 			response.WithDetail(err.Error()),
 		))
 		return
@@ -42,7 +42,7 @@ func (h *storageHealthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	if !stats.OK {
 		response.Write(w, response.New(http.StatusServiceUnavailable, "storage degraded",
-			response.WithType("https://flowd.dev/problems/storage-degraded"),
+			response.WithType("https://flowd.org/problems/storage-degraded"),
 			response.WithExtension("driver", stats.Driver),
 			response.WithExtension("bytes_used", stats.BytesUsed),
 			response.WithExtension("max_bytes", stats.MaxBytes),

--- a/internal/server/handlers/idempotency_hash_test.go
+++ b/internal/server/handlers/idempotency_hash_test.go
@@ -1,0 +1,37 @@
+package handlers
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func TestCanonicalJSONHashDeterministic(t *testing.T) {
+	bodyA := `{"job_id":"demo","args":{"name":"Alice","count":1,"items":[1,2,{"z":"k","a":"b"}]}}`
+	bodyB := `{"args":{"items":[1,2,{"a":"b","z":"k"}],"count":1,"name":"Alice"},"job_id":"demo"}`
+
+	canonicalA, err := canonicalizeJSON([]byte(bodyA))
+	if err != nil {
+		t.Fatalf("canonicalize bodyA: %v", err)
+	}
+	canonicalB, err := canonicalizeJSON([]byte(bodyB))
+	if err != nil {
+		t.Fatalf("canonicalize bodyB: %v", err)
+	}
+
+	if string(canonicalA) != string(canonicalB) {
+		t.Fatalf("expected canonical JSON to match; got %q vs %q", string(canonicalA), string(canonicalB))
+	}
+
+	sumA := sha256.Sum256(canonicalA)
+	sumB := sha256.Sum256(canonicalB)
+	hashA := hex.EncodeToString(sumA[:])
+	hashB := hex.EncodeToString(sumB[:])
+	if hashA != hashB {
+		t.Fatalf("expected matching hashes; got %s vs %s", hashA, hashB)
+	}
+	if hashA != strings.ToLower(hashA) {
+		t.Fatalf("expected lowercase hex digest, got %s", hashA)
+	}
+}

--- a/internal/server/handlers/idempotency_store.go
+++ b/internal/server/handlers/idempotency_store.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/flowd-org/flowd/internal/coredb"
+	"github.com/flowd-org/flowd/internal/metrics"
 )
 
 type idempotencyStore interface {
@@ -49,10 +50,12 @@ func (c *memoryIdempotencyCache) Lookup(_ context.Context, key, endpoint string,
 	defer c.mu.Unlock()
 	bucket, ok := c.items[key]
 	if !ok {
+		metrics.RecordIdempotencyLookup(metrics.PersistenceOutcomeMiss)
 		return RunPayload{}, 0, "", false, nil
 	}
 	entry, ok := bucket[endpoint]
 	if !ok {
+		metrics.RecordIdempotencyLookup(metrics.PersistenceOutcomeMiss)
 		return RunPayload{}, 0, "", false, nil
 	}
 	if now.After(entry.expires) {
@@ -60,8 +63,10 @@ func (c *memoryIdempotencyCache) Lookup(_ context.Context, key, endpoint string,
 		if len(bucket) == 0 {
 			delete(c.items, key)
 		}
+		metrics.RecordIdempotencyLookup(metrics.PersistenceOutcomeExpired)
 		return RunPayload{}, 0, "", false, nil
 	}
+	metrics.RecordIdempotencyLookup(metrics.PersistenceOutcomeHit)
 	return entry.payload, entry.status, entry.bodyHash, true, nil
 }
 

--- a/internal/server/handlers/idempotency_store.go
+++ b/internal/server/handlers/idempotency_store.go
@@ -13,8 +13,12 @@ import (
 
 type idempotencyStore interface {
 	Lookup(ctx context.Context, key, endpoint string, now time.Time) (RunPayload, int, string, bool, error)
+	Reserve(ctx context.Context, key, endpoint, bodyHash string, now, expiresAt time.Time) (bool, error)
 	Store(ctx context.Context, key, endpoint, bodyHash string, payload RunPayload, status int, expiresAt time.Time) error
+	Release(ctx context.Context, key, endpoint string) error
 }
+
+const idempotencyStatusInFlight = 0
 
 // memoryIdempotencyCache is the in-process fallback used when Core DB is unavailable.
 type memoryIdempotencyCache struct {
@@ -61,6 +65,36 @@ func (c *memoryIdempotencyCache) Lookup(_ context.Context, key, endpoint string,
 	return entry.payload, entry.status, entry.bodyHash, true, nil
 }
 
+func (c *memoryIdempotencyCache) Reserve(_ context.Context, key, endpoint, bodyHash string, now, expiresAt time.Time) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	bucket := c.items[key]
+	if bucket != nil {
+		entry, ok := bucket[endpoint]
+		if ok {
+			if now.After(entry.expires) {
+				delete(bucket, endpoint)
+				if len(bucket) == 0 {
+					delete(c.items, key)
+				}
+			} else {
+				return false, nil
+			}
+		}
+	}
+	if bucket == nil {
+		bucket = make(map[string]cacheEntry)
+		c.items[key] = bucket
+	}
+	bucket[endpoint] = cacheEntry{
+		payload:  RunPayload{},
+		status:   idempotencyStatusInFlight,
+		bodyHash: bodyHash,
+		expires:  expiresAt,
+	}
+	return true, nil
+}
+
 func (c *memoryIdempotencyCache) Store(_ context.Context, key, endpoint, bodyHash string, payload RunPayload, status int, expiresAt time.Time) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -74,6 +108,23 @@ func (c *memoryIdempotencyCache) Store(_ context.Context, key, endpoint, bodyHas
 		status:   status,
 		bodyHash: bodyHash,
 		expires:  expiresAt,
+	}
+	return nil
+}
+
+func (c *memoryIdempotencyCache) Release(_ context.Context, key, endpoint string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	bucket := c.items[key]
+	if bucket == nil {
+		return nil
+	}
+	entry, ok := bucket[endpoint]
+	if ok && entry.status == idempotencyStatusInFlight {
+		delete(bucket, endpoint)
+		if len(bucket) == 0 {
+			delete(c.items, key)
+		}
 	}
 	return nil
 }
@@ -105,6 +156,13 @@ func (d *dbIdempotencyStore) Lookup(ctx context.Context, key, endpoint string, n
 	return payload, status, hash, true, nil
 }
 
+func (d *dbIdempotencyStore) Reserve(ctx context.Context, key, endpoint, bodyHash string, now, expiresAt time.Time) (bool, error) {
+	if d == nil || d.store == nil {
+		return false, nil
+	}
+	return d.store.Reserve(ctx, key, endpoint, bodyHash, now, expiresAt)
+}
+
 func (d *dbIdempotencyStore) Store(ctx context.Context, key, endpoint, bodyHash string, payload RunPayload, status int, expiresAt time.Time) error {
 	if d == nil || d.store == nil {
 		return nil
@@ -114,4 +172,11 @@ func (d *dbIdempotencyStore) Store(ctx context.Context, key, endpoint, bodyHash 
 		return err
 	}
 	return d.store.Store(ctx, key, endpoint, bodyHash, status, data, expiresAt)
+}
+
+func (d *dbIdempotencyStore) Release(ctx context.Context, key, endpoint string) error {
+	if d == nil || d.store == nil {
+		return nil
+	}
+	return d.store.Release(ctx, key, endpoint)
 }

--- a/internal/server/handlers/journal_sink.go
+++ b/internal/server/handlers/journal_sink.go
@@ -48,6 +48,9 @@ func (s *journalEventSink) Publish(runID string, ev sse.Event) {
 	}
 	ev.ID = strconv.FormatInt(entry.Seq, 10)
 	ev.Timestamp = entry.Timestamp
+	if ev.RunID == "" {
+		ev.RunID = runID
+	}
 	if s.next != nil {
 		s.next.Publish(runID, ev)
 	}

--- a/internal/server/handlers/kv.go
+++ b/internal/server/handlers/kv.go
@@ -14,7 +14,7 @@ import (
 	"github.com/flowd-org/flowd/internal/server/response"
 )
 
-const namespaceForbiddenProblemType = "https://flowd.dev/problems/namespace-forbidden"
+const namespaceForbiddenProblemType = "https://flowd.org/problems/namespace-forbidden"
 
 // KVNamespaceConfig controls namespace-specific Rule-Y behaviour.
 type KVNamespaceConfig struct {

--- a/internal/server/handlers/oci_plan.go
+++ b/internal/server/handlers/oci_plan.go
@@ -52,7 +52,7 @@ func buildOCIPlan(ctx context.Context, req planRequest, cfg PlansConfig, src sou
 	if err != nil {
 		prob := response.New(http.StatusUnprocessableEntity, "invalid security profile",
 			response.WithExtension("code", "E_POLICY"),
-			response.WithDetail(err.Error()))
+			response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, req.Args)))
 		return types.Plan{}, nil, &prob, nil
 	}
 	ctx = requestctx.WithEffectiveProfile(ctx, effProfile)
@@ -78,11 +78,13 @@ func buildOCIPlan(ctx context.Context, req planRequest, cfg PlansConfig, src sou
 		if bindErr != nil {
 			var argErr *engine.ArgError
 			if errors.As(bindErr, &argErr) {
+				scrubber := newProblemScrubber(&spec, req.Args, nil, nil)
+				safeMsg := scrubProblemDetail(argErr.Msg, scrubber, nil, nil, nil)
 				prob := response.New(http.StatusUnprocessableEntity, "argument validation failed",
-					response.WithExtension("errors", []map[string]string{{"arg": argErr.Arg, "message": argErr.Msg}}))
+					response.WithExtension("errors", []map[string]string{{"arg": argErr.Arg, "message": safeMsg}}))
 				return types.Plan{}, nil, &prob, nil
 			}
-			prob := response.New(http.StatusBadRequest, "invalid arguments", response.WithDetail(bindErr.Error()))
+			prob := response.New(http.StatusBadRequest, "invalid arguments", response.WithDetail(scrubProblemDetail(bindErr.Error(), nil, nil, &spec, req.Args)))
 			return types.Plan{}, nil, &prob, nil
 		}
 		binding = bind
@@ -98,7 +100,7 @@ func buildOCIPlan(ctx context.Context, req planRequest, cfg PlansConfig, src sou
 		if newCtxErr != nil {
 			prob := response.New(http.StatusUnprocessableEntity, "policy error",
 				response.WithExtension("code", "E_POLICY"),
-				response.WithDetail(newCtxErr.Error()))
+				response.WithDetail(scrubProblemDetail(newCtxErr.Error(), nil, nil, &spec, req.Args)))
 			return types.Plan{}, nil, &prob, nil
 		}
 	}
@@ -117,7 +119,7 @@ func buildOCIPlan(ctx context.Context, req planRequest, cfg PlansConfig, src sou
 	if err != nil {
 		prob := response.New(http.StatusUnprocessableEntity, "policy error",
 			response.WithExtension("code", "E_POLICY"),
-			response.WithDetail(err.Error()))
+			response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, &spec, req.Args)))
 		return types.Plan{}, nil, &prob, nil
 	}
 

--- a/internal/server/handlers/oci_plan.go
+++ b/internal/server/handlers/oci_plan.go
@@ -157,7 +157,10 @@ func buildOCIPlan(ctx context.Context, req planRequest, cfg PlansConfig, src sou
 
 	plan := engine.BuildPlan(req.JobID, nil, &spec, binding)
 	plan.SecurityProfile = effProfile
-	plan.Provenance = map[string]interface{}{"source": sourceToProvenance(src)}
+	if plan.Provenance == nil {
+		plan.Provenance = map[string]any{}
+	}
+	plan.Provenance["source"] = sourceToProvenance(src)
 	if plan.ExecutorPreview == nil {
 		plan.ExecutorPreview = map[string]interface{}{}
 	}

--- a/internal/server/handlers/persistence_scrub.go
+++ b/internal/server/handlers/persistence_scrub.go
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package handlers
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/flowd-org/flowd/internal/coredb"
+	"github.com/flowd-org/flowd/internal/engine"
+	"github.com/flowd-org/flowd/internal/events"
+	"github.com/flowd-org/flowd/internal/secrets"
+	"github.com/flowd-org/flowd/internal/server/sse"
+)
+
+type persistenceScrubber struct {
+	secretNames       map[string]struct{}
+	secretValues      []string
+	secretHandlePaths []string
+	baseDir           string
+}
+
+type scrubbedEventSink struct {
+	next     EventSink
+	scrubber *persistenceScrubber
+}
+
+func newScrubbedEventSink(next EventSink, scrubber *persistenceScrubber) EventSink {
+	if next == nil || scrubber == nil {
+		return next
+	}
+	return &scrubbedEventSink{next: next, scrubber: scrubber}
+}
+
+func (s *scrubbedEventSink) Publish(runID string, ev sse.Event) {
+	if s == nil || s.next == nil {
+		return
+	}
+	if s.scrubber != nil {
+		ev.Data = scrubEventDataForPersistence(ev.Data, s.scrubber)
+	}
+	s.next.Publish(runID, ev)
+}
+
+func newPersistenceScrubber(binding *engine.Binding, secretHandles map[string]string) *persistenceScrubber {
+	scrubber := &persistenceScrubber{baseDir: strings.TrimSpace(secrets.BaseDir())}
+	if binding != nil {
+		if len(binding.SecretNames) > 0 {
+			scrubber.secretNames = binding.SecretNames
+		}
+		if len(binding.SecretValues) > 0 {
+			scrubber.secretValues = append([]string{}, binding.SecretValues...)
+		}
+	}
+	if len(secretHandles) > 0 {
+		scrubber.secretHandlePaths = make([]string, 0, len(secretHandles))
+		for _, path := range secretHandles {
+			if strings.TrimSpace(path) == "" {
+				continue
+			}
+			scrubber.secretHandlePaths = append(scrubber.secretHandlePaths, path)
+		}
+	}
+	return scrubber
+}
+
+func scrubRunPayloadForPersistence(payload RunPayload, binding *engine.Binding, secretHandles map[string]string) RunPayload {
+	scrubber := newPersistenceScrubber(binding, secretHandles)
+	return scrubRunPayload(payload, scrubber)
+}
+
+func scrubRunRecordForPersistence(record coredb.RunRecord, binding *engine.Binding, secretHandles map[string]string) coredb.RunRecord {
+	scrubber := newPersistenceScrubber(binding, secretHandles)
+	return scrubRunRecord(record, scrubber)
+}
+
+func scrubEventDataForPersistence(data string, scrubber *persistenceScrubber) string {
+	if data == "" {
+		return data
+	}
+	if scrubber == nil {
+		scrubber = newPersistenceScrubber(nil, nil)
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(data), &decoded); err == nil {
+		scrubbed := scrubAny(decoded, scrubber)
+		if scrubbedBytes, err := json.Marshal(scrubbed); err == nil {
+			return string(scrubbedBytes)
+		}
+	}
+	if scrubber.shouldRedactString(data) {
+		return events.SecretToken()
+	}
+	return data
+}
+
+func scrubRunPayload(payload RunPayload, scrubber *persistenceScrubber) RunPayload {
+	out := payload
+	if payload.Result != nil {
+		out.Result = scrubMap(payload.Result, scrubber)
+	}
+	if payload.Provenance != nil {
+		out.Provenance = scrubMap(payload.Provenance, scrubber)
+	}
+	return out
+}
+
+func scrubRunRecord(record coredb.RunRecord, scrubber *persistenceScrubber) coredb.RunRecord {
+	out := record
+	if record.Result != nil {
+		out.Result = scrubMap(record.Result, scrubber)
+	}
+	if record.Provenance != nil {
+		out.Provenance = scrubMap(record.Provenance, scrubber)
+	}
+	return out
+}
+
+func scrubMap(values map[string]any, scrubber *persistenceScrubber) map[string]any {
+	if len(values) == 0 {
+		return values
+	}
+	out := make(map[string]any, len(values))
+	for key, value := range values {
+		if scrubber != nil && scrubber.isSecretKey(key) {
+			out[key] = events.SecretToken()
+			continue
+		}
+		out[key] = scrubAny(value, scrubber)
+	}
+	return out
+}
+
+func scrubAny(value any, scrubber *persistenceScrubber) any {
+	switch v := value.(type) {
+	case map[string]any:
+		return scrubMap(v, scrubber)
+	case map[string]string:
+		out := make(map[string]any, len(v))
+		for key, val := range v {
+			if scrubber != nil && scrubber.isSecretKey(key) {
+				out[key] = events.SecretToken()
+				continue
+			}
+			out[key] = scrubString(val, scrubber)
+		}
+		return out
+	case []any:
+		out := make([]any, len(v))
+		for i, elem := range v {
+			out[i] = scrubAny(elem, scrubber)
+		}
+		return out
+	case []string:
+		out := make([]any, len(v))
+		for i, elem := range v {
+			out[i] = scrubString(elem, scrubber)
+		}
+		return out
+	case string:
+		return scrubString(v, scrubber)
+	default:
+		return value
+	}
+}
+
+func scrubString(value string, scrubber *persistenceScrubber) string {
+	if scrubber == nil {
+		return value
+	}
+	if scrubber.shouldRedactString(value) {
+		return events.SecretToken()
+	}
+	return value
+}
+
+func (s *persistenceScrubber) isSecretKey(key string) bool {
+	if s == nil || len(s.secretNames) == 0 {
+		return false
+	}
+	_, ok := s.secretNames[key]
+	return ok
+}
+
+func (s *persistenceScrubber) shouldRedactString(value string) bool {
+	if s == nil {
+		return false
+	}
+	if value == "" || value == events.SecretToken() {
+		return false
+	}
+	for _, secret := range s.secretValues {
+		if secret != "" && strings.Contains(value, secret) {
+			return true
+		}
+	}
+	for _, path := range s.secretHandlePaths {
+		if path != "" && strings.Contains(value, path) {
+			return true
+		}
+	}
+	if s.baseDir != "" && strings.Contains(value, s.baseDir) {
+		return true
+	}
+	return false
+}

--- a/internal/server/handlers/persistence_scrub.go
+++ b/internal/server/handlers/persistence_scrub.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flowd-org/flowd/internal/events"
 	"github.com/flowd-org/flowd/internal/secrets"
 	"github.com/flowd-org/flowd/internal/server/sse"
+	"github.com/flowd-org/flowd/internal/types"
 )
 
 type persistenceScrubber struct {
@@ -61,6 +62,78 @@ func newPersistenceScrubber(binding *engine.Binding, secretHandles map[string]st
 		}
 	}
 	return scrubber
+}
+
+func newProblemScrubber(spec *types.ArgSpec, args map[string]any, binding *engine.Binding, secretHandles map[string]string) *persistenceScrubber {
+	scrubber := newPersistenceScrubber(binding, secretHandles)
+	if scrubber == nil {
+		scrubber = newPersistenceScrubber(nil, secretHandles)
+	}
+	if len(args) == 0 || spec == nil {
+		return scrubber
+	}
+	for _, arg := range spec.Args {
+		if !isSecretArgSpec(arg) {
+			continue
+		}
+		if scrubber.secretNames == nil {
+			scrubber.secretNames = map[string]struct{}{}
+		}
+		scrubber.secretNames[arg.Name] = struct{}{}
+		if val, ok := args[arg.Name]; ok {
+			scrubber.secretValues = appendStringValues(scrubber.secretValues, val)
+		}
+	}
+	return scrubber
+}
+
+func isSecretArgSpec(arg types.Arg) bool {
+	return arg.Format == "secret" || arg.Secret
+}
+
+func appendStringValues(existing []string, value any) []string {
+	if value == nil {
+		return existing
+	}
+	seen := make(map[string]struct{}, len(existing))
+	for _, val := range existing {
+		if val == "" {
+			continue
+		}
+		seen[val] = struct{}{}
+	}
+	var add func(any)
+	add = func(v any) {
+		switch t := v.(type) {
+		case string:
+			if t == "" {
+				return
+			}
+			if _, ok := seen[t]; ok {
+				return
+			}
+			seen[t] = struct{}{}
+			existing = append(existing, t)
+		case []string:
+			for _, item := range t {
+				add(item)
+			}
+		case []any:
+			for _, item := range t {
+				add(item)
+			}
+		case map[string]string:
+			for _, item := range t {
+				add(item)
+			}
+		case map[string]any:
+			for _, item := range t {
+				add(item)
+			}
+		}
+	}
+	add(value)
+	return existing
 }
 
 func scrubRunPayloadForPersistence(payload RunPayload, binding *engine.Binding, secretHandles map[string]string) RunPayload {

--- a/internal/server/handlers/plans.go
+++ b/internal/server/handlers/plans.go
@@ -138,10 +138,19 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 		}
 
 		annotatePlan := func(plan *types.Plan) {
-			plan.JobID = effectiveID
 			if plan.Provenance == nil {
 				plan.Provenance = map[string]any{}
 			}
+			if plan.Outputs == nil {
+				plan.Outputs = map[string]any{}
+			}
+			if plan.PolicyFindings == nil {
+				plan.PolicyFindings = []types.Finding{}
+			}
+			if plan.Steps == nil {
+				plan.Steps = []types.PlanStepPreview{}
+			}
+			plan.JobID = effectiveID
 			plan.Provenance["canonical_id"] = effectiveID
 			canonicalPath := strings.ReplaceAll(effectiveID, ".", "/")
 			if aliasUsed != nil {

--- a/internal/server/handlers/plans.go
+++ b/internal/server/handlers/plans.go
@@ -437,8 +437,11 @@ func validatePlanArgs(spec types.ArgSpec, args map[string]interface{}) (*engine.
 	}
 
 	for name := range args {
+		if err := types.ValidateArgName(name); err != nil {
+			return nil, &engine.ArgError{Arg: name, Msg: err.Error()}
+		}
 		if !hasArg(spec, name) {
-			return nil, errors.New("unknown argument: " + name)
+			return nil, &engine.ArgError{Arg: name, Msg: "unknown argument"}
 		}
 	}
 
@@ -457,6 +460,9 @@ func validatePlanArgs(spec types.ArgSpec, args map[string]interface{}) (*engine.
 
 func attachSpecFlags(fs *pflag.FlagSet, spec types.ArgSpec) error {
 	for _, a := range spec.Args {
+		if err := types.ValidateArgName(a.Name); err != nil {
+			return &engine.ArgError{Arg: a.Name, Msg: err.Error()}
+		}
 		switch a.Type {
 		case "string":
 			def, _ := a.Default.(string)
@@ -478,7 +484,7 @@ func attachSpecFlags(fs *pflag.FlagSet, spec types.ArgSpec) error {
 		case "array", "object":
 			fs.StringArray(a.Name, nil, "")
 		default:
-			return errors.New("unsupported arg type: " + a.Type)
+			return &engine.ArgError{Arg: a.Name, Msg: "unsupported arg type"}
 		}
 	}
 	return nil
@@ -489,13 +495,13 @@ func setFlagFromValue(fs *pflag.FlagSet, arg types.Arg, val interface{}) error {
 	case "string":
 		s, ok := val.(string)
 		if !ok {
-			return errors.New("argument " + arg.Name + " must be a string")
+			return &engine.ArgError{Arg: arg.Name, Msg: "must be a string"}
 		}
 		return fs.Set(arg.Name, s)
 	case "boolean":
 		b, ok := val.(bool)
 		if !ok {
-			return errors.New("argument " + arg.Name + " must be a boolean")
+			return &engine.ArgError{Arg: arg.Name, Msg: "must be a boolean"}
 		}
 		return fs.Set(arg.Name, strconv.FormatBool(b))
 	case "integer":
@@ -507,7 +513,7 @@ func setFlagFromValue(fs *pflag.FlagSet, arg types.Arg, val interface{}) error {
 		case int64:
 			return fs.Set(arg.Name, strconv.Itoa(int(v)))
 		default:
-			return errors.New("argument " + arg.Name + " must be an integer")
+			return &engine.ArgError{Arg: arg.Name, Msg: "must be an integer"}
 		}
 	case "array":
 		switch arr := val.(type) {
@@ -515,7 +521,7 @@ func setFlagFromValue(fs *pflag.FlagSet, arg types.Arg, val interface{}) error {
 			for _, item := range arr {
 				s, ok := item.(string)
 				if !ok {
-					return errors.New("argument " + arg.Name + " array items must be strings")
+					return &engine.ArgError{Arg: arg.Name, Msg: "array items must be strings"}
 				}
 				if err := fs.Set(arg.Name, s); err != nil {
 					return err
@@ -530,17 +536,17 @@ func setFlagFromValue(fs *pflag.FlagSet, arg types.Arg, val interface{}) error {
 			}
 			return nil
 		default:
-			return errors.New("argument " + arg.Name + " must be an array of strings")
+			return &engine.ArgError{Arg: arg.Name, Msg: "must be an array of strings"}
 		}
 	case "object":
 		mp, ok := val.(map[string]interface{})
 		if !ok {
-			return errors.New("argument " + arg.Name + " must be an object")
+			return &engine.ArgError{Arg: arg.Name, Msg: "must be an object"}
 		}
 		for k, v := range mp {
 			str, ok := v.(string)
 			if !ok {
-				return errors.New("argument " + arg.Name + " values must be strings")
+				return &engine.ArgError{Arg: arg.Name, Msg: "object values must be strings"}
 			}
 			if err := fs.Set(arg.Name, k+"="+str); err != nil {
 				return err
@@ -548,7 +554,7 @@ func setFlagFromValue(fs *pflag.FlagSet, arg types.Arg, val interface{}) error {
 		}
 		return nil
 	default:
-		return errors.New("unsupported arg type: " + arg.Type)
+		return &engine.ArgError{Arg: arg.Name, Msg: "unsupported arg type"}
 	}
 }
 

--- a/internal/server/handlers/plans.go
+++ b/internal/server/handlers/plans.go
@@ -60,7 +60,7 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 
 		req, err := decodePlanRequest(r.Body)
 		if err != nil {
-			response.Write(w, response.New(http.StatusBadRequest, "invalid request body", response.WithDetail(err.Error())))
+			response.Write(w, response.New(http.StatusBadRequest, "invalid request body", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 			return
 		}
 		if req.JobID == "" {
@@ -75,16 +75,16 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 
 		if req.Source != nil && req.Source.Name != "" {
 			if cfg.Sources == nil {
-				response.Write(w, response.New(http.StatusNotFound, "source not found", response.WithDetail(req.Source.Name)))
+				response.Write(w, response.New(http.StatusNotFound, "source not found", response.WithDetail(scrubProblemDetail(req.Source.Name, nil, nil, nil, nil))))
 				return
 			}
 			source, ok := cfg.Sources.Get(req.Source.Name)
 			if !ok {
-				response.Write(w, response.New(http.StatusNotFound, "source not found", response.WithDetail(req.Source.Name)))
+				response.Write(w, response.New(http.StatusNotFound, "source not found", response.WithDetail(scrubProblemDetail(req.Source.Name, nil, nil, nil, nil))))
 				return
 			}
 			if source.LocalPath == "" {
-				response.Write(w, response.New(http.StatusBadRequest, "source not materialized", response.WithDetail("source "+req.Source.Name+" has no local checkout")))
+				response.Write(w, response.New(http.StatusBadRequest, "source not materialized", response.WithDetail(scrubProblemDetail("source "+req.Source.Name+" has no local checkout", nil, nil, nil, nil))))
 				return
 			}
 			discoverRoot = source.LocalPath
@@ -92,7 +92,7 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 
 		result, err := discoverFn(discoverRoot)
 		if err != nil {
-			response.Write(w, response.New(http.StatusInternalServerError, "job discovery failed", response.WithDetail(err.Error())))
+			response.Write(w, response.New(http.StatusInternalServerError, "job discovery failed", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 			return
 		}
 
@@ -189,11 +189,11 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 			ociPlan, attrs, handled, prob, planErr := tryBuildOCIPlan(r, req, cfg)
 			if handled {
 				if planErr != nil {
-					response.Write(w, response.New(http.StatusInternalServerError, "plan generation failed", response.WithDetail(planErr.Error())))
+					response.Write(w, response.New(http.StatusInternalServerError, "plan generation failed", response.WithDetail(scrubProblemDetail(planErr.Error(), nil, nil, nil, nil))))
 					return
 				}
 				if prob != nil {
-					response.Write(w, *prob)
+					response.Write(w, scrubProblemResponse(prob, nil, nil, nil, nil))
 					return
 				}
 				if logger := requestctx.Logger(ctx); logger != nil {
@@ -202,19 +202,19 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 				writePlanResponse(w, ociPlan)
 				return
 			}
-			response.Write(w, response.New(http.StatusNotFound, "job not found", response.WithDetail(requestedID)))
+			response.Write(w, response.New(http.StatusNotFound, "job not found", response.WithDetail(scrubProblemDetail(requestedID, nil, nil, nil, nil))))
 			return
 		}
 
 		cfgObj, err := loadConfig(jobPath)
 		if err != nil {
-			response.Write(w, response.New(http.StatusInternalServerError, "load config failed", response.WithDetail(err.Error())))
+			response.Write(w, response.New(http.StatusInternalServerError, "load config failed", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 			return
 		}
 		isDAG := isDAGConfig(cfgObj)
 		if isDAG {
 			if prob := validateDAGConfig(cfgObj); prob != nil {
-				response.Write(w, *prob)
+				response.Write(w, scrubProblemResponse(prob, nil, nil, nil, nil))
 				return
 			}
 		}
@@ -226,11 +226,13 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 			if bindErr != nil {
 				var argErr *engine.ArgError
 				if errors.As(bindErr, &argErr) {
+					scrubber := newProblemScrubber(spec, req.Args, nil, nil)
+					safeMsg := scrubProblemDetail(argErr.Msg, scrubber, nil, nil, nil)
 					response.Write(w, response.New(http.StatusUnprocessableEntity, "argument validation failed",
-						response.WithExtension("errors", []map[string]string{{"arg": argErr.Arg, "message": argErr.Msg}})))
+						response.WithExtension("errors", []map[string]string{{"arg": argErr.Arg, "message": safeMsg}})))
 					return
 				}
-				response.Write(w, response.New(http.StatusBadRequest, "invalid arguments", response.WithDetail(bindErr.Error())))
+				response.Write(w, response.New(http.StatusBadRequest, "invalid arguments", response.WithDetail(scrubProblemDetail(bindErr.Error(), nil, nil, spec, req.Args))))
 				return
 			}
 			binding = bind
@@ -243,7 +245,7 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 		if err != nil {
 			response.Write(w, response.New(http.StatusUnprocessableEntity, "invalid security profile",
 				response.WithExtension("code", "E_POLICY"),
-				response.WithDetail(err.Error())))
+				response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, spec, req.Args))))
 			return
 		}
 
@@ -261,7 +263,8 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 			if executor == "container" && runtimeVal == "" {
 				detected, detectErr := detectContainerRuntime(nil)
 				if detectErr != nil {
-					response.Write(w, runtimeUnavailableProblem(detectErr))
+					prob := runtimeUnavailableProblem(detectErr)
+					response.Write(w, scrubProblemResponse(&prob, nil, nil, spec, req.Args))
 					return
 				}
 				runtimeVal = detected
@@ -274,12 +277,12 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 
 			plan, attrs, prob, buildErr := buildDAGPlan(ctx, effectiveID, cfgObj, spec, binding, effProfile, policyCtx, cfg.Verifier, runtimeStr)
 			if buildErr != nil {
-				response.Write(w, response.New(http.StatusInternalServerError, "plan generation failed", response.WithDetail(buildErr.Error())))
+				response.Write(w, response.New(http.StatusInternalServerError, "plan generation failed", response.WithDetail(scrubProblemDetail(buildErr.Error(), nil, nil, spec, req.Args))))
 				return
 			}
 			annotatePlan(&plan)
 			if prob != nil {
-				response.Write(w, *prob)
+				response.Write(w, scrubProblemResponse(prob, nil, nil, spec, req.Args))
 				return
 			}
 			if logger := requestctx.Logger(ctx); logger != nil {
@@ -308,12 +311,13 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 		if image != "" {
 			if runtimeVal == "" {
 				if _, detectErr := detectContainerRuntime(nil); detectErr != nil {
-					response.Write(w, runtimeUnavailableProblem(detectErr))
+					prob := runtimeUnavailableProblem(detectErr)
+					response.Write(w, scrubProblemResponse(&prob, nil, nil, spec, req.Args))
 					return
 				}
 			}
 			if prob := enforceRegistryAllowList(ctx, image, policyCtx); prob != nil {
-				response.Write(w, *prob)
+				response.Write(w, scrubProblemResponse(prob, nil, nil, spec, req.Args))
 				return
 			}
 
@@ -321,13 +325,13 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 			if err != nil {
 				response.Write(w, response.New(http.StatusUnprocessableEntity, "policy error",
 					response.WithExtension("code", "E_POLICY"),
-					response.WithDetail(err.Error())))
+					response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, spec, req.Args))))
 				return
 			}
 
 			outcome, prob := enforceImageVerification(ctx, image, mode, cfg.Verifier)
 			if prob != nil {
-				response.Write(w, *prob)
+				response.Write(w, scrubProblemResponse(prob, nil, nil, spec, req.Args))
 				return
 			}
 			if mode != policy.VerifyModeDisabled {
@@ -351,14 +355,14 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 			}
 
 			if prob := enforceResourceCeilings(ctx, cfgObj, policyCtx.ContainerCeilings()); prob != nil {
-				response.Write(w, *prob)
+				response.Write(w, scrubProblemResponse(prob, nil, nil, spec, req.Args))
 				return
 			}
 		}
 
 		overrideFindings, _, prob := evaluateOverrides(ctx, cfgObj, effProfile, policyCtx)
 		if prob != nil {
-			response.Write(w, *prob)
+			response.Write(w, scrubProblemResponse(prob, nil, nil, spec, req.Args))
 			return
 		}
 		if len(overrideFindings) > 0 {

--- a/internal/server/handlers/plans.go
+++ b/internal/server/handlers/plans.go
@@ -67,6 +67,10 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 			response.Write(w, response.New(http.StatusBadRequest, "job_id is required"))
 			return
 		}
+		ctx = requestctx.WithScrubbedLogger(ctx, func(msg string) string {
+			return scrubProblemDetail(msg, nil, nil, nil, req.Args)
+		})
+		r = r.WithContext(ctx)
 
 		discoverRoot := cfg.Root
 		if discoverRoot == "" {

--- a/internal/server/handlers/plans.go
+++ b/internal/server/handlers/plans.go
@@ -288,7 +288,7 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 			}
 			r = r.WithContext(ctx)
 
-			plan, attrs, prob, buildErr := buildDAGPlan(ctx, effectiveID, cfgObj, spec, binding, effProfile, policyCtx, cfg.Verifier, runtimeStr)
+			plan, attrs, prob, buildErr := buildDAGPlan(ctx, effectiveID, cfgObj, spec, binding, effProfile, policyCtx, cfg.Verifier, runtimeStr, requestIDFromContext(ctx))
 			if buildErr != nil {
 				response.Write(w, response.New(http.StatusInternalServerError, "plan generation failed", response.WithDetail(scrubProblemDetail(buildErr.Error(), nil, nil, spec, req.Args))))
 				return
@@ -385,6 +385,7 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 		plan := engine.BuildPlan(effectiveID, cfgObj, spec, binding)
 		annotatePlan(&plan)
 		plan.SecurityProfile = effProfile
+		plan.RequestID = requestIDFromContext(ctx)
 		if len(findings) > 0 {
 			plan.PolicyFindings = findings
 		}

--- a/internal/server/handlers/plans_test.go
+++ b/internal/server/handlers/plans_test.go
@@ -61,6 +61,12 @@ argspec:
 	if plan.JobID != "demo" {
 		t.Fatalf("expected job_id demo, got %s", plan.JobID)
 	}
+	if plan.Outputs == nil {
+		t.Fatalf("expected outputs in plan")
+	}
+	if plan.Provenance == nil {
+		t.Fatalf("expected provenance in plan")
+	}
 	if len(plan.ResolvedArgs) == 0 || plan.ResolvedArgs["name"] != "Alice" {
 		t.Fatalf("expected resolved name Alice, got %+v", plan.ResolvedArgs)
 	}
@@ -94,6 +100,12 @@ interpreter: "container:alpine:3.20"
 	execPreview := plan.ExecutorPreview
 	if execPreview["executor"] != "container" {
 		t.Fatalf("expected executor preview container, got %+v", execPreview)
+	}
+	if plan.Outputs == nil {
+		t.Fatalf("expected outputs in plan")
+	}
+	if plan.Provenance == nil {
+		t.Fatalf("expected provenance in plan")
 	}
 	if execPreview["container_image"] != "alpine:3.20" {
 		t.Fatalf("expected container image in preview, got %+v", execPreview)
@@ -140,6 +152,12 @@ steps:
 	}
 	if plan.ExecutorPreview["composition"] != "steps" {
 		t.Fatalf("expected composition steps in preview, got %+v", plan.ExecutorPreview)
+	}
+	if plan.Outputs == nil {
+		t.Fatalf("expected outputs in plan")
+	}
+	if plan.Provenance == nil {
+		t.Fatalf("expected provenance in plan")
 	}
 	if len(plan.Steps) != 2 {
 		t.Fatalf("expected 2 steps in preview, got %+v", plan.Steps)
@@ -321,6 +339,12 @@ argspec:
 	if plan.JobID != "remote" {
 		t.Fatalf("expected plan job_id remote, got %s", plan.JobID)
 	}
+	if plan.Outputs == nil {
+		t.Fatalf("expected outputs in plan")
+	}
+	if plan.Provenance == nil {
+		t.Fatalf("expected provenance in plan")
+	}
 	if plan.ResolvedArgs["name"] != "Bob" {
 		t.Fatalf("expected resolved arg Bob, got %+v", plan.ResolvedArgs)
 	}
@@ -364,6 +388,12 @@ func TestPlansHandlerUsesGitSource(t *testing.T) {
 	}
 	if plan.JobID != "gitjob" {
 		t.Fatalf("expected job gitjob, got %s", plan.JobID)
+	}
+	if plan.Outputs == nil {
+		t.Fatalf("expected outputs in plan")
+	}
+	if plan.Provenance == nil {
+		t.Fatalf("expected provenance in plan")
 	}
 	if plan.ResolvedArgs["name"] != "Charlie" {
 		t.Fatalf("expected resolved name Charlie, got %+v", plan.ResolvedArgs)
@@ -541,6 +571,12 @@ container:
 	if plan.ImageTrust == nil || plan.ImageTrust.Mode != string(policy.VerifyModePermissive) || plan.ImageTrust.Verified {
 		t.Fatalf("unexpected image trust preview: %+v", plan.ImageTrust)
 	}
+	if plan.Outputs == nil {
+		t.Fatalf("expected outputs in plan")
+	}
+	if plan.Provenance == nil {
+		t.Fatalf("expected provenance in plan")
+	}
 	if len(plan.PolicyFindings) != 1 || plan.PolicyFindings[0].Code != "image.signature.permissive" {
 		t.Fatalf("expected permissive finding, got %+v", plan.PolicyFindings)
 	}
@@ -677,6 +713,12 @@ container:
 	}
 	if len(plan.PolicyFindings) == 0 {
 		t.Fatalf("expected policy findings for override, got none")
+	}
+	if plan.Outputs == nil {
+		t.Fatalf("expected outputs in plan")
+	}
+	if plan.Provenance == nil {
+		t.Fatalf("expected provenance in plan")
 	}
 	if plan.PolicyFindings[0].Code != "policy.override.allowed" {
 		t.Fatalf("expected policy.override.allowed, got %+v", plan.PolicyFindings)
@@ -850,6 +892,9 @@ jobs:
 	if plan.SecurityProfile != "secure" {
 		t.Fatalf("expected security profile secure, got %s", plan.SecurityProfile)
 	}
+	if plan.Outputs == nil {
+		t.Fatalf("expected outputs in plan")
+	}
 	if val, ok := plan.ResolvedArgs["image-tag"].(string); !ok || val != "latest" {
 		t.Fatalf("expected resolved arg image-tag=latest, got %+v", plan.ResolvedArgs)
 	}
@@ -934,6 +979,9 @@ jobs:
 	}
 	if plan.ImageTrust == nil || plan.ImageTrust.Mode != string(policy.VerifyModePermissive) || plan.ImageTrust.Verified {
 		t.Fatalf("expected permissive image trust warning, got %+v", plan.ImageTrust)
+	}
+	if plan.Outputs == nil {
+		t.Fatalf("expected outputs in plan")
 	}
 	foundWarning := false
 	for _, finding := range plan.PolicyFindings {

--- a/internal/server/handlers/problem_scrub.go
+++ b/internal/server/handlers/problem_scrub.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/flowd-org/flowd/internal/engine"
+	"github.com/flowd-org/flowd/internal/server/response"
+	"github.com/flowd-org/flowd/internal/types"
+)
+
+func scrubProblemDetail(detail string, scrubber *persistenceScrubber, binding *engine.Binding, spec *types.ArgSpec, args map[string]any) string {
+	if detail == "" {
+		return detail
+	}
+	if scrubber == nil {
+		scrubber = newProblemScrubber(spec, args, binding, nil)
+	}
+	return scrubString(detail, scrubber)
+}
+
+func scrubProblemResponse(prob *response.Problem, scrubber *persistenceScrubber, binding *engine.Binding, spec *types.ArgSpec, args map[string]any) response.Problem {
+	if prob == nil {
+		return response.New(http.StatusInternalServerError, "internal error")
+	}
+	if scrubber == nil {
+		scrubber = newProblemScrubber(spec, args, binding, nil)
+	}
+	copy := *prob
+	if copy.Title != "" {
+		copy.Title = scrubString(copy.Title, scrubber)
+	}
+	if copy.Detail != "" {
+		copy.Detail = scrubString(copy.Detail, scrubber)
+	}
+	if len(copy.Ext) > 0 {
+		copy.Ext = scrubProblemExtensions(copy.Ext, scrubber)
+	}
+	return copy
+}
+
+func scrubProblemExtensions(ext map[string]any, scrubber *persistenceScrubber) map[string]any {
+	if len(ext) == 0 {
+		return ext
+	}
+	out := make(map[string]any, len(ext))
+	for key, value := range ext {
+		out[key] = scrubAny(value, scrubber)
+	}
+	return out
+}

--- a/internal/server/handlers/request_id_test.go
+++ b/internal/server/handlers/request_id_test.go
@@ -1,0 +1,109 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flowd-org/flowd/internal/coredb"
+	"github.com/flowd-org/flowd/internal/server/requestctx"
+	"github.com/flowd-org/flowd/internal/server/runstore"
+)
+
+func TestRunsHandlerPersistsRequestID(t *testing.T) {
+	root := t.TempDir()
+	writeJobConfig(t, root, "demo", `
+version: v1
+job:
+  id: demo
+  name: Demo Job
+`)
+
+	db, err := coredb.Open(context.Background(), coredb.Options{DataDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open coredb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := runstore.New()
+	h := NewRunsHandler(RunsConfig{
+		Root:  root,
+		Now:   func() time.Time { return time.Unix(0, 0).UTC() },
+		Store: store,
+		DB:    db,
+	})
+
+	requestID := "req-test-123"
+	payload := `{"job_id":"demo"}`
+	req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Idempotency-Key", "aaaaaaaaaaaaaaaaaaaa")
+	req = req.WithContext(requestctx.WithRequestID(req.Context(), requestID))
+
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.Code)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := body["request_id"]; got != requestID {
+		t.Fatalf("expected request_id %q, got %v", requestID, got)
+	}
+
+	runID, _ := body["id"].(string)
+	if runID == "" {
+		t.Fatalf("expected run id")
+	}
+
+	get := httptest.NewRecorder()
+	NewRunGetHandler(RunGetConfig{Store: store, DB: db}).ServeHTTP(get, httptest.NewRequest(http.MethodGet, "/runs/"+runID, nil))
+	if get.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", get.Code)
+	}
+	var getBody map[string]any
+	if err := json.NewDecoder(get.Body).Decode(&getBody); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	if got := getBody["request_id"]; got != requestID {
+		t.Fatalf("expected persisted request_id %q, got %v", requestID, got)
+	}
+}
+
+func TestPlansHandlerEchoesRequestID(t *testing.T) {
+	root := t.TempDir()
+	writeJobConfig(t, root, "demo", `
+version: v1
+job:
+  id: demo
+  name: Demo Job
+`)
+
+	planHandler := NewPlansHandler(PlansConfig{Root: root})
+	requestID := "req-plan-456"
+	payload := `{"job_id":"demo"}`
+	req := httptest.NewRequest(http.MethodPost, "/plans", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(requestctx.WithRequestID(req.Context(), requestID))
+
+	resp := httptest.NewRecorder()
+	planHandler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.Code)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := body["request_id"]; got != requestID {
+		t.Fatalf("expected request_id %q, got %v", requestID, got)
+	}
+}

--- a/internal/server/handlers/run_events.go
+++ b/internal/server/handlers/run_events.go
@@ -101,17 +101,25 @@ func NewRunEventsHandler(store *runstore.Store, hub EventFeed, journal *coredb.J
 				resumeErr = fmt.Errorf("cursor %d expired", lastSeq)
 				metrics.RecordSSECursorExpired()
 				response.Write(w, response.New(http.StatusGone, "cursor expired",
-					response.WithType("https://flowd.dev/problems/cursor-expired"),
+					response.WithType("https://flowd.org/problems/sse/stale-cursor"),
 					response.WithDetail("run events are no longer retained"),
 				))
 				return
 			}
-			if lastSeq < earliest || (latest > 0 && lastSeq > latest) {
+			if latest > 0 && lastSeq > latest {
+				resumeOutcome = "invalid"
+				resumeErr = fmt.Errorf("cursor %d beyond latest %d", lastSeq, latest)
+				response.Write(w, response.New(http.StatusBadRequest, "invalid Last-Event-ID",
+					response.WithDetail(fmt.Sprintf("cursor %d beyond latest %d", lastSeq, latest)),
+				))
+				return
+			}
+			if lastSeq < earliest {
 				resumeOutcome = "expired"
 				resumeErr = fmt.Errorf("cursor %d expired", lastSeq)
 				metrics.RecordSSECursorExpired()
 				response.Write(w, response.New(http.StatusGone, "cursor expired",
-					response.WithType("https://flowd.dev/problems/cursor-expired"),
+					response.WithType("https://flowd.org/problems/sse/stale-cursor"),
 					response.WithDetail(fmt.Sprintf("cursor %d no longer retained", lastSeq)),
 				))
 				return
@@ -133,10 +141,10 @@ func NewRunEventsHandler(store *runstore.Store, hub EventFeed, journal *coredb.J
 		w.Header().Set("Connection", "keep-alive")
 		w.WriteHeader(http.StatusOK)
 
-		if _, err := w.Write([]byte("retry: 2000\n")); err != nil {
+		if _, err := w.Write([]byte("retry: 3000\n")); err != nil {
 			return
 		}
-		if _, err := w.Write([]byte(":connected\n\n")); err != nil {
+		if _, err := w.Write(sse.FormatHeartbeat(time.Now().UTC())); err != nil {
 			return
 		}
 		flush(w)
@@ -147,13 +155,17 @@ func NewRunEventsHandler(store *runstore.Store, hub EventFeed, journal *coredb.J
 				if ctx.Err() != nil {
 					return ctx.Err()
 				}
-				event := sse.Event{
+				payload, err := sse.EncodeEvent(sse.Event{
 					ID:        fmt.Sprintf("%d", entry.Seq),
 					Event:     entry.EventType,
 					Data:      string(entry.Payload),
 					Timestamp: entry.Timestamp,
+					RunID:     runID,
+				})
+				if err != nil {
+					return err
 				}
-				if err := writeSSE(ctx, w, runID, event); err != nil {
+				if err := writeSSEPayload(ctx, w, runID, payload, entry.Seq); err != nil {
 					return err
 				}
 				lastSentSeq = entry.Seq
@@ -202,28 +214,14 @@ func writeSSE(ctx context.Context, w http.ResponseWriter, runID string, ev sse.E
 			span.SetAttributes(tracing.Int64("sse.event_seq", seq))
 		}
 	}
-
-	var builder strings.Builder
-	if ev.ID != "" {
-		builder.WriteString("id: ")
-		builder.WriteString(ev.ID)
-		builder.WriteByte('\n')
-	}
-	if ev.Event != "" {
-		builder.WriteString("event: ")
-		builder.WriteString(ev.Event)
-		builder.WriteByte('\n')
-	}
 	if ev.Timestamp.IsZero() {
 		ev.Timestamp = time.Now().UTC()
 	}
-	for _, line := range strings.Split(ev.Data, "\n") {
-		builder.WriteString("data: ")
-		builder.WriteString(line)
-		builder.WriteByte('\n')
+	payload, err := sse.EncodeEvent(ev)
+	if err != nil {
+		return err
 	}
-	builder.WriteByte('\n')
-	if _, err = w.Write([]byte(builder.String())); err != nil {
+	if _, err = w.Write(payload); err != nil {
 		return err
 	}
 	flush(w)

--- a/internal/server/handlers/run_events.go
+++ b/internal/server/handlers/run_events.go
@@ -65,13 +65,14 @@ func NewRunEventsHandler(store *runstore.Store, hub EventFeed, journal *coredb.J
 			response.Write(w, response.New(http.StatusBadRequest, "invalid Last-Event-ID", response.WithDetail(err.Error())))
 			return
 		}
+		resumeRequested := strings.TrimSpace(lastEventID) != ""
 
 		ctx := r.Context()
-		if lastSeq > 0 {
+		if resumeRequested {
 			metrics.RecordSSEResumeAttempt()
 		}
 
-		if journal != nil && lastSeq > 0 {
+		if journal != nil && resumeRequested {
 			var resumeErr error
 			resumeOutcome := "ok"
 			ctx, resumeSpan := tracing.Start(ctx, "server.sse.resume",
@@ -95,17 +96,25 @@ func NewRunEventsHandler(store *runstore.Store, hub EventFeed, journal *coredb.J
 				response.Write(w, response.New(http.StatusInternalServerError, "journal lookup failed"))
 				return
 			}
-			if earliest > 0 {
-				if lastSeq < earliest || (latest > 0 && lastSeq > latest) {
-					resumeOutcome = "expired"
-					resumeErr = fmt.Errorf("cursor %d expired", lastSeq)
-					metrics.RecordSSECursorExpired()
-					response.Write(w, response.New(http.StatusGone, "cursor expired",
-						response.WithType("https://flowd.dev/problems/cursor-expired"),
-						response.WithDetail(fmt.Sprintf("cursor %d no longer retained", lastSeq)),
-					))
-					return
-				}
+			if earliest == 0 {
+				resumeOutcome = "expired"
+				resumeErr = fmt.Errorf("cursor %d expired", lastSeq)
+				metrics.RecordSSECursorExpired()
+				response.Write(w, response.New(http.StatusGone, "cursor expired",
+					response.WithType("https://flowd.dev/problems/cursor-expired"),
+					response.WithDetail("run events are no longer retained"),
+				))
+				return
+			}
+			if lastSeq < earliest || (latest > 0 && lastSeq > latest) {
+				resumeOutcome = "expired"
+				resumeErr = fmt.Errorf("cursor %d expired", lastSeq)
+				metrics.RecordSSECursorExpired()
+				response.Write(w, response.New(http.StatusGone, "cursor expired",
+					response.WithType("https://flowd.dev/problems/cursor-expired"),
+					response.WithDetail(fmt.Sprintf("cursor %d no longer retained", lastSeq)),
+				))
+				return
 			}
 		}
 

--- a/internal/server/handlers/run_events_export.go
+++ b/internal/server/handlers/run_events_export.go
@@ -17,7 +17,7 @@ import (
 const (
 	exportExtensionName  = "export"
 	extensionUnsupported = "about:blank#extension-unsupported"
-	cursorExpiredProblem = "https://flowd.dev/problems/cursor-expired"
+	cursorExpiredProblem = "https://flowd.org/problems/sse/stale-cursor"
 	ndjsonContentType    = "text/x-ndjson"
 	exportCacheControl   = "no-store"
 )

--- a/internal/server/handlers/run_events_export_test.go
+++ b/internal/server/handlers/run_events_export_test.go
@@ -17,8 +17,8 @@ func TestRunEventsExportHandlerStreamsNDJSON(t *testing.T) {
 	journal := newTestJournal(t)
 	sink := NewJournalEventSink(journal, EventSinkFunc(func(runID string, ev sse.Event) {}))
 
-	sink.Publish("run-export", sse.Event{Event: "run.start", Data: "{}"})
-	sink.Publish("run-export", sse.Event{Event: "step.log", Data: "{\"msg\":\"hello\"}"})
+	sink.Publish("run-export", sse.Event{Event: "run.started", Data: "{}"})
+	sink.Publish("run-export", sse.Event{Event: "step.output", Data: "{\"msg\":\"hello\"}"})
 
 	handler := NewRunEventsExportHandler(store, journal, true)
 	req := httptest.NewRequest(http.MethodGet, "/runs/run-export/events.ndjson", nil)
@@ -36,11 +36,11 @@ func TestRunEventsExportHandlerStreamsNDJSON(t *testing.T) {
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 NDJSON lines, got %d (%s)", len(lines), rec.Body.String())
 	}
-	if !strings.Contains(lines[0], "\"event\":\"run.start\"") {
-		t.Fatalf("expected run.start event, got %s", lines[0])
+	if !strings.Contains(lines[0], "\"event\":\"run.started\"") {
+		t.Fatalf("expected run.started event, got %s", lines[0])
 	}
-	if !strings.Contains(lines[1], "\"event\":\"step.log\"") {
-		t.Fatalf("expected step.log event, got %s", lines[1])
+	if !strings.Contains(lines[1], "\"event\":\"step.output\"") {
+		t.Fatalf("expected step.output event, got %s", lines[1])
 	}
 }
 

--- a/internal/server/handlers/run_events_test.go
+++ b/internal/server/handlers/run_events_test.go
@@ -264,6 +264,36 @@ func TestRunEventsHandlerInvalidLastEventID(t *testing.T) {
 	})
 }
 
+func TestRunEventsHandlerStaleCursorAfterEviction(t *testing.T) {
+	store := runstore.New()
+	store.Create(runstore.Run{ID: "run-evict", JobID: "demo", Status: "queued", StartedAt: time.Unix(0, 0)})
+	// Keepalive disabled to avoid background heartbeats in the response body.
+	hub := sse.New(sse.Config{KeepAliveInterval: time.Hour})
+	journal := newTestJournalWithLimit(t, 20)
+	// Only persist to journal; live hub is unused for this stale-cursor path.
+	sink := NewJournalEventSink(journal, EventSinkFunc(func(runID string, ev sse.Event) {}))
+
+	sink.Publish("run-evict", sse.Event{Event: "step.output", Data: "{\"msg\":\"old\"}"})
+	sink.Publish("run-evict", sse.Event{Event: "step.output", Data: "{\"msg\":\"new\"}"})
+
+	h := NewRunEventsHandler(store, hub, journal)
+	req := httptest.NewRequest(http.MethodGet, "/runs/run-evict/events", nil)
+	req.Header.Set("Last-Event-ID", "1")
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusGone {
+		t.Fatalf("expected 410 Gone, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/problem+json" {
+		t.Fatalf("expected problem+json content type, got %q", ct)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "https://flowd.org/problems/sse/stale-cursor") {
+		t.Fatalf("expected stale-cursor problem type, got %q", body)
+	}
+}
+
 func newTestJournal(t *testing.T) *coredb.Journal {
 	t.Helper()
 	return newTestJournalWithLimit(t, 0)

--- a/internal/server/handlers/run_events_test.go
+++ b/internal/server/handlers/run_events_test.go
@@ -181,6 +181,46 @@ func TestRunEventsHandlerReturns410ForExpiredCursor(t *testing.T) {
 	}
 }
 
+func TestRunEventsHandlerInvalidLastEventID(t *testing.T) {
+	store := runstore.New()
+	store.Create(runstore.Run{ID: "run-invalid", JobID: "demo", Status: "queued", StartedAt: time.Unix(0, 0)})
+
+	t.Run("non-integer", func(t *testing.T) {
+		hub := sse.New(sse.Config{KeepAliveInterval: time.Hour})
+		journal := newTestJournal(t)
+		h := NewRunEventsHandler(store, hub, journal)
+
+		req := httptest.NewRequest(http.MethodGet, "/runs/run-invalid/events", nil)
+		req.Header.Set("Last-Event-ID", "not-a-number")
+		rec := httptest.NewRecorder()
+
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 Bad Request, got %d", rec.Code)
+		}
+	})
+
+	t.Run("beyond-latest", func(t *testing.T) {
+		hub := sse.New(sse.Config{KeepAliveInterval: time.Hour})
+		journal := newTestJournal(t)
+		sink := NewJournalEventSink(journal, EventSinkFunc(func(runID string, ev sse.Event) {
+			hub.Publish(runID, ev)
+		}))
+
+		sink.Publish("run-invalid", sse.Event{Event: "run.started", Data: "{}"})
+
+		h := NewRunEventsHandler(store, hub, journal)
+		req := httptest.NewRequest(http.MethodGet, "/runs/run-invalid/events", nil)
+		req.Header.Set("Last-Event-ID", "2")
+		rec := httptest.NewRecorder()
+
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 Bad Request, got %d", rec.Code)
+		}
+	})
+}
+
 func newTestJournal(t *testing.T) *coredb.Journal {
 	t.Helper()
 	return newTestJournalWithLimit(t, 0)

--- a/internal/server/handlers/run_events_test.go
+++ b/internal/server/handlers/run_events_test.go
@@ -35,17 +35,20 @@ func TestRunEventsHandlerStreamsEvents(t *testing.T) {
 	}()
 
 	time.Sleep(10 * time.Millisecond)
-	sink.Publish("run-123", sse.Event{Event: "run.start", Data: "{}"})
+	sink.Publish("run-123", sse.Event{Event: "run.started", Data: "{}"})
 	time.Sleep(10 * time.Millisecond)
 	cancel()
 
 	<-done
 	body := rec.Body.String()
-	if !strings.Contains(body, "event: run.start") {
-		t.Fatalf("expected run.start event in body, got %q", body)
+	if !strings.Contains(body, "\"type\":\"run.started\"") {
+		t.Fatalf("expected run.started event in body, got %q", body)
 	}
-	if !strings.Contains(body, "retry: 2000") {
+	if !strings.Contains(body, "retry: 3000") {
 		t.Fatalf("expected retry directive in body, got %q", body)
+	}
+	if !strings.Contains(body, "event: flowd") {
+		t.Fatalf("expected flowd event envelope, got %q", body)
 	}
 }
 
@@ -58,8 +61,8 @@ func TestRunEventsHandlerReplayFromHeader(t *testing.T) {
 		hub.Publish(runID, ev)
 	}))
 
-	sink.Publish("run-456", sse.Event{Event: "run.start", Data: "{}"})
-	sink.Publish("run-456", sse.Event{Event: "step.log", Data: "{\"msg\":\"hello\"}"})
+	sink.Publish("run-456", sse.Event{Event: "run.started", Data: "{}"})
+	sink.Publish("run-456", sse.Event{Event: "step.output", Data: "{\"msg\":\"hello\"}"})
 
 	h := NewRunEventsHandler(store, hub, journal)
 	req := httptest.NewRequest(http.MethodGet, "/runs/run-456/events", nil)
@@ -96,8 +99,8 @@ func TestRunEventsHandlerReplayWithoutLastID(t *testing.T) {
 		hub.Publish(runID, ev)
 	}))
 
-	sink.Publish("run-789", sse.Event{Event: "run.start", Data: "{}"})
-	sink.Publish("run-789", sse.Event{Event: "step.log", Data: "{\"msg\":\"world\"}"})
+	sink.Publish("run-789", sse.Event{Event: "run.started", Data: "{}"})
+	sink.Publish("run-789", sse.Event{Event: "step.output", Data: "{\"msg\":\"world\"}"})
 
 	h := NewRunEventsHandler(store, hub, journal)
 	req := httptest.NewRequest(http.MethodGet, "/runs/run-789/events", nil)
@@ -116,7 +119,7 @@ func TestRunEventsHandlerReplayWithoutLastID(t *testing.T) {
 	<-done
 
 	body := rec.Body.String()
-	if !strings.Contains(body, "run.start") || !strings.Contains(body, "step.log") {
+	if !strings.Contains(body, "\"type\":\"run.started\"") || !strings.Contains(body, "\"type\":\"step.output\"") {
 		t.Fatalf("expected replayed events, got %q", body)
 	}
 }
@@ -155,8 +158,8 @@ func TestRunEventsHandlerReturns410ForExpiredCursor(t *testing.T) {
 		hub.Publish(runID, ev)
 	}))
 
-	sink.Publish("run-expired", sse.Event{Event: "step.log", Data: "{\"msg\":\"old\"}"})
-	sink.Publish("run-expired", sse.Event{Event: "step.log", Data: "{\"msg\":\"new\"}"})
+	sink.Publish("run-expired", sse.Event{Event: "step.output", Data: "{\"msg\":\"old\"}"})
+	sink.Publish("run-expired", sse.Event{Event: "step.output", Data: "{\"msg\":\"new\"}"})
 
 	h := NewRunEventsHandler(store, hub, dirJournal)
 	req := httptest.NewRequest(http.MethodGet, "/runs/run-expired/events", nil)
@@ -172,6 +175,9 @@ func TestRunEventsHandlerReturns410ForExpiredCursor(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "cursor expired") {
 		t.Fatalf("expected cursor expired problem, got %q", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "https://flowd.org/problems/sse/stale-cursor") {
+		t.Fatalf("expected stale-cursor problem type, got %q", rec.Body.String())
 	}
 }
 

--- a/internal/server/handlers/run_events_test.go
+++ b/internal/server/handlers/run_events_test.go
@@ -90,6 +90,49 @@ func TestRunEventsHandlerReplayFromHeader(t *testing.T) {
 	}
 }
 
+func TestRunEventsHandlerResumeFromLastEventID(t *testing.T) {
+	store := runstore.New()
+	store.Create(runstore.Run{ID: "run-resume", JobID: "demo", Status: "queued", StartedAt: time.Unix(0, 0)})
+	to := time.Hour
+	hub := sse.New(sse.Config{KeepAliveInterval: to})
+	journal := newTestJournal(t)
+	sink := NewJournalEventSink(journal, EventSinkFunc(func(runID string, ev sse.Event) {
+		hub.Publish(runID, ev)
+	}))
+
+	sink.Publish("run-resume", sse.Event{Event: "run.started", Data: "{}"})
+	sink.Publish("run-resume", sse.Event{Event: "step.output", Data: "{\"msg\":\"hello\"}"})
+	sink.Publish("run-resume", sse.Event{Event: "step.finished", Data: "{\"status\":\"ok\"}"})
+
+	h := NewRunEventsHandler(store, hub, journal)
+	req := httptest.NewRequest(http.MethodGet, "/runs/run-resume/events", nil)
+	req.Header.Set("Last-Event-ID", "1")
+	rec := httptest.NewRecorder()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req = req.WithContext(ctx)
+	done := make(chan struct{})
+	go func() {
+		h.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+	if strings.Contains(body, "id: 1") {
+		t.Fatalf("expected resume to skip id 1, got %q", body)
+	}
+	if !strings.Contains(body, "id: 2") || !strings.Contains(body, "id: 3") {
+		t.Fatalf("expected replay of ids 2 and 3, got %q", body)
+	}
+	if strings.Count(body, "id: 2") != 1 || strings.Count(body, "id: 3") != 1 {
+		t.Fatalf("expected single replay of ids 2 and 3, got %q", body)
+	}
+}
+
 func TestRunEventsHandlerReplayWithoutLastID(t *testing.T) {
 	store := runstore.New()
 	store.Create(runstore.Run{ID: "run-789", JobID: "demo", Status: "queued", StartedAt: time.Unix(0, 0)})

--- a/internal/server/handlers/run_events_test.go
+++ b/internal/server/handlers/run_events_test.go
@@ -133,6 +133,74 @@ func TestRunEventsHandlerResumeFromLastEventID(t *testing.T) {
 	}
 }
 
+func TestRunEventsHandlerResumeAfterRestart(t *testing.T) {
+	ctx := context.Background()
+	dataDir := t.TempDir()
+
+	db, err := coredb.Open(ctx, coredb.Options{DataDir: dataDir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	journal := coredb.NewJournal(db, 0)
+	if journal == nil {
+		_ = db.Close()
+		t.Fatal("expected journal")
+	}
+
+	sink := NewJournalEventSink(journal, EventSinkFunc(func(runID string, ev sse.Event) {}))
+	sink.Publish("run-restart", sse.Event{Event: "run.started", Data: "{}"})
+	sink.Publish("run-restart", sse.Event{Event: "step.output", Data: "{\"msg\":\"hello\"}"})
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	db, err = coredb.Open(ctx, coredb.Options{DataDir: dataDir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+
+	journal = coredb.NewJournal(db, 0)
+	if journal == nil {
+		t.Fatal("expected journal after restart")
+	}
+
+	store := runstore.New()
+	store.Create(runstore.Run{ID: "run-restart", JobID: "demo", Status: "queued", StartedAt: time.Unix(0, 0)})
+	hub := sse.New(sse.Config{KeepAliveInterval: time.Hour})
+	h := NewRunEventsHandler(store, hub, journal)
+
+	req := httptest.NewRequest(http.MethodGet, "/runs/run-restart/events", nil)
+	req.Header.Set("Last-Event-ID", "1")
+	rec := httptest.NewRecorder()
+
+	streamCtx, cancel := context.WithCancel(context.Background())
+	req = req.WithContext(streamCtx)
+	done := make(chan struct{})
+	go func() {
+		h.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := rec.Body.String()
+	if strings.Contains(body, "id: 1") {
+		t.Fatalf("expected resume to skip id 1 after restart, got %q", body)
+	}
+	if strings.Count(body, "id: 2") != 1 {
+		t.Fatalf("expected single replay of event id 2, got %q", body)
+	}
+	if !strings.Contains(body, "\"type\":\"step.output\"") {
+		t.Fatalf("expected step.output event, got %q", body)
+	}
+}
+
 func TestRunEventsHandlerReplayWithoutLastID(t *testing.T) {
 	store := runstore.New()
 	store.Create(runstore.Run{ID: "run-789", JobID: "demo", Status: "queued", StartedAt: time.Unix(0, 0)})

--- a/internal/server/handlers/run_get.go
+++ b/internal/server/handlers/run_get.go
@@ -4,14 +4,26 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/flowd-org/flowd/internal/coredb"
 	"github.com/flowd-org/flowd/internal/server/response"
 	"github.com/flowd-org/flowd/internal/server/runstore"
 )
 
+// RunGetConfig configures the run GET handler.
+type RunGetConfig struct {
+	Store *runstore.Store
+	DB    *coredb.DB
+}
+
 // NewRunGetHandler returns an HTTP handler for GET /runs/{id}.
-func NewRunGetHandler(store *runstore.Store) http.Handler {
+func NewRunGetHandler(cfg RunGetConfig) http.Handler {
+	store := cfg.Store
 	if store == nil {
 		store = runstore.New()
+	}
+	var dbRuns *coredb.RunStore
+	if cfg.DB != nil {
+		dbRuns = coredb.NewRunStore(cfg.DB)
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
@@ -25,12 +37,22 @@ func NewRunGetHandler(store *runstore.Store) http.Handler {
 			return
 		}
 
+		if dbRuns != nil {
+			record, ok, err := dbRuns.Get(r.Context(), id)
+			if err != nil {
+				response.Write(w, response.New(http.StatusInternalServerError, "run lookup failed", response.WithDetail(err.Error())))
+				return
+			}
+			if ok {
+				writeRunPayload(w, payloadFromRecord(record), http.StatusOK)
+				return
+			}
+		}
 		run, ok := store.Get(id)
 		if !ok {
 			response.Write(w, response.New(http.StatusNotFound, "run not found"))
 			return
 		}
-
 		writeRunPayload(w, payloadFromStore(run), http.StatusOK)
 	})
 }

--- a/internal/server/handlers/run_payload.go
+++ b/internal/server/handlers/run_payload.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/flowd-org/flowd/internal/coredb"
 	"github.com/flowd-org/flowd/internal/server/response"
 	"github.com/flowd-org/flowd/internal/server/runstore"
 )
@@ -33,15 +34,31 @@ func newRunPayload(id, jobID, status string, startedAt time.Time) RunPayload {
 
 func payloadFromStore(run runstore.Run) RunPayload {
 	return RunPayload{
-		ID:         run.ID,
-		JobID:      run.JobID,
-		Status:     run.Status,
-		StartedAt:  run.StartedAt,
-		FinishedAt: run.FinishedAt,
-		Result:     run.Result,
-		Executor:   run.Executor,
-		Runtime:    run.Runtime,
-		Provenance: run.Provenance,
+		ID:              run.ID,
+		JobID:           run.JobID,
+		Status:          run.Status,
+		StartedAt:       run.StartedAt,
+		FinishedAt:      run.FinishedAt,
+		Result:          run.Result,
+		Executor:        run.Executor,
+		Runtime:         run.Runtime,
+		SecurityProfile: run.SecurityProfile,
+		Provenance:      run.Provenance,
+	}
+}
+
+func payloadFromRecord(record coredb.RunRecord) RunPayload {
+	return RunPayload{
+		ID:              record.ID,
+		JobID:           record.JobID,
+		Status:          record.Status,
+		StartedAt:       record.StartedAt,
+		FinishedAt:      record.FinishedAt,
+		Result:          record.Result,
+		Executor:        record.Executor,
+		Runtime:         record.Runtime,
+		SecurityProfile: record.SecurityProfile,
+		Provenance:      record.Provenance,
 	}
 }
 

--- a/internal/server/handlers/run_payload.go
+++ b/internal/server/handlers/run_payload.go
@@ -21,6 +21,7 @@ type RunPayload struct {
 	Runtime         string         `json:"runtime,omitempty"`
 	SecurityProfile string         `json:"security_profile,omitempty"`
 	Provenance      map[string]any `json:"provenance,omitempty"`
+	RequestID       string         `json:"request_id,omitempty"`
 }
 
 func newRunPayload(id, jobID, status string, startedAt time.Time) RunPayload {
@@ -44,6 +45,7 @@ func payloadFromStore(run runstore.Run) RunPayload {
 		Runtime:         run.Runtime,
 		SecurityProfile: run.SecurityProfile,
 		Provenance:      run.Provenance,
+		RequestID:       run.RequestID,
 	}
 }
 
@@ -59,6 +61,7 @@ func payloadFromRecord(record coredb.RunRecord) RunPayload {
 		Runtime:         record.Runtime,
 		SecurityProfile: record.SecurityProfile,
 		Provenance:      record.Provenance,
+		RequestID:       record.RequestID,
 	}
 }
 

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -459,6 +459,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	execScriptDir = startRes.ScriptDir
 	binding := startRes.Binding
 	plan := startRes.Plan
+	runID := startRes.RunID
 
 	executorMode := strings.ToLower(cfg.Executor)
 	if strings.HasPrefix(cfg.Interpreter, "container:") && executorMode == "" {
@@ -517,6 +518,14 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	if policyCtx == nil {
 		policyCtx, _ = policy.NewContext(nil)
 	}
+	policyPayload := &RunPayload{
+		ID:              runID,
+		JobID:           effectiveID,
+		SecurityProfile: effProfile,
+		Executor:        executorMode,
+		Runtime:         runtimeStr,
+		Provenance:      provenance,
+	}
 
 	var findings []types.Finding
 	var trustPreview *types.ImageTrustPreview
@@ -529,6 +538,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	image := containerImageFromConfig(cfg)
 	if image != "" {
 		if prob := enforceRegistryAllowList(ctx, image, policyCtx); prob != nil {
+			publishPolicyDenied(h.events, policyPayload, "container.image", policyProblemCode(prob), policyProblemDetail(prob))
 			response.Write(w, *prob)
 			return
 		}
@@ -541,6 +551,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		}
 		outcome, prob := enforceImageVerification(ctx, image, mode, h.verifier)
 		if prob != nil {
+			publishPolicyDenied(h.events, policyPayload, "container.image", policyProblemCode(prob), policyProblemDetail(prob))
 			response.Write(w, *prob)
 			return
 		}
@@ -564,6 +575,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 		if prob := enforceResourceCeilings(ctx, cfg, policyCtx.ContainerCeilings()); prob != nil {
+			publishPolicyDenied(h.events, policyPayload, "container.resources", policyProblemCode(prob), policyProblemDetail(prob))
 			response.Write(w, *prob)
 			return
 		}
@@ -571,13 +583,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	overrideFindings, decisions, prob := evaluateOverrides(ctx, cfg, effProfile, policyCtx)
 	if prob != nil {
 		if len(decisions) > 0 {
-			tempPayload := &RunPayload{
-				JobID:           effectiveID,
-				SecurityProfile: effProfile,
-				Executor:        executorMode,
-				Provenance:      provenance,
-			}
-			publishPolicyDecisions(h.events, tempPayload, decisions)
+			publishPolicyDecisions(h.events, policyPayload, decisions)
 		}
 		response.Write(w, *prob)
 		return
@@ -593,7 +599,6 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	if trustPreview != nil {
 		plan.ImageTrust = trustPreview
 	}
-	runID := startRes.RunID
 	if executorMode == "container" && runtime != "" {
 		if err := container.RemoveContainer(context.Background(), runtime, runID); err != nil {
 			response.Write(w, containerNameConflictProblem(err))
@@ -606,10 +611,15 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	if runtime != "" {
 		resp.Runtime = string(runtime)
 	}
+	resultPayload := map[string]any{}
 	if len(plan.ResolvedArgs) > 0 {
-		resp.Result = map[string]any{
-			"resolved_args": plan.ResolvedArgs,
-		}
+		resultPayload["resolved_args"] = plan.ResolvedArgs
+	}
+	if len(findings) > 0 {
+		resultPayload["policy_findings"] = findings
+	}
+	if len(resultPayload) > 0 {
+		resp.Result = resultPayload
 	}
 	resp.Provenance = provenance
 
@@ -1114,17 +1124,7 @@ func publishPolicyDecisions(sink EventSink, payload *RunPayload, decisions []pol
 	if sink == nil || payload == nil || len(decisions) == 0 {
 		return
 	}
-	base := map[string]any{
-		"run_id":           payload.ID,
-		"job_id":           payload.JobID,
-		"security_profile": payload.SecurityProfile,
-		"executor":         payload.Executor,
-		"runtime":          payload.Runtime,
-		"timestamp":        time.Now().UTC(),
-	}
-	if payload.Provenance != nil {
-		base["provenance"] = payload.Provenance
-	}
+	base := policyEventBase(payload)
 	for _, dec := range decisions {
 		data := make(map[string]any, len(base)+4)
 		for k, v := range base {
@@ -1141,7 +1141,73 @@ func publishPolicyDecisions(sink EventSink, payload *RunPayload, decisions []pol
 			bytes = []byte("{}")
 		}
 		sink.Publish(payload.ID, sse.Event{Event: "policy.decision", Data: string(bytes)})
+		if dec.Decision == "denied" {
+			publishPolicyDenied(sink, payload, dec.Subject, dec.Code, dec.Reason)
+		}
 	}
+}
+
+func publishPolicyDenied(sink EventSink, payload *RunPayload, subject, code, reason string) {
+	if sink == nil || payload == nil {
+		return
+	}
+	base := policyEventBase(payload)
+	data := make(map[string]any, len(base)+4)
+	for k, v := range base {
+		data[k] = v
+	}
+	if subject != "" {
+		data["subject"] = subject
+	}
+	if code != "" {
+		data["code"] = code
+	}
+	data["decision"] = "denied"
+	if reason != "" {
+		data["reason"] = reason
+	}
+	bytes, err := json.Marshal(data)
+	if err != nil {
+		bytes = []byte("{}")
+	}
+	sink.Publish(payload.ID, sse.Event{Event: "policy.denied", Data: string(bytes)})
+}
+
+func policyEventBase(payload *RunPayload) map[string]any {
+	base := map[string]any{
+		"run_id":           payload.ID,
+		"job_id":           payload.JobID,
+		"security_profile": payload.SecurityProfile,
+		"executor":         payload.Executor,
+		"runtime":          payload.Runtime,
+		"timestamp":        time.Now().UTC(),
+	}
+	if payload.Provenance != nil {
+		base["provenance"] = payload.Provenance
+	}
+	return base
+}
+
+func policyProblemCode(prob *response.Problem) string {
+	if prob == nil || prob.Ext == nil {
+		return ""
+	}
+	if value, ok := prob.Ext["code"]; ok {
+		if code, ok := value.(string); ok {
+			return code
+		}
+	}
+	return ""
+}
+
+func policyProblemDetail(prob *response.Problem) string {
+	if prob == nil {
+		return ""
+	}
+	if prob.Detail != "" {
+		return prob.Detail
+	}
+	return prob.Title
 }
 
 type runExecutionContext struct {

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -1320,7 +1320,7 @@ func (h *RunsHandler) failRun(runID string, status string, err error) {
 			payload["error"] = err.Error()
 		}
 		h.events.Publish(runID, sse.Event{
-			Event: "run.finish",
+			Event: "run.finished",
 			Data:  encodeData(payload),
 		})
 	}

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -469,6 +469,14 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	runID := startRes.RunID
 	secretHandles := startRes.SecretHandles
 	secretCleanup := startRes.SecretCleanup
+	logScrubber := newPersistenceScrubber(binding, secretHandles)
+	if logger != nil {
+		ctx = requestctx.WithScrubbedLogger(ctx, func(msg string) string {
+			return scrubProblemDetail(msg, logScrubber, binding, spec, req.Args)
+		})
+		logger = requestctx.Logger(ctx)
+		r = r.WithContext(ctx)
+	}
 	cleanupSecrets := true
 	defer func() {
 		if cleanupSecrets && secretCleanup != nil {

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -1077,14 +1077,22 @@ func writePlanArtifact(plan types.Plan, runDir string) error {
 	return nil
 }
 
-func prepareSecrets(runID string, binding *engine.Binding) (string, error) {
+func prepareSecrets(runID string, binding *engine.Binding) (map[string]string, func() error, error) {
 	if binding == nil || len(binding.SecretNames) == 0 {
-		return "", nil
+		return nil, nil, nil
 	}
+	defer func() {
+		for name, buf := range binding.SecretBuffers {
+			if _, ok := binding.SecretNames[name]; ok {
+				buf.Close()
+			}
+		}
+	}()
 	secretDir, err := secrets.RunDir(runID)
 	if err != nil {
-		return "", err
+		return nil, nil, err
 	}
+	paths := make(map[string]string, len(binding.SecretNames))
 	for name := range binding.SecretNames {
 		value := ""
 		if raw, ok := binding.Values[name]; ok && raw != nil {
@@ -1094,11 +1102,47 @@ func prepareSecrets(runID string, binding *engine.Binding) (string, error) {
 				value = fmt.Sprint(raw)
 			}
 		}
-		if _, err := secrets.CreateFile(secretDir, name, []byte(value)); err != nil {
-			return "", err
+		if buf, ok := binding.SecretBuffers[name]; ok {
+			path, err := secrets.CreateFile(secretDir, name, buf.Bytes())
+			if err != nil {
+				return nil, nil, err
+			}
+			paths[name] = path
+			continue
+		}
+		path, err := secrets.CreateFile(secretDir, name, []byte(value))
+		if err != nil {
+			return nil, nil, err
+		}
+		paths[name] = path
+	}
+
+	handles := make(map[string]string, len(paths))
+	var closers []func() error
+	for name, path := range paths {
+		handlePath, closeFn, err := secrets.ReadHandle(path)
+		if err != nil {
+			for _, closeFn := range closers {
+				_ = closeFn()
+			}
+			return nil, nil, err
+		}
+		handles[name] = handlePath
+		if closeFn != nil {
+			closers = append(closers, closeFn)
 		}
 	}
-	return secretDir, nil
+
+	cleanup := func() error {
+		var firstErr error
+		for _, closeFn := range closers {
+			if err := closeFn(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		return firstErr
+	}
+	return handles, cleanup, nil
 }
 
 func publishPolicyDecisions(sink EventSink, payload *RunPayload, decisions []policyDecision) {
@@ -1233,10 +1277,15 @@ func (h *RunsHandler) executeRun(execCtx *runExecutionContext) {
 		return
 	}
 
-	secretDir, err := prepareSecrets(runID, execCtx.binding)
+	secretHandles, secretCleanup, err := prepareSecrets(runID, execCtx.binding)
 	if err != nil {
 		h.failRun(runID, "failed", err)
 		return
+	}
+	if secretCleanup != nil {
+		defer func() {
+			_ = secretCleanup()
+		}()
 	}
 
 	stdoutFile, err := os.OpenFile(filepath.Join(runDir, "stdout"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
@@ -1293,8 +1342,8 @@ func (h *RunsHandler) executeRun(execCtx *runExecutionContext) {
 			}
 		}
 	}
-	if secretDir != "" {
-		execCfg.SecretsDir = secretDir
+	if len(secretHandles) > 0 {
+		execCfg.SecretHandles = secretHandles
 	}
 
 	runCtx := execCtx.ctx

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -27,6 +27,7 @@ import (
 	"github.com/flowd-org/flowd/internal/executor"
 	"github.com/flowd-org/flowd/internal/executor/container"
 	"github.com/flowd-org/flowd/internal/indexer"
+	"github.com/flowd-org/flowd/internal/observability/logctx"
 	"github.com/flowd-org/flowd/internal/paths"
 	"github.com/flowd-org/flowd/internal/policy"
 	"github.com/flowd-org/flowd/internal/policy/verify"
@@ -37,6 +38,19 @@ import (
 	"github.com/flowd-org/flowd/internal/server/sse"
 	"github.com/flowd-org/flowd/internal/types"
 )
+
+func requestIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if requestID, ok := requestctx.RequestID(ctx); ok {
+		return requestID
+	}
+	if requestID, ok := logctx.RequestID(ctx); ok {
+		return requestID
+	}
+	return ""
+}
 
 const (
 	defaultRunStatus          = "queued"
@@ -444,6 +458,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		JobID:     effectiveID,
 		ScriptDir: execScriptDir,
 		Args:      req.Args,
+		RequestID: requestIDFromContext(ctx),
 	})
 	if err != nil {
 		var argErr *engine.ArgError
@@ -616,6 +631,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	plan.SecurityProfile = effProfile
+	plan.RequestID = requestIDFromContext(ctx)
 	if len(findings) > 0 {
 		plan.PolicyFindings = findings
 	}
@@ -637,6 +653,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	resp := newRunPayload(runID, effectiveID, defaultRunStatus, now)
 	resp.Executor = executorMode
 	resp.SecurityProfile = effProfile
+	resp.RequestID = requestIDFromContext(ctx)
 	if runtime != "" {
 		resp.Runtime = string(runtime)
 	}
@@ -701,6 +718,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		Runtime:         respForPersistence.Runtime,
 		SecurityProfile: respForPersistence.SecurityProfile,
 		Provenance:      respForPersistence.Provenance,
+		RequestID:       respForPersistence.RequestID,
 	})
 
 	eventSink := newScrubbedEventSink(h.events, scrubber)
@@ -1015,6 +1033,7 @@ func runRecordFromPayload(payload RunPayload) coredb.RunRecord {
 		Runtime:         payload.Runtime,
 		SecurityProfile: payload.SecurityProfile,
 		Provenance:      payload.Provenance,
+		RequestID:       payload.RequestID,
 	}
 }
 
@@ -1030,6 +1049,7 @@ func runRecordFromStore(run runstore.Run) coredb.RunRecord {
 		Runtime:         run.Runtime,
 		SecurityProfile: run.SecurityProfile,
 		Provenance:      run.Provenance,
+		RequestID:       run.RequestID,
 	}
 }
 

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -187,7 +187,7 @@ func (h *RunsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	req, rawBody, err := decodeRunRequest(r.Body)
 	if err != nil {
-		response.Write(w, response.New(http.StatusBadRequest, "invalid request body", response.WithDetail(err.Error())))
+		response.Write(w, response.New(http.StatusBadRequest, "invalid request body", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		return
 	}
 	if req.JobID == "" {
@@ -197,7 +197,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 
 	canonicalBody, err := canonicalizeJSON(rawBody)
 	if err != nil {
-		response.Write(w, response.New(http.StatusBadRequest, "invalid request body", response.WithDetail(err.Error())))
+		response.Write(w, response.New(http.StatusBadRequest, "invalid request body", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		return
 	}
 	bodyHash := sha256.Sum256(canonicalBody)
@@ -241,7 +241,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	if h.idempotency != nil {
 		cached, status, storedHash, found, err := h.idempotency.Lookup(ctx, scopedKey, endpoint, now)
 		if err != nil {
-			response.Write(w, response.New(http.StatusInternalServerError, "idempotency lookup failed", response.WithDetail(err.Error())))
+			response.Write(w, response.New(http.StatusInternalServerError, "idempotency lookup failed", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 			return
 		}
 		if found {
@@ -267,14 +267,14 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 			if coredb.IsQuotaExceeded(err) {
 				response.Write(w, storageQuotaExceededProblem())
 			} else {
-				response.Write(w, response.New(http.StatusInternalServerError, "idempotency reserve failed", response.WithDetail(err.Error())))
+				response.Write(w, response.New(http.StatusInternalServerError, "idempotency reserve failed", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 			}
 			return
 		}
 		if !reserved {
 			cached, status, storedHash, found, err = h.idempotency.Lookup(ctx, scopedKey, endpoint, now)
 			if err != nil {
-				response.Write(w, response.New(http.StatusInternalServerError, "idempotency lookup failed", response.WithDetail(err.Error())))
+				response.Write(w, response.New(http.StatusInternalServerError, "idempotency lookup failed", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 				return
 			}
 			if found {
@@ -317,11 +317,11 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		if h.sources != nil {
 			src, ok := h.sources.Get(req.Source.Name)
 			if !ok {
-				response.Write(w, response.New(http.StatusNotFound, "source not found", response.WithDetail(req.Source.Name)))
+				response.Write(w, response.New(http.StatusNotFound, "source not found", response.WithDetail(scrubProblemDetail(req.Source.Name, nil, nil, nil, nil))))
 				return
 			}
 			if src.LocalPath == "" {
-				response.Write(w, response.New(http.StatusBadRequest, "source not materialized", response.WithDetail("source "+req.Source.Name+" has no local checkout")))
+				response.Write(w, response.New(http.StatusBadRequest, "source not materialized", response.WithDetail(scrubProblemDetail("source "+req.Source.Name+" has no local checkout", nil, nil, nil, nil))))
 				return
 			}
 			runRoot = src.LocalPath
@@ -330,7 +330,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.discover(runRoot)
 	if err != nil {
-		response.Write(w, response.New(http.StatusInternalServerError, "job discovery failed", response.WithDetail(err.Error())))
+		response.Write(w, response.New(http.StatusInternalServerError, "job discovery failed", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		return
 	}
 
@@ -404,18 +404,18 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 			response.Write(w, *prob)
 			return
 		}
-		response.Write(w, response.New(http.StatusNotFound, "job not found", response.WithDetail(requestedID)))
+		response.Write(w, response.New(http.StatusNotFound, "job not found", response.WithDetail(scrubProblemDetail(requestedID, nil, nil, nil, nil))))
 		return
 	}
 
 	absScriptDir, err := filepath.Abs(scriptDir)
 	if err != nil {
-		response.Write(w, response.New(http.StatusInternalServerError, "resolve script directory", response.WithDetail(err.Error())))
+		response.Write(w, response.New(http.StatusInternalServerError, "resolve script directory", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		return
 	}
 	absScriptsRoot, err := filepath.Abs(runRoot)
 	if err != nil {
-		response.Write(w, response.New(http.StatusInternalServerError, "resolve scripts root", response.WithDetail(err.Error())))
+		response.Write(w, response.New(http.StatusInternalServerError, "resolve scripts root", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		return
 	}
 	relJobPath, relErr := filepath.Rel(absScriptsRoot, absScriptDir)
@@ -428,7 +428,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 
 	cfg, err := h.loadConfig(absScriptDir)
 	if err != nil {
-		response.Write(w, response.New(http.StatusInternalServerError, "load config failed", response.WithDetail(err.Error())))
+		response.Write(w, response.New(http.StatusInternalServerError, "load config failed", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		return
 	}
 
@@ -448,8 +448,10 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var argErr *engine.ArgError
 		if errors.As(err, &argErr) {
+			scrubber := newProblemScrubber(spec, req.Args, nil, nil)
+			safeMsg := scrubProblemDetail(argErr.Msg, scrubber, nil, nil, nil)
 			response.Write(w, response.New(http.StatusUnprocessableEntity, "argument validation failed",
-				response.WithExtension("errors", []map[string]string{{"arg": argErr.Arg, "message": argErr.Msg}})))
+				response.WithExtension("errors", []map[string]string{{"arg": argErr.Arg, "message": safeMsg}})))
 			return
 		}
 		if errors.Is(err, engine.ErrSecretContainerUnsupported) {
@@ -457,7 +459,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 				response.WithExtension("code", "E_SECRET")))
 			return
 		}
-		response.Write(w, response.New(http.StatusBadRequest, "invalid arguments", response.WithDetail(err.Error())))
+		response.Write(w, response.New(http.StatusBadRequest, "invalid arguments", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, spec, req.Args))))
 		return
 	}
 	effectiveID = startRes.EffectiveJobID
@@ -523,7 +525,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		response.Write(w, response.New(http.StatusUnprocessableEntity, "invalid security profile",
 			response.WithExtension("code", "E_POLICY"),
-			response.WithDetail(err.Error())))
+			response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, spec, req.Args))))
 		return
 	}
 
@@ -552,20 +554,20 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	if image != "" {
 		if prob := enforceRegistryAllowList(ctx, image, policyCtx); prob != nil {
 			publishPolicyDenied(h.events, policyPayload, "container.image", policyProblemCode(prob), policyProblemDetail(prob))
-			response.Write(w, *prob)
+			response.Write(w, scrubProblemResponse(prob, nil, nil, spec, req.Args))
 			return
 		}
 		mode, err := policyCtx.VerifyModeForProfile(effProfile)
 		if err != nil {
 			response.Write(w, response.New(http.StatusUnprocessableEntity, "policy error",
 				response.WithExtension("code", "E_POLICY"),
-				response.WithDetail(err.Error())))
+				response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, spec, req.Args))))
 			return
 		}
 		outcome, prob := enforceImageVerification(ctx, image, mode, h.verifier)
 		if prob != nil {
 			publishPolicyDenied(h.events, policyPayload, "container.image", policyProblemCode(prob), policyProblemDetail(prob))
-			response.Write(w, *prob)
+			response.Write(w, scrubProblemResponse(prob, nil, nil, spec, req.Args))
 			return
 		}
 		if mode != policy.VerifyModeDisabled {
@@ -589,7 +591,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		}
 		if prob := enforceResourceCeilings(ctx, cfg, policyCtx.ContainerCeilings()); prob != nil {
 			publishPolicyDenied(h.events, policyPayload, "container.resources", policyProblemCode(prob), policyProblemDetail(prob))
-			response.Write(w, *prob)
+			response.Write(w, scrubProblemResponse(prob, nil, nil, spec, req.Args))
 			return
 		}
 	}
@@ -598,7 +600,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		if len(decisions) > 0 {
 			publishPolicyDecisions(h.events, policyPayload, decisions)
 		}
-		response.Write(w, *prob)
+		response.Write(w, scrubProblemResponse(prob, nil, nil, spec, req.Args))
 		return
 	}
 	if len(overrideFindings) > 0 {
@@ -614,7 +616,8 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 	if executorMode == "container" && runtime != "" {
 		if err := container.RemoveContainer(context.Background(), runtime, runID); err != nil {
-			response.Write(w, containerNameConflictProblem(err))
+			prob := containerNameConflictProblem(err)
+			response.Write(w, scrubProblemResponse(&prob, nil, nil, spec, req.Args))
 			return
 		}
 	}
@@ -655,7 +658,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 			if coredb.IsQuotaExceeded(err) {
 				response.Write(w, storageQuotaExceededProblem())
 			} else {
-				response.Write(w, response.New(http.StatusInternalServerError, "idempotency store failed", response.WithDetail(err.Error())))
+				response.Write(w, response.New(http.StatusInternalServerError, "idempotency store failed", response.WithDetail(scrubProblemDetail(err.Error(), scrubber, nil, spec, req.Args))))
 			}
 			return
 		}
@@ -674,7 +677,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 			if coredb.IsQuotaExceeded(err) {
 				response.Write(w, storageQuotaExceededProblem())
 			} else {
-				response.Write(w, response.New(http.StatusInternalServerError, "run store failed", response.WithDetail(err.Error())))
+				response.Write(w, response.New(http.StatusInternalServerError, "run store failed", response.WithDetail(scrubProblemDetail(err.Error(), scrubber, nil, spec, req.Args))))
 			}
 			return
 		}

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -89,6 +89,7 @@ type RunsHandler struct {
 	idempotency    idempotencyStore
 	idempotencyTTL time.Duration
 	store          *runstore.Store
+	dbRuns         *coredb.RunStore
 	events         EventSink
 	resolveSrc     func(jobID string, ref *RunSourceRef) (map[string]any, bool)
 	sources        *sourcestore.Store
@@ -142,6 +143,11 @@ func NewRunsHandler(cfg RunsConfig) *RunsHandler {
 		idemStore = newMemoryIdempotencyCache(ttl)
 	}
 
+	var dbRuns *coredb.RunStore
+	if cfg.DB != nil {
+		dbRuns = coredb.NewRunStore(cfg.DB)
+	}
+
 	return &RunsHandler{
 		root:           root,
 		discover:       discoverFn,
@@ -150,6 +156,7 @@ func NewRunsHandler(cfg RunsConfig) *RunsHandler {
 		idempotency:    idemStore,
 		idempotencyTTL: ttl,
 		store:          store,
+		dbRuns:         dbRuns,
 		events:         cfg.Events,
 		resolveSrc:     cfg.ResolveSource,
 		sources:        cfg.Sources,
@@ -563,15 +570,30 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if h.dbRuns != nil {
+		if err := h.dbRuns.Create(ctx, runRecordFromPayload(resp)); err != nil {
+			if logger != nil {
+				logger.Error("run store failed", slog.String("error", err.Error()))
+			}
+			if coredb.IsQuotaExceeded(err) {
+				response.Write(w, storageQuotaExceededProblem())
+			} else {
+				response.Write(w, response.New(http.StatusInternalServerError, "run store failed", response.WithDetail(err.Error())))
+			}
+			return
+		}
+	}
+
 	h.store.Create(runstore.Run{
-		ID:         resp.ID,
-		JobID:      resp.JobID,
-		Status:     resp.Status,
-		StartedAt:  resp.StartedAt,
-		Result:     resp.Result,
-		Executor:   resp.Executor,
-		Runtime:    resp.Runtime,
-		Provenance: resp.Provenance,
+		ID:              resp.ID,
+		JobID:           resp.JobID,
+		Status:          resp.Status,
+		StartedAt:       resp.StartedAt,
+		Result:          resp.Result,
+		Executor:        resp.Executor,
+		Runtime:         resp.Runtime,
+		SecurityProfile: resp.SecurityProfile,
+		Provenance:      resp.Provenance,
 	})
 
 	if len(decisions) > 0 {
@@ -742,6 +764,27 @@ func (h *RunsHandler) handleList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	runs := h.store.List()
+	if h.dbRuns != nil {
+		records, err := h.dbRuns.List(r.Context())
+		if err != nil {
+			response.Write(w, response.New(http.StatusInternalServerError, "list runs failed", response.WithDetail(err.Error())))
+			return
+		}
+		payloads := make([]RunPayload, len(records))
+		for i, record := range records {
+			payloads[i] = payloadFromRecord(record)
+		}
+		pageRuns := paginateRunPayloads(payloads, page, perPage)
+		data, err := json.Marshal(pageRuns)
+		if err != nil {
+			response.Write(w, response.New(http.StatusInternalServerError, "encode runs failed", response.WithDetail(err.Error())))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+		return
+	}
 	start := (page - 1) * perPage
 	if start >= len(runs) {
 		runs = []runstore.Run{}
@@ -834,6 +877,48 @@ func parseRunsPagination(r *http.Request) (int, int, error) {
 	}
 
 	return page, perPage, nil
+}
+
+func paginateRunPayloads(payloads []RunPayload, page, perPage int) []RunPayload {
+	start := (page - 1) * perPage
+	if start >= len(payloads) {
+		return []RunPayload{}
+	}
+	end := start + perPage
+	if end > len(payloads) {
+		end = len(payloads)
+	}
+	return payloads[start:end]
+}
+
+func runRecordFromPayload(payload RunPayload) coredb.RunRecord {
+	return coredb.RunRecord{
+		ID:              payload.ID,
+		JobID:           payload.JobID,
+		Status:          payload.Status,
+		StartedAt:       payload.StartedAt,
+		FinishedAt:      payload.FinishedAt,
+		Result:          payload.Result,
+		Executor:        payload.Executor,
+		Runtime:         payload.Runtime,
+		SecurityProfile: payload.SecurityProfile,
+		Provenance:      payload.Provenance,
+	}
+}
+
+func runRecordFromStore(run runstore.Run) coredb.RunRecord {
+	return coredb.RunRecord{
+		ID:              run.ID,
+		JobID:           run.JobID,
+		Status:          run.Status,
+		StartedAt:       run.StartedAt,
+		FinishedAt:      run.FinishedAt,
+		Result:          run.Result,
+		Executor:        run.Executor,
+		Runtime:         run.Runtime,
+		SecurityProfile: run.SecurityProfile,
+		Provenance:      run.Provenance,
+	}
 }
 
 func encodeData(payload any) string {
@@ -1159,6 +1244,9 @@ func (h *RunsHandler) updateRunStatus(runID, status string, finished *time.Time)
 		current.FinishedAt = finished
 	}
 	h.store.Update(current)
+	if h.dbRuns != nil {
+		_ = h.dbRuns.Update(context.Background(), runRecordFromStore(current))
+	}
 }
 
 func (h *RunsHandler) failRun(runID string, status string, err error) {

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -641,11 +641,14 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 	resp.Provenance = provenance
 
+	scrubber := newPersistenceScrubber(binding, secretHandles)
+	respForPersistence := scrubRunPayload(resp, scrubber)
+
 	if h.idempotency != nil {
 		if idempotencyExpiresAt.IsZero() {
 			idempotencyExpiresAt = now.Add(h.idempotencyTTL)
 		}
-		if err := h.idempotency.Store(ctx, scopedKey, endpoint, bodyHashHex, resp, http.StatusCreated, idempotencyExpiresAt); err != nil {
+		if err := h.idempotency.Store(ctx, scopedKey, endpoint, bodyHashHex, respForPersistence, http.StatusCreated, idempotencyExpiresAt); err != nil {
 			if logger != nil {
 				logger.Error("idempotency store failed", slog.String("error", err.Error()))
 			}
@@ -662,7 +665,9 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if h.dbRuns != nil {
-		if err := h.dbRuns.Create(ctx, runRecordFromPayload(resp)); err != nil {
+		record := runRecordFromPayload(resp)
+		record = scrubRunRecord(record, scrubber)
+		if err := h.dbRuns.Create(ctx, record); err != nil {
 			if logger != nil {
 				logger.Error("run store failed", slog.String("error", err.Error()))
 			}
@@ -676,19 +681,20 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.store.Create(runstore.Run{
-		ID:              resp.ID,
-		JobID:           resp.JobID,
-		Status:          resp.Status,
-		StartedAt:       resp.StartedAt,
-		Result:          resp.Result,
-		Executor:        resp.Executor,
-		Runtime:         resp.Runtime,
-		SecurityProfile: resp.SecurityProfile,
-		Provenance:      resp.Provenance,
+		ID:              respForPersistence.ID,
+		JobID:           respForPersistence.JobID,
+		Status:          respForPersistence.Status,
+		StartedAt:       respForPersistence.StartedAt,
+		Result:          respForPersistence.Result,
+		Executor:        respForPersistence.Executor,
+		Runtime:         respForPersistence.Runtime,
+		SecurityProfile: respForPersistence.SecurityProfile,
+		Provenance:      respForPersistence.Provenance,
 	})
 
+	eventSink := newScrubbedEventSink(h.events, scrubber)
 	if len(decisions) > 0 {
-		publishPolicyDecisions(h.events, &resp, decisions)
+		publishPolicyDecisions(eventSink, &resp, decisions)
 	}
 	runCtx := &runExecutionContext{
 		ctx:           nil,
@@ -703,6 +709,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		runtime:       runtime,
 		secretHandles: secretHandles,
 		secretCleanup: secretCleanup,
+		scrubber:      scrubber,
 	}
 	ctxWithCancel, cancel := context.WithCancel(context.Background())
 	runCtx.ctx = ctxWithCancel
@@ -1207,6 +1214,7 @@ type runExecutionContext struct {
 	sink          events.Sink
 	secretHandles map[string]string
 	secretCleanup func() error
+	scrubber      *persistenceScrubber
 }
 
 func (h *RunsHandler) executeRun(execCtx *runExecutionContext) {
@@ -1258,8 +1266,9 @@ func (h *RunsHandler) executeRun(execCtx *runExecutionContext) {
 	}
 	defer stderrFile.Close()
 
+	serverSink := newScrubbedEventSink(h.events, execCtx.scrubber)
 	sink := events.NewCompositeSink(
-		newSSESink(h.events, &execCtx.runPayload),
+		newSSESink(serverSink, &execCtx.runPayload),
 	)
 	execCtx.sink = sink
 
@@ -1360,7 +1369,9 @@ func (h *RunsHandler) updateRunStatus(runID, status string, finished *time.Time)
 	}
 	h.store.Update(current)
 	if h.dbRuns != nil {
-		_ = h.dbRuns.Update(context.Background(), runRecordFromStore(current))
+		record := runRecordFromStore(current)
+		record = scrubRunRecord(record, newPersistenceScrubber(nil, nil))
+		_ = h.dbRuns.Update(context.Background(), record)
 	}
 }
 

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -99,6 +99,14 @@ type RunsHandler struct {
 	running        sync.Map // runID -> *runExecutionContext
 }
 
+type staticConfigLoader struct {
+	cfg *types.Config
+}
+
+func (s staticConfigLoader) LoadConfig(scriptDir string) (*types.Config, error) {
+	return s.cfg, nil
+}
+
 // NewRunsHandler returns an HTTP handler for POST /runs.
 func NewRunsHandler(cfg RunsConfig) *RunsHandler {
 	root := cfg.Root
@@ -360,24 +368,32 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	spec := cfg.ArgSpec
-	var binding *engine.Binding
-	if spec != nil && len(spec.Args) > 0 {
-		bind, bindErr := validatePlanArgs(*spec, req.Args)
-		if bindErr != nil {
-			var argErr *engine.ArgError
-			if errors.As(bindErr, &argErr) {
-				response.Write(w, response.New(http.StatusUnprocessableEntity, "argument validation failed",
-					response.WithExtension("errors", []map[string]string{{"arg": argErr.Arg, "message": argErr.Msg}})))
-				return
-			}
-			response.Write(w, response.New(http.StatusBadRequest, "invalid arguments", response.WithDetail(bindErr.Error())))
-			return
-		}
-		binding = bind
-	} else if len(req.Args) > 0 {
+	if (spec == nil || len(spec.Args) == 0) && len(req.Args) > 0 {
 		response.Write(w, response.New(http.StatusBadRequest, "job does not accept arguments"))
 		return
 	}
+	orchestrator := engine.NewOrchestrator(engine.OrchestratorDeps{
+		ConfigLoader: staticConfigLoader{cfg: cfg},
+	})
+	startRes, err := orchestrator.StartRun(ctx, types.StartRunRequest{
+		JobID:     effectiveID,
+		ScriptDir: execScriptDir,
+		Args:      req.Args,
+	})
+	if err != nil {
+		var argErr *engine.ArgError
+		if errors.As(err, &argErr) {
+			response.Write(w, response.New(http.StatusUnprocessableEntity, "argument validation failed",
+				response.WithExtension("errors", []map[string]string{{"arg": argErr.Arg, "message": argErr.Msg}})))
+			return
+		}
+		response.Write(w, response.New(http.StatusBadRequest, "invalid arguments", response.WithDetail(err.Error())))
+		return
+	}
+	effectiveID = startRes.EffectiveJobID
+	execScriptDir = startRes.ScriptDir
+	binding := startRes.Binding
+	plan := startRes.Plan
 
 	executorMode := strings.ToLower(cfg.Executor)
 	if strings.HasPrefix(cfg.Interpreter, "container:") && executorMode == "" {
@@ -505,7 +521,6 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		findings = append(findings, overrideFindings...)
 	}
 
-	plan := engine.BuildPlan(effectiveID, cfg, spec, binding)
 	plan.SecurityProfile = effProfile
 	if len(findings) > 0 {
 		plan.PolicyFindings = findings
@@ -513,7 +528,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	if trustPreview != nil {
 		plan.ImageTrust = trustPreview
 	}
-	runID := events.GenerateRunID()
+	runID := startRes.RunID
 	if executorMode == "container" && runtime != "" {
 		if err := container.RemoveContainer(context.Background(), runtime, runID); err != nil {
 			response.Write(w, containerNameConflictProblem(err))

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -30,7 +30,6 @@ import (
 	"github.com/flowd-org/flowd/internal/paths"
 	"github.com/flowd-org/flowd/internal/policy"
 	"github.com/flowd-org/flowd/internal/policy/verify"
-	"github.com/flowd-org/flowd/internal/secrets"
 	"github.com/flowd-org/flowd/internal/server/requestctx"
 	"github.com/flowd-org/flowd/internal/server/response"
 	"github.com/flowd-org/flowd/internal/server/runstore"
@@ -453,6 +452,11 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 				response.WithExtension("errors", []map[string]string{{"arg": argErr.Arg, "message": argErr.Msg}})))
 			return
 		}
+		if errors.Is(err, engine.ErrSecretContainerUnsupported) {
+			response.Write(w, response.New(http.StatusUnprocessableEntity, "container execution does not support secret args",
+				response.WithExtension("code", "E_SECRET")))
+			return
+		}
 		response.Write(w, response.New(http.StatusBadRequest, "invalid arguments", response.WithDetail(err.Error())))
 		return
 	}
@@ -461,6 +465,14 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	binding := startRes.Binding
 	plan := startRes.Plan
 	runID := startRes.RunID
+	secretHandles := startRes.SecretHandles
+	secretCleanup := startRes.SecretCleanup
+	cleanupSecrets := true
+	defer func() {
+		if cleanupSecrets && secretCleanup != nil {
+			_ = secretCleanup()
+		}
+	}()
 
 	executorMode := strings.ToLower(cfg.Executor)
 	if strings.HasPrefix(cfg.Interpreter, "container:") && executorMode == "" {
@@ -606,6 +618,11 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	if executorMode == "container" && binding != nil && len(binding.SecretNames) > 0 {
+		response.Write(w, response.New(http.StatusUnprocessableEntity, "container execution does not support secret args",
+			response.WithExtension("code", "E_SECRET")))
+		return
+	}
 	resp := newRunPayload(runID, effectiveID, defaultRunStatus, now)
 	resp.Executor = executorMode
 	resp.SecurityProfile = effProfile
@@ -674,16 +691,18 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		publishPolicyDecisions(h.events, &resp, decisions)
 	}
 	runCtx := &runExecutionContext{
-		ctx:        nil,
-		cancel:     nil,
-		runPayload: resp,
-		scriptDir:  execScriptDir,
-		config:     cfg,
-		spec:       spec,
-		binding:    binding,
-		plan:       plan,
-		executor:   executorMode,
-		runtime:    runtime,
+		ctx:           nil,
+		cancel:        nil,
+		runPayload:    resp,
+		scriptDir:     execScriptDir,
+		config:        cfg,
+		spec:          spec,
+		binding:       binding,
+		plan:          plan,
+		executor:      executorMode,
+		runtime:       runtime,
+		secretHandles: secretHandles,
+		secretCleanup: secretCleanup,
 	}
 	ctxWithCancel, cancel := context.WithCancel(context.Background())
 	runCtx.ctx = ctxWithCancel
@@ -709,6 +728,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		}
 		logger.Info("run.accepted", attrs...)
 	}
+	cleanupSecrets = false
 	go h.executeRun(runCtx)
 }
 
@@ -1077,72 +1097,10 @@ func writePlanArtifact(plan types.Plan, runDir string) error {
 	return nil
 }
 
+// prepareSecrets kept for tests; prefer orchestrator-managed secret preparation.
 func prepareSecrets(runID string, binding *engine.Binding) (map[string]string, func() error, error) {
-	if binding == nil || len(binding.SecretNames) == 0 {
-		return nil, nil, nil
-	}
-	defer func() {
-		for name, buf := range binding.SecretBuffers {
-			if _, ok := binding.SecretNames[name]; ok {
-				buf.Close()
-			}
-		}
-	}()
-	secretDir, err := secrets.RunDir(runID)
-	if err != nil {
-		return nil, nil, err
-	}
-	paths := make(map[string]string, len(binding.SecretNames))
-	for name := range binding.SecretNames {
-		value := ""
-		if raw, ok := binding.Values[name]; ok && raw != nil {
-			if s, ok := raw.(string); ok {
-				value = s
-			} else {
-				value = fmt.Sprint(raw)
-			}
-		}
-		if buf, ok := binding.SecretBuffers[name]; ok {
-			path, err := secrets.CreateFile(secretDir, name, buf.Bytes())
-			if err != nil {
-				return nil, nil, err
-			}
-			paths[name] = path
-			continue
-		}
-		path, err := secrets.CreateFile(secretDir, name, []byte(value))
-		if err != nil {
-			return nil, nil, err
-		}
-		paths[name] = path
-	}
-
-	handles := make(map[string]string, len(paths))
-	var closers []func() error
-	for name, path := range paths {
-		handlePath, closeFn, err := secrets.ReadHandle(path)
-		if err != nil {
-			for _, closeFn := range closers {
-				_ = closeFn()
-			}
-			return nil, nil, err
-		}
-		handles[name] = handlePath
-		if closeFn != nil {
-			closers = append(closers, closeFn)
-		}
-	}
-
-	cleanup := func() error {
-		var firstErr error
-		for _, closeFn := range closers {
-			if err := closeFn(); err != nil && firstErr == nil {
-				firstErr = err
-			}
-		}
-		return firstErr
-	}
-	return handles, cleanup, nil
+	provider := engine.DefaultSecretProvider{}
+	return provider.Prepare(runID, binding)
 }
 
 func publishPolicyDecisions(sink EventSink, payload *RunPayload, decisions []policyDecision) {
@@ -1236,17 +1194,19 @@ func policyProblemDetail(prob *response.Problem) string {
 }
 
 type runExecutionContext struct {
-	ctx        context.Context
-	cancel     context.CancelFunc
-	runPayload RunPayload
-	scriptDir  string
-	config     *types.Config
-	spec       *types.ArgSpec
-	binding    *engine.Binding
-	plan       types.Plan
-	executor   string
-	runtime    container.Runtime
-	sink       events.Sink
+	ctx           context.Context
+	cancel        context.CancelFunc
+	runPayload    RunPayload
+	scriptDir     string
+	config        *types.Config
+	spec          *types.ArgSpec
+	binding       *engine.Binding
+	plan          types.Plan
+	executor      string
+	runtime       container.Runtime
+	sink          events.Sink
+	secretHandles map[string]string
+	secretCleanup func() error
 }
 
 func (h *RunsHandler) executeRun(execCtx *runExecutionContext) {
@@ -1277,14 +1237,10 @@ func (h *RunsHandler) executeRun(execCtx *runExecutionContext) {
 		return
 	}
 
-	secretHandles, secretCleanup, err := prepareSecrets(runID, execCtx.binding)
-	if err != nil {
-		h.failRun(runID, "failed", err)
-		return
-	}
-	if secretCleanup != nil {
+	secretHandles := execCtx.secretHandles
+	if execCtx.secretCleanup != nil {
 		defer func() {
-			_ = secretCleanup()
+			_ = execCtx.secretCleanup()
 		}()
 	}
 

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -45,9 +45,10 @@ const (
 	defaultRunsPage           = 1
 	defaultRunsPerPage        = 50
 	maxRunsPerPage            = 200
-	storageQuotaProblemType   = "https://flowd.dev/problems/storage-quota-exceeded"
+	storageQuotaProblemType   = "https://flowd.org/problems/storage-quota-exceeded"
 	storageQuotaProblemDetail = "Core storage quota exceeded; free up space or increase the configured quota before retrying."
-	idempotencyInFlightType   = "https://flowd.dev/problems/idempotency-key-in-use"
+	idempotencyMismatchType   = "https://flowd.org/problems/idempotency/mismatch"
+	idempotencyInFlightType   = "https://flowd.org/problems/scheduler/rejected"
 )
 
 var (
@@ -210,7 +211,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		}
 		if !strings.EqualFold(headerHash, bodyHashHex) {
 			response.Write(w, response.New(http.StatusConflict, "idempotency hash mismatch",
-				response.WithType("https://flowd.dev/problems/idempotency-key-conflict"),
+				response.WithType(idempotencyMismatchType),
 				response.WithDetail("request hash does not match stored hash"),
 				response.WithExtension("incoming_sha256", strings.ToLower(headerHash)),
 				response.WithExtension("computed_sha256", bodyHashHex),
@@ -246,7 +247,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		if found {
 			if storedHash != bodyHashHex {
 				response.Write(w, response.New(http.StatusConflict, "idempotency key conflict",
-					response.WithType("https://flowd.dev/problems/idempotency-key-conflict"),
+					response.WithType(idempotencyMismatchType),
 					response.WithExtension("stored_sha256", storedHash),
 					response.WithExtension("incoming_sha256", bodyHashHex),
 				))
@@ -279,7 +280,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 			if found {
 				if storedHash != bodyHashHex {
 					response.Write(w, response.New(http.StatusConflict, "idempotency key conflict",
-						response.WithType("https://flowd.dev/problems/idempotency-key-conflict"),
+						response.WithType(idempotencyMismatchType),
 						response.WithExtension("stored_sha256", storedHash),
 						response.WithExtension("incoming_sha256", bodyHashHex),
 					))
@@ -1372,7 +1373,7 @@ func storageQuotaExceededProblem() response.Problem {
 }
 
 func idempotencyInFlightProblem() response.Problem {
-	return response.New(http.StatusConflict, "idempotency key in use",
+	return response.New(http.StatusTooManyRequests, "idempotency key in use",
 		response.WithType(idempotencyInFlightType),
 		response.WithDetail("a request with the same Idempotency-Key is still processing"),
 	)

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -27,6 +27,7 @@ import (
 	"github.com/flowd-org/flowd/internal/executor"
 	"github.com/flowd-org/flowd/internal/executor/container"
 	"github.com/flowd-org/flowd/internal/indexer"
+	"github.com/flowd-org/flowd/internal/metrics"
 	"github.com/flowd-org/flowd/internal/observability/logctx"
 	"github.com/flowd-org/flowd/internal/paths"
 	"github.com/flowd-org/flowd/internal/policy"
@@ -260,6 +261,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		}
 		if found {
 			if storedHash != bodyHashHex {
+				metrics.RecordIdempotencyConflict()
 				response.Write(w, response.New(http.StatusConflict, "idempotency key conflict",
 					response.WithType(idempotencyMismatchType),
 					response.WithExtension("stored_sha256", storedHash),
@@ -268,10 +270,12 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			if status == idempotencyStatusInFlight {
+				metrics.RecordIdempotencyInFlight()
 				response.Write(w, idempotencyInFlightProblem())
 				return
 			}
 			w.Header().Set("Idempotent-Replay", "true")
+			metrics.RecordIdempotencyReplay()
 			writeRunPayload(w, cached, status)
 			return
 		}
@@ -293,6 +297,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 			}
 			if found {
 				if storedHash != bodyHashHex {
+					metrics.RecordIdempotencyConflict()
 					response.Write(w, response.New(http.StatusConflict, "idempotency key conflict",
 						response.WithType(idempotencyMismatchType),
 						response.WithExtension("stored_sha256", storedHash),
@@ -301,10 +306,12 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 				if status == idempotencyStatusInFlight {
+					metrics.RecordIdempotencyInFlight()
 					response.Write(w, idempotencyInFlightProblem())
 					return
 				}
 				w.Header().Set("Idempotent-Replay", "true")
+				metrics.RecordIdempotencyReplay()
 				writeRunPayload(w, cached, status)
 				return
 			}
@@ -470,6 +477,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if errors.Is(err, engine.ErrSecretContainerUnsupported) {
+			metrics.RecordSecretContainerRejected()
 			response.Write(w, response.New(http.StatusUnprocessableEntity, "container execution does not support secret args",
 				response.WithExtension("code", "E_SECRET")))
 			return
@@ -646,6 +654,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if executorMode == "container" && binding != nil && len(binding.SecretNames) > 0 {
+		metrics.RecordSecretContainerRejected()
 		response.Write(w, response.New(http.StatusUnprocessableEntity, "container execution does not support secret args",
 			response.WithExtension("code", "E_SECRET")))
 		return
@@ -1305,6 +1314,7 @@ func (h *RunsHandler) executeRun(execCtx *runExecutionContext) {
 
 	h.updateRunStatus(runID, "running", nil)
 	if sink != nil {
+		metrics.RecordRunStarted()
 		sink.EmitRunStart(runID, jobID)
 	}
 
@@ -1372,6 +1382,7 @@ func (h *RunsHandler) executeRun(execCtx *runExecutionContext) {
 	execCtx.runPayload.FinishedAt = &finished
 	execCtx.runPayload.Status = status
 	if sink != nil {
+		metrics.RecordRunFinished(status)
 		sink.EmitRunFinish(runID, status, runErr)
 	}
 	prevStatus := ""

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -30,6 +30,7 @@ import (
 	"github.com/flowd-org/flowd/internal/paths"
 	"github.com/flowd-org/flowd/internal/policy"
 	"github.com/flowd-org/flowd/internal/policy/verify"
+	"github.com/flowd-org/flowd/internal/secrets"
 	"github.com/flowd-org/flowd/internal/server/requestctx"
 	"github.com/flowd-org/flowd/internal/server/response"
 	"github.com/flowd-org/flowd/internal/server/runstore"
@@ -1076,20 +1077,15 @@ func writePlanArtifact(plan types.Plan, runDir string) error {
 	return nil
 }
 
-func prepareSecrets(runDir string, binding *engine.Binding) (string, error) {
+func prepareSecrets(runID string, binding *engine.Binding) (string, error) {
 	if binding == nil || len(binding.SecretNames) == 0 {
 		return "", nil
 	}
-	secretDir := filepath.Join(runDir, "secrets")
-	if err := os.MkdirAll(secretDir, 0o700); err != nil {
-		return "", fmt.Errorf("create secrets dir: %w", err)
+	secretDir, err := secrets.RunDir(runID)
+	if err != nil {
+		return "", err
 	}
 	for name := range binding.SecretNames {
-		safeName := sanitizeSecretName(name)
-		if safeName == "" {
-			safeName = "secret"
-		}
-		path := filepath.Join(secretDir, safeName)
 		value := ""
 		if raw, ok := binding.Values[name]; ok && raw != nil {
 			if s, ok := raw.(string); ok {
@@ -1098,26 +1094,11 @@ func prepareSecrets(runDir string, binding *engine.Binding) (string, error) {
 				value = fmt.Sprint(raw)
 			}
 		}
-		if err := os.WriteFile(path, []byte(value), 0o600); err != nil {
-			return "", fmt.Errorf("write secret %s: %w", name, err)
+		if _, err := secrets.CreateFile(secretDir, name, []byte(value)); err != nil {
+			return "", err
 		}
 	}
 	return secretDir, nil
-}
-
-func sanitizeSecretName(name string) string {
-	if name == "" {
-		return ""
-	}
-	var b strings.Builder
-	for _, r := range name {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
-			b.WriteRune(r)
-		} else {
-			b.WriteRune('_')
-		}
-	}
-	return b.String()
 }
 
 func publishPolicyDecisions(sink EventSink, payload *RunPayload, decisions []policyDecision) {
@@ -1252,7 +1233,7 @@ func (h *RunsHandler) executeRun(execCtx *runExecutionContext) {
 		return
 	}
 
-	secretDir, err := prepareSecrets(runDir, execCtx.binding)
+	secretDir, err := prepareSecrets(runID, execCtx.binding)
 	if err != nil {
 		h.failRun(runID, "failed", err)
 		return

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -40,12 +40,14 @@ import (
 
 const (
 	defaultRunStatus          = "queued"
-	defaultIdempotencyTTL     = 10 * time.Minute
+	defaultIdempotencyTTL     = 24 * time.Hour
+	maxIdempotencyTTL         = 72 * time.Hour
 	defaultRunsPage           = 1
 	defaultRunsPerPage        = 50
 	maxRunsPerPage            = 200
 	storageQuotaProblemType   = "https://flowd.dev/problems/storage-quota-exceeded"
 	storageQuotaProblemDetail = "Core storage quota exceeded; free up space or increase the configured quota before retrying."
+	idempotencyInFlightType   = "https://flowd.dev/problems/idempotency-key-in-use"
 )
 
 var (
@@ -129,6 +131,9 @@ func NewRunsHandler(cfg RunsConfig) *RunsHandler {
 	ttl := cfg.IdempotencyTTL
 	if ttl <= 0 {
 		ttl = defaultIdempotencyTTL
+	}
+	if ttl > maxIdempotencyTTL {
+		ttl = maxIdempotencyTTL
 	}
 
 	store := cfg.Store
@@ -229,6 +234,9 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	scopedKey := scopedIdempotencyKey(principal, idemKey)
 	endpoint := r.Method + " " + r.URL.Path
 	now := h.now()
+	reserved := false
+	idempotencyStored := false
+	var idempotencyExpiresAt time.Time
 	if h.idempotency != nil {
 		cached, status, storedHash, found, err := h.idempotency.Lookup(ctx, scopedKey, endpoint, now)
 		if err != nil {
@@ -244,10 +252,59 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 				))
 				return
 			}
+			if status == idempotencyStatusInFlight {
+				response.Write(w, idempotencyInFlightProblem())
+				return
+			}
 			w.Header().Set("Idempotent-Replay", "true")
 			writeRunPayload(w, cached, status)
 			return
 		}
+		idempotencyExpiresAt = now.Add(h.idempotencyTTL)
+		reserved, err = h.idempotency.Reserve(ctx, scopedKey, endpoint, bodyHashHex, now, idempotencyExpiresAt)
+		if err != nil {
+			if coredb.IsQuotaExceeded(err) {
+				response.Write(w, storageQuotaExceededProblem())
+			} else {
+				response.Write(w, response.New(http.StatusInternalServerError, "idempotency reserve failed", response.WithDetail(err.Error())))
+			}
+			return
+		}
+		if !reserved {
+			cached, status, storedHash, found, err = h.idempotency.Lookup(ctx, scopedKey, endpoint, now)
+			if err != nil {
+				response.Write(w, response.New(http.StatusInternalServerError, "idempotency lookup failed", response.WithDetail(err.Error())))
+				return
+			}
+			if found {
+				if storedHash != bodyHashHex {
+					response.Write(w, response.New(http.StatusConflict, "idempotency key conflict",
+						response.WithType("https://flowd.dev/problems/idempotency-key-conflict"),
+						response.WithExtension("stored_sha256", storedHash),
+						response.WithExtension("incoming_sha256", bodyHashHex),
+					))
+					return
+				}
+				if status == idempotencyStatusInFlight {
+					response.Write(w, idempotencyInFlightProblem())
+					return
+				}
+				w.Header().Set("Idempotent-Replay", "true")
+				writeRunPayload(w, cached, status)
+				return
+			}
+		}
+	}
+	if h.idempotency != nil && reserved {
+		defer func() {
+			if idempotencyStored {
+				return
+			}
+			releaseErr := h.idempotency.Release(context.Background(), scopedKey, endpoint)
+			if releaseErr != nil && logger != nil {
+				logger.Error("idempotency release failed", slog.String("error", releaseErr.Error()))
+			}
+		}()
 	}
 
 	runRoot := h.root
@@ -556,8 +613,10 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	resp.Provenance = provenance
 
 	if h.idempotency != nil {
-		expiresAt := now.Add(h.idempotencyTTL)
-		if err := h.idempotency.Store(ctx, scopedKey, endpoint, bodyHashHex, resp, http.StatusCreated, expiresAt); err != nil {
+		if idempotencyExpiresAt.IsZero() {
+			idempotencyExpiresAt = now.Add(h.idempotencyTTL)
+		}
+		if err := h.idempotency.Store(ctx, scopedKey, endpoint, bodyHashHex, resp, http.StatusCreated, idempotencyExpiresAt); err != nil {
 			if logger != nil {
 				logger.Error("idempotency store failed", slog.String("error", err.Error()))
 			}
@@ -567,6 +626,9 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 				response.Write(w, response.New(http.StatusInternalServerError, "idempotency store failed", response.WithDetail(err.Error())))
 			}
 			return
+		}
+		if reserved {
+			idempotencyStored = true
 		}
 	}
 
@@ -1306,6 +1368,13 @@ func storageQuotaExceededProblem() response.Problem {
 	return response.New(http.StatusTooManyRequests, "storage quota exceeded",
 		response.WithType(storageQuotaProblemType),
 		response.WithDetail(storageQuotaProblemDetail),
+	)
+}
+
+func idempotencyInFlightProblem() response.Problem {
+	return response.New(http.StatusConflict, "idempotency key in use",
+		response.WithType(idempotencyInFlightType),
+		response.WithDetail("a request with the same Idempotency-Key is still processing"),
 	)
 }
 

--- a/internal/server/handlers/runs_test.go
+++ b/internal/server/handlers/runs_test.go
@@ -508,8 +508,16 @@ func (quotaFailingIdempotencyStore) Lookup(context.Context, string, string, time
 	return RunPayload{}, 0, "", false, nil
 }
 
+func (quotaFailingIdempotencyStore) Reserve(context.Context, string, string, string, time.Time, time.Time) (bool, error) {
+	return true, nil
+}
+
 func (quotaFailingIdempotencyStore) Store(context.Context, string, string, string, RunPayload, int, time.Time) error {
 	return coredb.ErrJournalQuotaExceeded
+}
+
+func (quotaFailingIdempotencyStore) Release(context.Context, string, string) error {
+	return nil
 }
 
 func TestRunsHandlerStorageQuotaExceeded(t *testing.T) {

--- a/internal/server/handlers/runs_test.go
+++ b/internal/server/handlers/runs_test.go
@@ -166,7 +166,7 @@ argspec:
 	}
 	waitFor(func() bool { return sink.count() >= 1 }, 200*time.Millisecond, t)
 	e := sink.snapshot()[0]
-	if e.runID == "" || e.event.Event != "run.start" {
+	if e.runID == "" || e.event.Event != "run.started" {
 		t.Fatalf("unexpected event payload: %+v", e)
 	}
 	var payload map[string]any
@@ -185,7 +185,7 @@ argspec:
 	if _, ok := payload["provenance"].(map[string]any); !ok {
 		t.Fatalf("expected provenance in event payload, got %T", payload["provenance"])
 	}
-	waitFor(func() bool { return sink.countBy("run.finish") >= 1 }, 500*time.Millisecond, t)
+	waitFor(func() bool { return sink.countBy("run.finished") >= 1 }, 500*time.Millisecond, t)
 }
 
 func TestRunsHandlerProvenanceFromResolver(t *testing.T) {
@@ -304,7 +304,7 @@ func TestRunsHandlerGitSource(t *testing.T) {
 		t.Fatalf("expected resolved_ref to be populated")
 	}
 
-	waitFor(func() bool { return sink.countBy("run.finish") >= 1 }, 2*time.Second, t)
+	waitFor(func() bool { return sink.countBy("run.finished") >= 1 }, 2*time.Second, t)
 }
 
 func TestRunsHandlerUsesLocalSource(t *testing.T) {
@@ -495,10 +495,10 @@ argspec:
 	if secondBody["id"] != firstID {
 		t.Fatalf("expected idempotent response id %s, got %v", firstID, secondBody["id"])
 	}
-	waitFor(func() bool { return sink.countBy("run.finish") >= 1 }, 500*time.Millisecond, t)
+	waitFor(func() bool { return sink.countBy("run.finished") >= 1 }, 500*time.Millisecond, t)
 	t.Logf("events: %+v", sink.snapshot())
-	if sink.countBy("run.start") != 1 {
-		t.Fatalf("expected single run.start emission under idempotency, got %d", sink.countBy("run.start"))
+	if sink.countBy("run.started") != 1 {
+		t.Fatalf("expected single run.started emission under idempotency, got %d", sink.countBy("run.started"))
 	}
 }
 
@@ -891,7 +891,7 @@ argspec:
 		t.Fatalf("expected run id in response")
 	}
 
-	waitFor(func() bool { return sink.countBy("run.finish") >= 1 }, 2*time.Second, t)
+	waitFor(func() bool { return sink.countBy("run.finished") >= 1 }, 2*time.Second, t)
 
 	saved, ok := runStore.Get(runID)
 	if !ok {

--- a/internal/server/handlers/runs_test.go
+++ b/internal/server/handlers/runs_test.go
@@ -1565,17 +1565,23 @@ func TestSourceToProvenanceIncludesDigest(t *testing.T) {
 }
 
 func TestPrepareSecretsWritesFiles(t *testing.T) {
-	runDir := t.TempDir()
+	baseDir := t.TempDir()
+	prev := paths.DataDir()
+	paths.SetDataDirOverride(baseDir)
+	t.Cleanup(func() { paths.SetDataDirOverride(prev) })
 	binding := &engine.Binding{
 		Values:      map[string]interface{}{"api-key": "supersecret"},
 		SecretNames: map[string]struct{}{"api-key": {}},
 	}
-	secretDir, err := prepareSecrets(runDir, binding)
+	secretDir, err := prepareSecrets("run-123", binding)
 	if err != nil {
 		t.Fatalf("prepare secrets: %v", err)
 	}
 	if secretDir == "" {
 		t.Fatal("expected secrets directory path")
+	}
+	if !strings.Contains(secretDir, baseDir) {
+		t.Fatalf("expected secret dir under data dir, got %s", secretDir)
 	}
 	content, err := os.ReadFile(filepath.Join(secretDir, "api-key"))
 	if err != nil {

--- a/internal/server/handlers/runs_test.go
+++ b/internal/server/handlers/runs_test.go
@@ -127,7 +127,7 @@ argspec:
 	if source["resolved_ref"] == "" {
 		t.Fatalf("expected resolved_ref in provenance")
 	}
-	getHandler := NewRunGetHandler(store)
+	getHandler := NewRunGetHandler(RunGetConfig{Store: store})
 	getReq := httptest.NewRequest(http.MethodGet, "/runs/"+payload["id"].(string), nil)
 	getResp := httptest.NewRecorder()
 	getHandler.ServeHTTP(getResp, getReq)
@@ -435,7 +435,7 @@ func TestRunsHandlerUnknownJob(t *testing.T) {
 		t.Fatalf("expected 404, got %d", resp.Code)
 	}
 
-	getHandler := NewRunGetHandler(store)
+	getHandler := NewRunGetHandler(RunGetConfig{Store: store})
 	getReq := httptest.NewRequest(http.MethodGet, "/runs/does-not-exist", nil)
 	getResp := httptest.NewRecorder()
 	getHandler.ServeHTTP(getResp, getReq)

--- a/internal/server/handlers/runs_test.go
+++ b/internal/server/handlers/runs_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/flowd-org/flowd/internal/paths"
 	"github.com/flowd-org/flowd/internal/policy"
 	"github.com/flowd-org/flowd/internal/policy/verify"
+	"github.com/flowd-org/flowd/internal/secrets"
 	"github.com/flowd-org/flowd/internal/server/requestctx"
 	"github.com/flowd-org/flowd/internal/server/runstore"
 	"github.com/flowd-org/flowd/internal/server/sourcestore"
@@ -755,6 +756,76 @@ argspec:
 
 	if resp.Code != http.StatusConflict {
 		t.Fatalf("expected 409 for hash mismatch, got %d", resp.Code)
+	}
+}
+
+func TestRunsHandlerIdempotencyStoreRedactsSecrets(t *testing.T) {
+	root := t.TempDir()
+	writeJobConfig(t, root, "secret-demo", `
+version: v1
+job:
+  id: secret-demo
+  name: Secret Demo Job
+argspec:
+  args:
+    - name: token
+      type: string
+      format: secret
+      required: true
+`)
+
+	db, err := coredb.Open(context.Background(), coredb.Options{DataDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open coredb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	h := NewRunsHandler(RunsConfig{Root: root, DB: db})
+	req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(`{"job_id":"secret-demo","args":{"token":"supersecret"}}`))
+	req.Header.Set("Content-Type", "application/json")
+	key := addIdempotencyHeader(req)
+	resp := httptest.NewRecorder()
+
+	h.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	store := coredb.NewIdempotencyStore(db)
+	body, status, _, ok, err := store.Lookup(context.Background(), key, "POST /runs", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("lookup idempotency: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected idempotency entry to be stored")
+	}
+	if status != http.StatusCreated {
+		t.Fatalf("expected stored status 201, got %d", status)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode stored payload: %v", err)
+	}
+	result, ok := payload["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected result payload, got %T", payload["result"])
+	}
+	resolved, ok := result["resolved_args"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected resolved_args, got %T", result["resolved_args"])
+	}
+	if resolved["token"] != "$$REDACTED$$" {
+		t.Fatalf("expected redacted token, got %v", resolved["token"])
+	}
+
+	bodyStr := string(body)
+	if strings.Contains(bodyStr, "supersecret") {
+		t.Fatalf("stored idempotency payload contains secret value")
+	}
+	if baseDir := secrets.BaseDir(); baseDir != "" && strings.Contains(bodyStr, baseDir) {
+		t.Fatalf("stored idempotency payload contains secret handle base dir")
 	}
 }
 

--- a/internal/server/handlers/runs_test.go
+++ b/internal/server/handlers/runs_test.go
@@ -502,6 +502,130 @@ argspec:
 	}
 }
 
+func TestRunsHandlerIdempotencyCoreDBReplayAndConflict(t *testing.T) {
+	root := t.TempDir()
+	writeJobConfig(t, root, "demo", `
+version: v1
+job:
+  id: demo
+  name: Demo Job
+argspec:
+  args:
+    - name: name
+      type: string
+      required: true
+`)
+
+	db, err := coredb.Open(context.Background(), coredb.Options{DataDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open coredb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := runstore.New()
+	sink := &recordingSink{}
+	blocked := make(chan struct{})
+	unblock := make(chan struct{})
+	var discoverCalls int32
+	discover := func(root string) (indexer.Result, error) {
+		if atomic.AddInt32(&discoverCalls, 1) == 1 {
+			close(blocked)
+			<-unblock
+		}
+		return indexer.Discover(root)
+	}
+	h := NewRunsHandler(RunsConfig{
+		Root:     root,
+		Store:    store,
+		Events:   sink,
+		DB:       db,
+		Discover: discover,
+	})
+	key := "dddddddddddddddddddd"
+	payload := `{"job_id":"demo","args":{"name":"Alice"}}`
+
+	first := httptest.NewRecorder()
+	req1 := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(payload))
+	req1.Header.Set("Content-Type", "application/json")
+	setSpecificIdempotencyKey(req1, key)
+	firstDone := make(chan struct{})
+	go func() {
+		h.ServeHTTP(first, req1)
+		close(firstDone)
+	}()
+
+	waitFor(func() bool {
+		select {
+		case <-blocked:
+			return true
+		default:
+			return false
+		}
+	}, 500*time.Millisecond, t)
+
+	second := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(payload))
+	req2.Header.Set("Content-Type", "application/json")
+	setSpecificIdempotencyKey(req2, key)
+	h.ServeHTTP(second, req2)
+	if second.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 for in-flight idempotency, got %d", second.Code)
+	}
+	var problem map[string]any
+	if err := json.NewDecoder(second.Body).Decode(&problem); err != nil {
+		t.Fatalf("decode in-flight problem: %v", err)
+	}
+	if problem["type"] != idempotencyInFlightType {
+		t.Fatalf("expected in-flight type %s, got %+v", idempotencyInFlightType, problem)
+	}
+
+	close(unblock)
+	<-firstDone
+	if first.Code != http.StatusCreated {
+		t.Fatalf("expected first request 201, got %d", first.Code)
+	}
+	var firstBody map[string]any
+	if err := json.NewDecoder(first.Body).Decode(&firstBody); err != nil {
+		t.Fatalf("decode first body: %v", err)
+	}
+	firstID, _ := firstBody["id"].(string)
+
+	third := httptest.NewRecorder()
+	req3 := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(payload))
+	req3.Header.Set("Content-Type", "application/json")
+	setSpecificIdempotencyKey(req3, key)
+	h.ServeHTTP(third, req3)
+	if third.Code != http.StatusCreated {
+		t.Fatalf("expected replay 201, got %d", third.Code)
+	}
+	if replay := third.Header().Get("Idempotent-Replay"); replay != "true" {
+		t.Fatalf("expected Idempotent-Replay header true, got %q", replay)
+	}
+	var thirdBody map[string]any
+	if err := json.NewDecoder(third.Body).Decode(&thirdBody); err != nil {
+		t.Fatalf("decode replay body: %v", err)
+	}
+	if thirdBody["id"] != firstID {
+		t.Fatalf("expected replay id %s, got %v", firstID, thirdBody["id"])
+	}
+
+	conflict := httptest.NewRecorder()
+	req4 := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(`{"job_id":"demo","args":{"name":"Bob"}}`))
+	req4.Header.Set("Content-Type", "application/json")
+	setSpecificIdempotencyKey(req4, key)
+	h.ServeHTTP(conflict, req4)
+	if conflict.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for idempotency conflict, got %d", conflict.Code)
+	}
+	problem = map[string]any{}
+	if err := json.NewDecoder(conflict.Body).Decode(&problem); err != nil {
+		t.Fatalf("decode conflict problem: %v", err)
+	}
+	if problem["type"] != idempotencyMismatchType {
+		t.Fatalf("expected conflict type %s, got %+v", idempotencyMismatchType, problem)
+	}
+}
+
 type quotaFailingIdempotencyStore struct{}
 
 func (quotaFailingIdempotencyStore) Lookup(context.Context, string, string, time.Time) (RunPayload, int, string, bool, error) {

--- a/internal/server/handlers/runs_test.go
+++ b/internal/server/handlers/runs_test.go
@@ -589,6 +589,22 @@ argspec:
 	}
 }
 
+func TestRunsHandlerIdempotencyTTLDefault(t *testing.T) {
+	root := t.TempDir()
+	h := NewRunsHandler(RunsConfig{Root: root})
+	if h.idempotencyTTL != defaultIdempotencyTTL {
+		t.Fatalf("expected default idempotency TTL %s, got %s", defaultIdempotencyTTL, h.idempotencyTTL)
+	}
+}
+
+func TestRunsHandlerIdempotencyTTLMaxBound(t *testing.T) {
+	root := t.TempDir()
+	h := NewRunsHandler(RunsConfig{Root: root, IdempotencyTTL: 100 * time.Hour})
+	if h.idempotencyTTL != maxIdempotencyTTL {
+		t.Fatalf("expected idempotency TTL capped at %s, got %s", maxIdempotencyTTL, h.idempotencyTTL)
+	}
+}
+
 func TestRunsHandlerIdempotencyHashMismatch(t *testing.T) {
 	root := t.TempDir()
 	writeJobConfig(t, root, "demo", `

--- a/internal/server/handlers/runs_test.go
+++ b/internal/server/handlers/runs_test.go
@@ -1573,29 +1573,29 @@ func TestPrepareSecretsWritesFiles(t *testing.T) {
 		Values:      map[string]interface{}{"api-key": "supersecret"},
 		SecretNames: map[string]struct{}{"api-key": {}},
 	}
-	secretDir, err := prepareSecrets("run-123", binding)
+	secretHandles, cleanup, err := prepareSecrets("run-123", binding)
 	if err != nil {
 		t.Fatalf("prepare secrets: %v", err)
 	}
-	if secretDir == "" {
-		t.Fatal("expected secrets directory path")
+	if cleanup == nil {
+		t.Fatal("expected secret cleanup")
 	}
-	if !strings.Contains(secretDir, baseDir) {
-		t.Fatalf("expected secret dir under data dir, got %s", secretDir)
+	defer func() {
+		_ = cleanup()
+	}()
+	if len(secretHandles) == 0 {
+		t.Fatal("expected secret handles")
 	}
-	content, err := os.ReadFile(filepath.Join(secretDir, "api-key"))
+	handlePath, ok := secretHandles["api-key"]
+	if !ok || handlePath == "" {
+		t.Fatal("expected handle for api-key")
+	}
+	content, err := os.ReadFile(handlePath)
 	if err != nil {
-		t.Fatalf("read secret file: %v", err)
+		t.Fatalf("read handle: %v", err)
 	}
 	if string(content) != "supersecret" {
 		t.Fatalf("expected secret content preserved, got %q", string(content))
-	}
-	info, err := os.Stat(filepath.Join(secretDir, "api-key"))
-	if err != nil {
-		t.Fatalf("stat secret file: %v", err)
-	}
-	if info.Mode().Perm() != 0o600 {
-		t.Fatalf("expected secret file perms 0600, got %v", info.Mode().Perm())
 	}
 }
 

--- a/internal/server/handlers/runs_test.go
+++ b/internal/server/handlers/runs_test.go
@@ -1323,6 +1323,104 @@ container:
 	}
 }
 
+func TestRunsHandlerPolicyDeniedSSEEventPersistedAndLive(t *testing.T) {
+	root := t.TempDir()
+	writeJobConfig(t, root, "override", `
+version: v1
+job:
+  id: override
+  name: Override Job
+executor: container
+interpreter: "container:alpine:3.20"
+container:
+  network: bridge
+`)
+
+	db, err := coredb.Open(context.Background(), coredb.Options{DataDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open coredb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	journal := coredb.NewJournal(db, 0)
+
+	store := runstore.New()
+	runHub := sse.New(sse.Config{KeepAliveInterval: time.Hour})
+	globalHub := sse.New(sse.Config{KeepAliveInterval: time.Hour})
+	baseSink := EventSinkFunc(func(runID string, ev sse.Event) {
+		runHub.Publish(runID, ev)
+		globalHub.Publish("global", WrapGlobalEvent(runID, ev))
+	})
+	eventSink := NewJournalEventSink(journal, baseSink)
+
+	oldDetect := detectContainerRuntime
+	detectContainerRuntime = func(func(string) (string, error)) (container.Runtime, error) {
+		return container.RuntimeDocker, nil
+	}
+	defer func() { detectContainerRuntime = oldDetect }()
+
+	h := NewRunsHandler(RunsConfig{
+		Root:    root,
+		Profile: "secure",
+		Store:   store,
+		Events:  eventSink,
+		DB:      db,
+		Runtime: container.RuntimeDocker,
+	})
+	globalEvents := NewEventsHandler(EventsConfig{
+		RunStore:  store,
+		RunHub:    runHub,
+		GlobalHub: globalHub,
+		Journal:   journal,
+	})
+
+	// Start a live SSE stream and ensure it is ready.
+	liveCtx, liveCancel := context.WithCancel(context.Background())
+	liveReq := httptest.NewRequest(http.MethodGet, "/events/stream", nil).WithContext(liveCtx)
+	liveRec := httptest.NewRecorder()
+	liveDone := make(chan struct{})
+	go func() {
+		globalEvents.ServeHTTP(liveRec, liveReq)
+		close(liveDone)
+	}()
+	waitFor(func() bool { return strings.Contains(liveRec.Body.String(), "retry: 3000") }, 200*time.Millisecond, t)
+
+	// Trigger a policy denial.
+	req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(`{"job_id":"override"}`))
+	req.Header.Set("Content-Type", "application/json")
+	addIdempotencyHeader(req)
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", resp.Code, resp.Body.String())
+	}
+	var problem map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&problem); err != nil {
+		t.Fatalf("decode problem: %v", err)
+	}
+	if problem["code"] != "policy.denied" {
+		t.Fatalf("expected policy.denied, got %+v", problem)
+	}
+
+	// Live stream should include policy.denied event.
+	waitFor(func() bool { return strings.Contains(liveRec.Body.String(), "\"type\":\"policy.denied\"") }, 500*time.Millisecond, t)
+	liveCancel()
+	<-liveDone
+
+	// Persisted replay should include policy.denied event as well.
+	replayCtx, replayCancel := context.WithCancel(context.Background())
+	replayReq := httptest.NewRequest(http.MethodGet, "/events/stream", nil).WithContext(replayCtx)
+	replayRec := httptest.NewRecorder()
+	replayDone := make(chan struct{})
+	go func() {
+		globalEvents.ServeHTTP(replayRec, replayReq)
+		close(replayDone)
+	}()
+	waitFor(func() bool { return strings.Contains(replayRec.Body.String(), "\"type\":\"policy.denied\"") }, 500*time.Millisecond, t)
+	replayCancel()
+	<-replayDone
+}
+
 func TestRunsHandlerOverrideAllowedPermissive(t *testing.T) {
 	root := t.TempDir()
 	writeJobConfig(t, root, "override", `

--- a/internal/server/handlers/runtime_helpers.go
+++ b/internal/server/handlers/runtime_helpers.go
@@ -10,7 +10,7 @@ import (
 func runtimeUnavailableProblem(err error) response.Problem {
 	opts := []response.Option{response.WithExtension("code", "container.runtime.unavailable")}
 	if err != nil && err.Error() != "" {
-		opts = append(opts, response.WithDetail(err.Error()))
+		opts = append(opts, response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil)))
 	}
 	return response.New(http.StatusUnprocessableEntity, "container runtime unavailable", opts...)
 }
@@ -18,7 +18,7 @@ func runtimeUnavailableProblem(err error) response.Problem {
 func containerNameConflictProblem(err error) response.Problem {
 	opts := []response.Option{response.WithExtension("code", "container.name.conflict")}
 	if err != nil && err.Error() != "" {
-		opts = append(opts, response.WithDetail(err.Error()))
+		opts = append(opts, response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil)))
 	}
 	return response.New(http.StatusUnprocessableEntity, "container name conflict", opts...)
 }

--- a/internal/server/handlers/sources.go
+++ b/internal/server/handlers/sources.go
@@ -209,7 +209,7 @@ func handleListSources(w http.ResponseWriter, r *http.Request, cfg SourcesConfig
 	}
 	data, err := json.Marshal(items)
 	if err != nil {
-		response.Write(w, response.New(http.StatusInternalServerError, "encode sources failed", response.WithDetail(err.Error())))
+		response.Write(w, response.New(http.StatusInternalServerError, "encode sources failed", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -223,7 +223,7 @@ func handleUpsertSource(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	dec := json.NewDecoder(r.Body)
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&req); err != nil {
-		response.Write(w, response.New(http.StatusBadRequest, "invalid request body", response.WithDetail(err.Error())))
+		response.Write(w, response.New(http.StatusBadRequest, "invalid request body", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		return
 	}
 
@@ -232,7 +232,7 @@ func handleUpsertSource(ctx context.Context, w http.ResponseWriter, r *http.Requ
 		return
 	}
 	if req.Name != "" && strings.ContainsAny(req.Name, "/\\") {
-		response.Write(w, response.New(http.StatusBadRequest, "invalid name", response.WithDetail("name must not contain path separators")))
+		response.Write(w, response.New(http.StatusBadRequest, "invalid name", response.WithDetail(scrubProblemDetail("name must not contain path separators", nil, nil, nil, nil))))
 		return
 	}
 
@@ -244,7 +244,7 @@ func handleUpsertSource(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	case "oci":
 		handleOCISource(ctx, w, req, cfg)
 	default:
-		response.Write(w, response.New(http.StatusBadRequest, "unsupported source type", response.WithDetail(req.Type)))
+		response.Write(w, response.New(http.StatusBadRequest, "unsupported source type", response.WithDetail(scrubProblemDetail(req.Type, nil, nil, nil, nil))))
 	}
 }
 
@@ -282,13 +282,13 @@ func handleLocalSource(w http.ResponseWriter, req sourceRequest, cfg SourcesConf
 	if allowedRoot == "" {
 		response.Write(w, response.New(http.StatusBadRequest, "source not allowed",
 			response.WithExtension("code", "source.not.allowed"),
-			response.WithDetail("local path outside allow-list")))
+			response.WithDetail(scrubProblemDetail("local path outside allow-list", nil, nil, nil, nil))))
 		return
 	}
 	expose, err := normalizeExpose(req.Expose)
 	if err != nil {
 		response.Write(w, response.New(http.StatusBadRequest, "invalid expose",
-			response.WithDetail(err.Error())))
+			response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		return
 	}
 
@@ -296,7 +296,7 @@ func handleLocalSource(w http.ResponseWriter, req sourceRequest, cfg SourcesConf
 	if aliasErr != nil {
 		response.Write(w, response.New(http.StatusBadRequest, "invalid alias configuration",
 			response.WithExtension("code", "alias.configuration.invalid"),
-			response.WithDetail(aliasErr.Error())))
+			response.WithDetail(scrubProblemDetail(aliasErr.Error(), nil, nil, nil, nil))))
 		return
 	}
 
@@ -343,7 +343,7 @@ func handleGitSource(ctx context.Context, w http.ResponseWriter, req sourceReque
 
 	parsed, err := url.Parse(repoURL)
 	if err != nil {
-		response.Write(w, response.New(http.StatusBadRequest, "invalid git url", response.WithDetail(err.Error())))
+		response.Write(w, response.New(http.StatusBadRequest, "invalid git url", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		return
 	}
 
@@ -360,7 +360,7 @@ func handleGitSource(ctx context.Context, w http.ResponseWriter, req sourceReque
 		}
 		absPath, err := filepath.Abs(localPath)
 		if err != nil {
-			response.Write(w, response.New(http.StatusBadRequest, "invalid git url", response.WithDetail(err.Error())))
+			response.Write(w, response.New(http.StatusBadRequest, "invalid git url", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 			return
 		}
 		absPath = filepath.Clean(absPath)
@@ -374,7 +374,7 @@ func handleGitSource(ctx context.Context, w http.ResponseWriter, req sourceReque
 		if !allowed {
 			response.Write(w, response.New(http.StatusBadRequest, "source not allowed",
 				response.WithExtension("code", "source.not.allowed"),
-				response.WithDetail("git path outside allow-list")))
+				response.WithDetail(scrubProblemDetail("git path outside allow-list", nil, nil, nil, nil))))
 			return
 		}
 		repoForClone = absPath
@@ -383,7 +383,7 @@ func handleGitSource(ctx context.Context, w http.ResponseWriter, req sourceReque
 		if !hostAllowed(host, cfg.AllowGitHosts) {
 			response.Write(w, response.New(http.StatusBadRequest, "source not allowed",
 				response.WithExtension("code", "source.not.allowed"),
-				response.WithDetail("git host "+host+" not allowed")))
+				response.WithDetail(scrubProblemDetail("git host "+host+" not allowed", nil, nil, nil, nil))))
 			return
 		}
 	}
@@ -396,13 +396,13 @@ func handleGitSource(ctx context.Context, w http.ResponseWriter, req sourceReque
 	expose, err := normalizeExpose(req.Expose)
 	if err != nil {
 		response.Write(w, response.New(http.StatusBadRequest, "invalid expose",
-			response.WithDetail(err.Error())))
+			response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		return
 	}
 
 	commit, checkoutPath, err := materializeGitSource(ctx, cfg.CheckoutDir, name, repoForClone, refName)
 	if err != nil {
-		response.Write(w, response.New(http.StatusBadRequest, "git checkout failed", response.WithDetail(err.Error())))
+		response.Write(w, response.New(http.StatusBadRequest, "git checkout failed", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		return
 	}
 
@@ -417,7 +417,7 @@ func handleGitSource(ctx context.Context, w http.ResponseWriter, req sourceReque
 	if aliasErr != nil {
 		response.Write(w, response.New(http.StatusBadRequest, "invalid alias configuration",
 			response.WithExtension("code", "alias.configuration.invalid"),
-			response.WithDetail(aliasErr.Error())))
+			response.WithDetail(scrubProblemDetail(aliasErr.Error(), nil, nil, nil, nil))))
 		return
 	}
 
@@ -459,27 +459,27 @@ func handleOCISource(ctx context.Context, w http.ResponseWriter, req sourceReque
 		return
 	}
 	if strings.Contains(imageRef, "://") {
-		response.Write(w, response.New(http.StatusBadRequest, "invalid image reference", response.WithDetail("image reference must not include scheme")))
+		response.Write(w, response.New(http.StatusBadRequest, "invalid image reference", response.WithDetail(scrubProblemDetail("image reference must not include scheme", nil, nil, nil, nil))))
 		return
 	}
 
 	if !req.Trusted {
 		response.Write(w, response.New(http.StatusBadRequest, "trust confirmation required",
 			response.WithExtension("code", "source.trust.required"),
-			response.WithDetail("oci sources require trusted=true")))
+			response.WithDetail(scrubProblemDetail("oci sources require trusted=true", nil, nil, nil, nil))))
 		return
 	}
 
 	storedPolicy, internalPolicy, err := normalizePullPolicy(req.PullPolicy)
 	if err != nil {
 		response.Write(w, response.New(http.StatusBadRequest, "invalid pull policy",
-			response.WithDetail(err.Error())))
+			response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		return
 	}
 	expose, err := normalizeExpose(req.Expose)
 	if err != nil {
 		response.Write(w, response.New(http.StatusBadRequest, "invalid expose",
-			response.WithDetail(err.Error())))
+			response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		return
 	}
 
@@ -487,7 +487,7 @@ func handleOCISource(ctx context.Context, w http.ResponseWriter, req sourceReque
 	if err != nil {
 		response.Write(w, response.New(http.StatusUnprocessableEntity, "policy error",
 			response.WithExtension("code", "E_POLICY"),
-			response.WithDetail(err.Error())))
+			response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		return
 	}
 	ctx = requestctx.WithEffectiveProfile(ctx, effProfile)
@@ -498,13 +498,13 @@ func handleOCISource(ctx context.Context, w http.ResponseWriter, req sourceReque
 		if err != nil {
 			response.Write(w, response.New(http.StatusUnprocessableEntity, "policy error",
 				response.WithExtension("code", "E_POLICY"),
-				response.WithDetail(err.Error())))
+				response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 			return
 		}
 	}
 
 	if prob := enforceRegistryAllowList(ctx, imageRef, policyCtx); prob != nil {
-		response.Write(w, *prob)
+		response.Write(w, scrubProblemResponse(prob, nil, nil, nil, nil))
 		return
 	}
 
@@ -512,7 +512,7 @@ func handleOCISource(ctx context.Context, w http.ResponseWriter, req sourceReque
 	if err != nil {
 		response.Write(w, response.New(http.StatusUnprocessableEntity, "policy error",
 			response.WithExtension("code", "E_POLICY"),
-			response.WithDetail(err.Error())))
+			response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		return
 	}
 
@@ -522,7 +522,7 @@ func handleOCISource(ctx context.Context, w http.ResponseWriter, req sourceReque
 			response.Write(w, response.New(http.StatusUnprocessableEntity, "signature verification required",
 				response.WithType(problemTypeSignatureInvalid),
 				response.WithExtension("code", "source-signature-invalid"),
-				response.WithDetail("signature verification is disabled for the current profile")))
+				response.WithDetail(scrubProblemDetail("signature verification is disabled for the current profile", nil, nil, nil, nil))))
 			return
 		}
 		if !outcome.Verified {
@@ -533,17 +533,18 @@ func handleOCISource(ctx context.Context, w http.ResponseWriter, req sourceReque
 			response.Write(w, response.New(http.StatusUnprocessableEntity, "signature verification failed",
 				response.WithType(problemTypeSignatureInvalid),
 				response.WithExtension("code", "source-signature-invalid"),
-				response.WithDetail(detail)))
+				response.WithDetail(scrubProblemDetail(detail, nil, nil, nil, nil))))
 			return
 		}
 	} else if prob != nil {
-		response.Write(w, *prob)
+		response.Write(w, scrubProblemResponse(prob, nil, nil, nil, nil))
 		return
 	}
 
 	runtimeVal, runtimeStr, runtimeErr := resolveRuntimeForOCI(ctx, cfg)
 	if runtimeErr != nil {
-		response.Write(w, runtimeUnavailableProblem(runtimeErr))
+		prob := runtimeUnavailableProblem(runtimeErr)
+		response.Write(w, scrubProblemResponse(&prob, nil, nil, nil, nil))
 		return
 	}
 	ctx = requestctx.WithRuntime(ctx, runtimeStr)
@@ -554,7 +555,7 @@ func handleOCISource(ctx context.Context, w http.ResponseWriter, req sourceReque
 			detail := err.Error()
 			response.Write(w, response.New(http.StatusBadRequest, "oci pull failed",
 				response.WithExtension("code", "E_OCI"),
-				response.WithDetail(detail)))
+				response.WithDetail(scrubProblemDetail(detail, nil, nil, nil, nil))))
 			return
 		}
 		metrics.Default.RecordContainerPull(time.Since(start))
@@ -567,16 +568,16 @@ func handleOCISource(ctx context.Context, w http.ResponseWriter, req sourceReque
 			metrics.Default.RecordAddonManifestInvalid()
 			response.Write(w, response.New(http.StatusBadRequest, "addon manifest missing",
 				response.WithExtension("code", "E_ADDON_MANIFEST"),
-				response.WithDetail(err.Error())))
+				response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		case errors.Is(err, errManifestInvalid):
 			metrics.Default.RecordAddonManifestInvalid()
 			response.Write(w, response.New(http.StatusBadRequest, "addon manifest invalid",
 				response.WithExtension("code", "E_ADDON_MANIFEST"),
-				response.WithDetail(err.Error())))
+				response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		default:
 			response.Write(w, response.New(http.StatusBadRequest, "oci command failed",
 				response.WithExtension("code", "E_OCI"),
-				response.WithDetail(err.Error())))
+				response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		}
 		return
 	}
@@ -586,14 +587,14 @@ func handleOCISource(ctx context.Context, w http.ResponseWriter, req sourceReque
 		metrics.Default.RecordAddonManifestInvalid()
 		response.Write(w, response.New(http.StatusBadRequest, "addon manifest parse failed",
 			response.WithExtension("code", "E_ADDON_MANIFEST"),
-			response.WithDetail(parseErr.Error())))
+			response.WithDetail(scrubProblemDetail(parseErr.Error(), nil, nil, nil, nil))))
 		return
 	}
 	if len(validationErrs) > 0 {
 		metrics.Default.RecordAddonManifestInvalid()
 		response.Write(w, response.New(http.StatusBadRequest, "addon manifest invalid",
 			response.WithExtension("code", "E_ADDON_MANIFEST"),
-			response.WithDetail(strings.Join(validationErrs, "; "))))
+			response.WithDetail(scrubProblemDetail(strings.Join(validationErrs, "; "), nil, nil, nil, nil))))
 		return
 	}
 
@@ -604,7 +605,7 @@ func handleOCISource(ctx context.Context, w http.ResponseWriter, req sourceReque
 		} else {
 			response.Write(w, response.New(http.StatusBadRequest, "image inspect failed",
 				response.WithExtension("code", "E_OCI"),
-				response.WithDetail(inspectErr.Error())))
+				response.WithDetail(scrubProblemDetail(inspectErr.Error(), nil, nil, nil, nil))))
 			return
 		}
 	}
@@ -620,7 +621,7 @@ func handleOCISource(ctx context.Context, w http.ResponseWriter, req sourceReque
 	if writeErr != nil {
 		response.Write(w, response.New(http.StatusInternalServerError, "cache manifest failed",
 			response.WithExtension("code", "E_OCI"),
-			response.WithDetail(writeErr.Error())))
+			response.WithDetail(scrubProblemDetail(writeErr.Error(), nil, nil, nil, nil))))
 		return
 	}
 

--- a/internal/server/handlers/sources.go
+++ b/internal/server/handlers/sources.go
@@ -64,7 +64,7 @@ var (
 	addonManifestMountPath = "/flwd-addon/" + addonManifestFileName
 )
 
-const problemTypeSignatureInvalid = "https://flowd.dev/problems/source-signature-invalid"
+const problemTypeSignatureInvalid = "https://flowd.org/problems/source-signature-invalid"
 
 func normalizeExpose(value string) (string, error) {
 	v := strings.ToLower(strings.TrimSpace(value))

--- a/internal/server/handlers/sse_sink.go
+++ b/internal/server/handlers/sse_sink.go
@@ -30,7 +30,7 @@ func (s *sseSink) EmitRunStart(runID, jobID string) {
 	if !s.run.StartedAt.IsZero() {
 		data["started_at"] = s.run.StartedAt
 	}
-	s.publish("run.start", data)
+	s.publish("run.started", data)
 }
 
 func (s *sseSink) EmitRunFinish(runID, status string, err error) {
@@ -44,13 +44,13 @@ func (s *sseSink) EmitRunFinish(runID, status string, err error) {
 	if err != nil {
 		data["error"] = err.Error()
 	}
-	s.publish("run.finish", data)
+	s.publish("run.finished", data)
 }
 
 func (s *sseSink) EmitStepStart(runID, step string) {
 	data := s.basePayload()
 	data["step"] = step
-	s.publish("step.start", data)
+	s.publish("step.started", data)
 }
 
 func (s *sseSink) EmitStepLog(runID, step, channel, message string) {
@@ -58,7 +58,7 @@ func (s *sseSink) EmitStepLog(runID, step, channel, message string) {
 	data["step"] = step
 	data["channel"] = channel
 	data["message"] = message
-	s.publish("step.log", data)
+	s.publish("step.output", data)
 }
 
 func (s *sseSink) EmitStepFinish(runID, step string, exitCode int, err error) {
@@ -71,7 +71,7 @@ func (s *sseSink) EmitStepFinish(runID, step string, exitCode int, err error) {
 	} else {
 		data["status"] = "completed"
 	}
-	s.publish("step.finish", data)
+	s.publish("step.finished", data)
 }
 
 func (s *sseSink) basePayload() map[string]any {

--- a/internal/server/metrics/metrics.go
+++ b/internal/server/metrics/metrics.go
@@ -32,9 +32,21 @@ type Registry struct {
 	persistenceLatency    map[[2]string]*valueHistogram
 	persistenceEvictions  map[string]uint64
 	persistenceBytes      map[string]uint64
+	idempotencyLookups    map[string]uint64
+	idempotencyReplays    uint64
+	idempotencyConflicts  uint64
+	idempotencyInFlight   uint64
 	sseActive             map[string]int64
+	sseStreamStarts       map[string]uint64
+	sseStreamEnds         map[string]uint64
 	sseResumeTotal        uint64
 	sseCursorExpiredTotal uint64
+	runStartedTotal       uint64
+	runFinishedTotals     map[string]uint64
+	secretHandlesCreated  uint64
+	secretHandlesCleaned  uint64
+	secretHandleErrors    uint64
+	secretContainerReject uint64
 }
 
 // NewRegistry constructs a metrics registry with default buckets.
@@ -52,7 +64,11 @@ func NewRegistry() *Registry {
 		persistenceLatency:   make(map[[2]string]*valueHistogram),
 		persistenceEvictions: make(map[string]uint64),
 		persistenceBytes:     make(map[string]uint64),
+		idempotencyLookups:   make(map[string]uint64),
 		sseActive:            make(map[string]int64),
+		sseStreamStarts:      make(map[string]uint64),
+		sseStreamEnds:        make(map[string]uint64),
+		runFinishedTotals:    make(map[string]uint64),
 	}
 	for op, outcomes := range persistenceLatencyDefaults {
 		op = normalizeLabel(op)
@@ -64,6 +80,9 @@ func NewRegistry() *Registry {
 	for _, kind := range persistenceDefaultKinds {
 		r.persistenceEvictions[normalizeLabel(kind)] = 0
 		r.persistenceBytes[normalizeLabel(kind)] = 0
+	}
+	for _, outcome := range idempotencyLookupOutcomes {
+		r.idempotencyLookups[normalizeLabel(outcome)] = 0
 	}
 	return r
 }
@@ -254,17 +273,49 @@ func (r *Registry) writeAll(w http.ResponseWriter) {
 	}
 	buf.WriteByte('\n')
 
+	writeMetricHeader(buf, "flowd_idempotency_lookup_total", "Idempotency lookup outcomes", "counter")
+	for _, outcome := range sortedKeysUint(r.idempotencyLookups) {
+		fmt.Fprintf(buf, "flowd_idempotency_lookup_total{outcome=%q} %d\n", outcome, r.idempotencyLookups[outcome])
+	}
+	buf.WriteByte('\n')
+
+	writeMetricHeader(buf, "flowd_idempotency_replay_total", "Idempotency replay responses", "counter")
+	fmt.Fprintf(buf, "flowd_idempotency_replay_total %d\n", r.idempotencyReplays)
+	buf.WriteByte('\n')
+
+	writeMetricHeader(buf, "flowd_idempotency_conflict_total", "Idempotency conflict responses", "counter")
+	fmt.Fprintf(buf, "flowd_idempotency_conflict_total %d\n", r.idempotencyConflicts)
+	buf.WriteByte('\n')
+
+	writeMetricHeader(buf, "flowd_idempotency_inflight_total", "Idempotency in-flight responses", "counter")
+	fmt.Fprintf(buf, "flowd_idempotency_inflight_total %d\n", r.idempotencyInFlight)
+	buf.WriteByte('\n')
+
 	writeMetricHeader(buf, "flowd_sse_active_streams", "Active SSE streams by transport", "gauge")
 	for _, transport := range sortedKeysInt64(r.sseActive) {
 		fmt.Fprintf(buf, "flowd_sse_active_streams{transport=%q} %d\n", transport, r.sseActive[transport])
 	}
 	buf.WriteByte('\n')
 
+	writeMetricHeader(buf, "flowd_sse_stream_start_total", "SSE stream starts by transport", "counter")
+	for _, transport := range sortedKeysUint(r.sseStreamStarts) {
+		fmt.Fprintf(buf, "flowd_sse_stream_start_total{transport=%q} %d\n", transport, r.sseStreamStarts[transport])
+	}
+	buf.WriteByte('\n')
+
+	writeMetricHeader(buf, "flowd_sse_stream_end_total", "SSE stream ends by transport", "counter")
+	for _, transport := range sortedKeysUint(r.sseStreamEnds) {
+		fmt.Fprintf(buf, "flowd_sse_stream_end_total{transport=%q} %d\n", transport, r.sseStreamEnds[transport])
+	}
+	buf.WriteByte('\n')
+
 	writeMetricHeader(buf, "flowd_sse_resume_total", "SSE resume attempts", "counter")
-	fmt.Fprintf(buf, "flowd_sse_resume_total %d\n\n", r.sseResumeTotal)
+	fmt.Fprintf(buf, "flowd_sse_resume_total %d\n", r.sseResumeTotal)
+	buf.WriteByte('\n')
 
 	writeMetricHeader(buf, "flowd_sse_cursor_expired_total", "SSE cursor expired responses (HTTP 410)", "counter")
-	fmt.Fprintf(buf, "flowd_sse_cursor_expired_total %d\n\n", r.sseCursorExpiredTotal)
+	fmt.Fprintf(buf, "flowd_sse_cursor_expired_total %d\n", r.sseCursorExpiredTotal)
+	buf.WriteByte('\n')
 
 	r.writeHistogram(buf, "flwd_container_runs_total", "counter", func() (float64, bool) {
 		return float64(r.containerRunsTotal), true
@@ -284,6 +335,32 @@ func (r *Registry) writeAll(w http.ResponseWriter) {
 
 	writeMetricHeader(buf, "flwd_addon_manifest_invalid_total", "Invalid add-on manifests", "counter")
 	fmt.Fprintf(buf, "flwd_addon_manifest_invalid_total %d\n\n", r.addonManifestInvalid)
+
+	writeMetricHeader(buf, "flowd_runs_started_total", "Run started events", "counter")
+	fmt.Fprintf(buf, "flowd_runs_started_total %d\n", r.runStartedTotal)
+	buf.WriteByte('\n')
+
+	writeMetricHeader(buf, "flowd_runs_finished_total", "Run finished events by status", "counter")
+	for _, status := range sortedKeysUint(r.runFinishedTotals) {
+		fmt.Fprintf(buf, "flowd_runs_finished_total{status=%q} %d\n", status, r.runFinishedTotals[status])
+	}
+	buf.WriteByte('\n')
+
+	writeMetricHeader(buf, "flowd_secret_handles_created_total", "Secret handles created", "counter")
+	fmt.Fprintf(buf, "flowd_secret_handles_created_total %d\n", r.secretHandlesCreated)
+	buf.WriteByte('\n')
+
+	writeMetricHeader(buf, "flowd_secret_handles_cleaned_total", "Secret handles cleaned", "counter")
+	fmt.Fprintf(buf, "flowd_secret_handles_cleaned_total %d\n", r.secretHandlesCleaned)
+	buf.WriteByte('\n')
+
+	writeMetricHeader(buf, "flowd_secret_handle_errors_total", "Secret handle cleanup errors", "counter")
+	fmt.Fprintf(buf, "flowd_secret_handle_errors_total %d\n", r.secretHandleErrors)
+	buf.WriteByte('\n')
+
+	writeMetricHeader(buf, "flowd_secret_container_rejected_total", "Container runs rejected due to secret args", "counter")
+	fmt.Fprintf(buf, "flowd_secret_container_rejected_total %d\n", r.secretContainerReject)
+	buf.WriteByte('\n')
 }
 
 func (r *Registry) writeHistogram(buf *bufio.Writer, name, metricType string, getter func() (float64, bool)) {
@@ -540,6 +617,38 @@ func (r *Registry) RecordPersistenceEviction(kind string, bytes int64) {
 	r.persistenceBytes[kind] += uint64(bytes)
 }
 
+// RecordIdempotencyLookup increments idempotency lookup counters by outcome.
+func (r *Registry) RecordIdempotencyLookup(outcome string) {
+	outcome = normalizeLabel(outcome)
+	if outcome == "" {
+		outcome = "error"
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.idempotencyLookups[outcome]++
+}
+
+// RecordIdempotencyReplay increments idempotency replay counter.
+func (r *Registry) RecordIdempotencyReplay() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.idempotencyReplays++
+}
+
+// RecordIdempotencyConflict increments idempotency conflict counter.
+func (r *Registry) RecordIdempotencyConflict() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.idempotencyConflicts++
+}
+
+// RecordIdempotencyInFlight increments idempotency in-flight counter.
+func (r *Registry) RecordIdempotencyInFlight() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.idempotencyInFlight++
+}
+
 // RecordSSEActiveDelta adjusts the active SSE stream gauge for the provided transport.
 func (r *Registry) RecordSSEActiveDelta(transport string, delta int64) {
 	transport = normalizeLabel(transport)
@@ -554,6 +663,28 @@ func (r *Registry) RecordSSEActiveDelta(transport string, delta int64) {
 	}
 }
 
+// RecordSSEStreamStart increments SSE stream start counter for a transport.
+func (r *Registry) RecordSSEStreamStart(transport string) {
+	transport = normalizeLabel(transport)
+	if transport == "" {
+		transport = "unknown"
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sseStreamStarts[transport]++
+}
+
+// RecordSSEStreamEnd increments SSE stream end counter for a transport.
+func (r *Registry) RecordSSEStreamEnd(transport string) {
+	transport = normalizeLabel(transport)
+	if transport == "" {
+		transport = "unknown"
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sseStreamEnds[transport]++
+}
+
 // RecordSSEResumeAttempt increments the SSE resume counter.
 func (r *Registry) RecordSSEResumeAttempt() {
 	r.mu.Lock()
@@ -566,6 +697,54 @@ func (r *Registry) RecordSSECursorExpired() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.sseCursorExpiredTotal++
+}
+
+// RecordRunStarted increments run started counter.
+func (r *Registry) RecordRunStarted() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.runStartedTotal++
+}
+
+// RecordRunFinished increments run finished counter by status.
+func (r *Registry) RecordRunFinished(status string) {
+	status = normalizeLabel(status)
+	if status == "" {
+		status = "unknown"
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.runFinishedTotals[status]++
+}
+
+// RecordSecretHandleCreated increments secret handle creation counters.
+func (r *Registry) RecordSecretHandleCreated(count int) {
+	if count <= 0 {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.secretHandlesCreated += uint64(count)
+}
+
+// RecordSecretHandleCleanup increments secret handle cleanup counters.
+func (r *Registry) RecordSecretHandleCleanup(count int, success bool) {
+	if count <= 0 {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.secretHandlesCleaned += uint64(count)
+	if !success {
+		r.secretHandleErrors++
+	}
+}
+
+// RecordSecretContainerRejected increments container secret rejection counter.
+func (r *Registry) RecordSecretContainerRejected() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.secretContainerReject++
 }
 
 func normalizeLabel(v string) string {
@@ -583,6 +762,8 @@ var persistenceLatencyDefaults = map[string][]string{
 }
 
 var persistenceDefaultKinds = []string{"journal", "idempotency"}
+
+var idempotencyLookupOutcomes = []string{"hit", "miss", "expired", "error"}
 
 type valueHistogram struct {
 	buckets []float64

--- a/internal/server/metrics/metrics.go
+++ b/internal/server/metrics/metrics.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	coremetrics "github.com/flowd-org/flowd/internal/metrics"
 )
 
 // Registry collects counters, gauges, and histograms for Prometheus exposition.
@@ -68,6 +70,10 @@ func NewRegistry() *Registry {
 
 // Default global registry used by the server.
 var Default = NewRegistry()
+
+func init() {
+	coremetrics.SetSink(Default)
+}
 
 // SetBuildInfo configures the build info labels exposed by flwd_build_info.
 func (r *Registry) SetBuildInfo(labels map[string]string) {

--- a/internal/server/metrics/metrics_test.go
+++ b/internal/server/metrics/metrics_test.go
@@ -47,6 +47,8 @@ func TestSSEMetricsOutput(t *testing.T) {
 	reg.RecordSSEActiveDelta("sse", 2)
 	reg.RecordSSEActiveDelta("sse", -1)
 	reg.RecordSSEActiveDelta("websocket", 3)
+	reg.RecordSSEStreamStart("sse")
+	reg.RecordSSEStreamEnd("sse")
 	reg.RecordSSEResumeAttempt()
 	reg.RecordSSEResumeAttempt()
 	reg.RecordSSECursorExpired()
@@ -67,5 +69,75 @@ func TestSSEMetricsOutput(t *testing.T) {
 	}
 	if !strings.Contains(body, `flowd_sse_cursor_expired_total 1`) {
 		t.Fatalf("expected cursor expired counter, got body:\n%s", body)
+	}
+	if !strings.Contains(body, `flowd_sse_stream_start_total{transport="sse"} 1`) {
+		t.Fatalf("expected stream start counter, got body:\n%s", body)
+	}
+	if !strings.Contains(body, `flowd_sse_stream_end_total{transport="sse"} 1`) {
+		t.Fatalf("expected stream end counter, got body:\n%s", body)
+	}
+}
+
+func TestIdempotencyMetricsOutput(t *testing.T) {
+	reg := NewRegistry()
+	reg.RecordIdempotencyLookup("hit")
+	reg.RecordIdempotencyLookup("miss")
+	reg.RecordIdempotencyReplay()
+	reg.RecordIdempotencyConflict()
+	reg.RecordIdempotencyInFlight()
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rr := httptest.NewRecorder()
+	reg.Handler().ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	if !strings.Contains(body, `flowd_idempotency_lookup_total{outcome="hit"} 1`) {
+		t.Fatalf("expected idempotency hit lookup counter, got body:\n%s", body)
+	}
+	if !strings.Contains(body, `flowd_idempotency_lookup_total{outcome="miss"} 1`) {
+		t.Fatalf("expected idempotency miss lookup counter, got body:\n%s", body)
+	}
+	if !strings.Contains(body, "flowd_idempotency_replay_total 1\n") {
+		t.Fatalf("expected idempotency replay counter, got body:\n%s", body)
+	}
+	if !strings.Contains(body, "flowd_idempotency_conflict_total 1\n") {
+		t.Fatalf("expected idempotency conflict counter, got body:\n%s", body)
+	}
+	if !strings.Contains(body, "flowd_idempotency_inflight_total 1\n") {
+		t.Fatalf("expected idempotency in-flight counter, got body:\n%s", body)
+	}
+}
+
+func TestRunAndSecretMetricsOutput(t *testing.T) {
+	reg := NewRegistry()
+	reg.RecordRunStarted()
+	reg.RecordRunFinished("completed")
+	reg.RecordSecretHandleCreated(2)
+	reg.RecordSecretHandleCleanup(2, true)
+	reg.RecordSecretHandleCleanup(1, false)
+	reg.RecordSecretContainerRejected()
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rr := httptest.NewRecorder()
+	reg.Handler().ServeHTTP(rr, req)
+
+	body := rr.Body.String()
+	if !strings.Contains(body, "flowd_runs_started_total 1\n") {
+		t.Fatalf("expected run started counter, got body:\n%s", body)
+	}
+	if !strings.Contains(body, `flowd_runs_finished_total{status="completed"} 1`) {
+		t.Fatalf("expected run finished counter, got body:\n%s", body)
+	}
+	if !strings.Contains(body, "flowd_secret_handles_created_total 2\n") {
+		t.Fatalf("expected secret handles created counter, got body:\n%s", body)
+	}
+	if !strings.Contains(body, "flowd_secret_handles_cleaned_total 3\n") {
+		t.Fatalf("expected secret handles cleaned counter, got body:\n%s", body)
+	}
+	if !strings.Contains(body, "flowd_secret_handle_errors_total 1\n") {
+		t.Fatalf("expected secret handle errors counter, got body:\n%s", body)
+	}
+	if !strings.Contains(body, "flowd_secret_container_rejected_total 1\n") {
+		t.Fatalf("expected secret container rejected counter, got body:\n%s", body)
 	}
 }

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -170,6 +170,8 @@ func templateRoute(path string) string {
 		return "/sources/{name}"
 	case path == "/events":
 		return "/events"
+	case path == "/events/stream":
+		return "/events/stream"
 	default:
 		return path
 	}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -38,9 +38,20 @@ func loggingMiddleware(cfg Config) Middleware {
 				slog.String("method", r.Method),
 				slog.String("path", r.URL.Path),
 			)
+			requestID := strings.TrimSpace(r.Header.Get("X-Request-ID"))
+			if requestID == "" {
+				requestID = strings.TrimSpace(r.Header.Get("X-Request-Id"))
+			}
+			if requestID != "" {
+				reqLogger = reqLogger.With(slog.String("request_id", requestID))
+				w.Header().Set("X-Request-ID", requestID)
+			}
 			meta := &requestctx.Metadata{}
 			ctx := requestctx.WithMetadata(r.Context(), meta)
 			ctx = requestctx.WithLogger(ctx, reqLogger)
+			if requestID != "" {
+				ctx = requestctx.WithRequestID(ctx, requestID)
+			}
 			next.ServeHTTP(recorder, r.WithContext(ctx))
 			effective, ok := requestctx.EffectiveProfile(ctx)
 			if !ok || effective == "" {
@@ -59,6 +70,14 @@ func loggingMiddleware(cfg Config) Middleware {
 			}
 			if runtime != "" {
 				attrs = append(attrs, slog.String("runtime.effective", runtime))
+			}
+			if requestID == "" {
+				if ctxRequestID, ok := requestctx.RequestID(ctx); ok {
+					requestID = ctxRequestID
+				}
+			}
+			if requestID != "" {
+				attrs = append(attrs, slog.String("request_id", requestID))
 			}
 			reqLogger.Info("request", attrs...)
 		})

--- a/internal/server/requestctx/requestctx.go
+++ b/internal/server/requestctx/requestctx.go
@@ -33,6 +33,22 @@ func Logger(ctx context.Context) *slog.Logger {
 	return logctx.Logger(ctx)
 }
 
+// WithScrubbedLogger wraps the request logger with a scrubber to redact sensitive data.
+func WithScrubbedLogger(ctx context.Context, scrub func(string) string) context.Context {
+	if scrub == nil {
+		return ctx
+	}
+	logger := logctx.Logger(ctx)
+	if logger == nil {
+		return ctx
+	}
+	wrapped := logctx.WrapLogger(logger, scrub)
+	if wrapped == logger {
+		return ctx
+	}
+	return logctx.WithLogger(ctx, wrapped)
+}
+
 // WithEffectiveProfile annotates the context with the effective security profile.
 func WithEffectiveProfile(ctx context.Context, profile string) context.Context {
 	if profile == "" {

--- a/internal/server/requestctx/requestctx.go
+++ b/internal/server/requestctx/requestctx.go
@@ -3,15 +3,15 @@ package requestctx
 import (
 	"context"
 	"log/slog"
+
+	"github.com/flowd-org/flowd/internal/observability/logctx"
 )
 
-type loggerKey struct{}
 type profileKey struct{}
 type metadataKey struct{}
 type principalKey struct{}
 
 var (
-	ctxLoggerKey    = &loggerKey{}
 	ctxProfileKey   = &profileKey{}
 	ctxMetadataKey  = &metadataKey{}
 	ctxPrincipalKey = &principalKey{}
@@ -25,19 +25,12 @@ type Metadata struct {
 
 // WithLogger stores the request-scoped logger in the context.
 func WithLogger(ctx context.Context, logger *slog.Logger) context.Context {
-	if logger == nil {
-		return ctx
-	}
-	return context.WithValue(ctx, ctxLoggerKey, logger)
+	return logctx.WithLogger(ctx, logger)
 }
 
 // Logger extracts the request-scoped logger from context, if present.
 func Logger(ctx context.Context) *slog.Logger {
-	if ctx == nil {
-		return nil
-	}
-	logger, _ := ctx.Value(ctxLoggerKey).(*slog.Logger)
-	return logger
+	return logctx.Logger(ctx)
 }
 
 // WithEffectiveProfile annotates the context with the effective security profile.

--- a/internal/server/requestctx/requestctx.go
+++ b/internal/server/requestctx/requestctx.go
@@ -19,8 +19,9 @@ var (
 
 // Metadata stores auxiliary request attributes for structured logging.
 type Metadata struct {
-	Runtime string
-	Route   string
+	Runtime   string
+	Route     string
+	RequestID string
 }
 
 // WithLogger stores the request-scoped logger in the context.
@@ -98,6 +99,29 @@ func WithRuntime(ctx context.Context, runtime string) context.Context {
 	}
 	meta.Runtime = runtime
 	return ctx
+}
+
+// WithRequestID annotates metadata with the request/correlation identifier.
+func WithRequestID(ctx context.Context, requestID string) context.Context {
+	if requestID == "" {
+		return ctx
+	}
+	meta := MetadataFromContext(ctx)
+	if meta == nil {
+		meta = &Metadata{}
+		ctx = context.WithValue(ctx, ctxMetadataKey, meta)
+	}
+	meta.RequestID = requestID
+	return ctx
+}
+
+// RequestID extracts the request/correlation identifier from metadata, if any.
+func RequestID(ctx context.Context) (string, bool) {
+	meta := MetadataFromContext(ctx)
+	if meta == nil || meta.RequestID == "" {
+		return "", false
+	}
+	return meta.RequestID, true
 }
 
 // Runtime extracts the runtime value recorded in metadata, if any.

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -242,11 +242,14 @@ func buildHandler(cfg Config, policyCtx *policy.Context, verifier policyverify.I
 		runGet.ServeHTTP(w, r)
 	}))
 	mux.Handle("/health/storage", storageHealth)
-	mux.Handle("/events", handlers.NewEventsHandler(handlers.EventsConfig{
+	eventsHandler := handlers.NewEventsHandler(handlers.EventsConfig{
 		RunStore:  runStore,
 		RunHub:    hub,
 		GlobalHub: globalHub,
-	}))
+		Journal:   journal,
+	})
+	mux.Handle("/events", eventsHandler)
+	mux.Handle("/events/stream", eventsHandler)
 
 	return chainMiddleware(mux,
 		metricsMiddleware(cfg),

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -194,7 +194,7 @@ func buildHandler(cfg Config, policyCtx *policy.Context, verifier policyverify.I
 		}
 		return sourcetoProvenance(src), true
 	}
-	runGet := handlers.NewRunGetHandler(runStore)
+	runGet := handlers.NewRunGetHandler(handlers.RunGetConfig{Store: runStore, DB: cfg.CoreDB})
 	runEvents := handlers.NewRunEventsHandler(runStore, hub, journal)
 	runEventsExport := handlers.NewRunEventsExportHandler(runStore, journal, cfg.ExtensionEnabled("export"))
 	storageHealth := handlers.NewStorageHealthHandler(cfg.CoreDB)

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -188,7 +188,7 @@ func TestRuleYKVHandlerIntegration(t *testing.T) {
 	if err := json.Unmarshal(disallowed.Body.Bytes(), &problem); err != nil {
 		t.Fatalf("decode forbidden problem: %v", err)
 	}
-	if problem["type"] != "https://flowd.dev/problems/namespace-forbidden" {
+	if problem["type"] != "https://flowd.org/problems/namespace-forbidden" {
 		t.Fatalf("expected namespace-forbidden problem, got %v", problem["type"])
 	}
 

--- a/internal/server/runstore/store.go
+++ b/internal/server/runstore/store.go
@@ -8,15 +8,16 @@ import (
 
 // Run represents the persisted metadata for a run.
 type Run struct {
-	ID         string         `json:"id"`
-	JobID      string         `json:"job_id"`
-	Status     string         `json:"status"`
-	StartedAt  time.Time      `json:"started_at"`
-	FinishedAt *time.Time     `json:"finished_at,omitempty"`
-	Result     map[string]any `json:"result,omitempty"`
-	Executor   string         `json:"executor,omitempty"`
-	Runtime    string         `json:"runtime,omitempty"`
-	Provenance map[string]any `json:"provenance,omitempty"`
+	ID              string         `json:"id"`
+	JobID           string         `json:"job_id"`
+	Status          string         `json:"status"`
+	StartedAt       time.Time      `json:"started_at"`
+	FinishedAt      *time.Time     `json:"finished_at,omitempty"`
+	Result          map[string]any `json:"result,omitempty"`
+	Executor        string         `json:"executor,omitempty"`
+	Runtime         string         `json:"runtime,omitempty"`
+	SecurityProfile string         `json:"security_profile,omitempty"`
+	Provenance      map[string]any `json:"provenance,omitempty"`
 }
 
 // Store keeps runs in memory for serve mode.

--- a/internal/server/runstore/store.go
+++ b/internal/server/runstore/store.go
@@ -18,6 +18,7 @@ type Run struct {
 	Runtime         string         `json:"runtime,omitempty"`
 	SecurityProfile string         `json:"security_profile,omitempty"`
 	Provenance      map[string]any `json:"provenance,omitempty"`
+	RequestID       string         `json:"request_id,omitempty"`
 }
 
 // Store keeps runs in memory for serve mode.

--- a/internal/server/sse/hub.go
+++ b/internal/server/sse/hub.go
@@ -75,7 +75,11 @@ func (h *Hub) Publish(runID string, ev Event) {
 // Subscribe registers a subscriber for a run and replays buffered events after the provided lastEventID.
 func (h *Hub) Subscribe(ctx context.Context, runID, lastEventID string) *Subscription {
 	stream := h.getOrCreateStream(runID)
-	ch := make(chan []byte, 32)
+	bufSize := 32
+	if h.cfg.MaxBufferSize > bufSize {
+		bufSize = h.cfg.MaxBufferSize
+	}
+	ch := make(chan []byte, bufSize)
 	subCtx, cancel := context.WithCancel(ctx)
 	stream.addSubscriber(subCtx, ch, h.cfg.KeepAliveInterval)
 	stream.replay(ch, lastEventID)
@@ -181,11 +185,16 @@ func (rs *runStream) replay(ch chan<- []byte, lastID string) {
 		return
 	}
 	start := 0
+	found := false
 	for i, ev := range rs.events {
 		if ev.ID == lastID {
 			start = i + 1
+			found = true
 			break
 		}
+	}
+	if !found {
+		return
 	}
 	for _, ev := range rs.events[start:] {
 		ch <- formatEvent(ev)

--- a/internal/server/sse/hub.go
+++ b/internal/server/sse/hub.go
@@ -2,7 +2,9 @@ package sse
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -12,6 +14,7 @@ const (
 	defaultKeepAliveInterval = 15 * time.Second
 	defaultBufferSize        = 1000
 	defaultRetention         = 5 * time.Minute
+	flowdEventName           = "flowd"
 )
 
 // Event represents an SSE payload delivered to subscribers.
@@ -20,6 +23,8 @@ type Event struct {
 	Event     string
 	Data      string
 	Timestamp time.Time
+	RunID     string
+	Tenant    string
 }
 
 // Config controls Hub behaviour.
@@ -66,6 +71,9 @@ func (h *Hub) Publish(runID string, ev Event) {
 	if ev.Timestamp.IsZero() {
 		ev.Timestamp = h.nowFn()
 	}
+	if ev.RunID == "" {
+		ev.RunID = runID
+	}
 
 	stream := h.getOrCreateStream(runID)
 	stored := stream.add(ev, h.cfg.MaxBufferSize, h.cfg.Retention, h.nowFn())
@@ -81,7 +89,7 @@ func (h *Hub) Subscribe(ctx context.Context, runID, lastEventID string) *Subscri
 	}
 	ch := make(chan []byte, bufSize)
 	subCtx, cancel := context.WithCancel(ctx)
-	stream.addSubscriber(subCtx, ch, h.cfg.KeepAliveInterval)
+	stream.addSubscriber(subCtx, ch, h.cfg.KeepAliveInterval, h.nowFn)
 	stream.replay(ch, lastEventID)
 	return &Subscription{
 		C:    ch,
@@ -119,6 +127,7 @@ type subscriber struct {
 	ch         chan<- []byte
 	keepAlive  time.Duration
 	keepTicker *time.Ticker
+	nowFn      func() time.Time
 }
 
 func newRunStream() *runStream {
@@ -135,6 +144,9 @@ func (rs *runStream) add(ev Event, maxSize int, retention time.Duration, now tim
 	rs.seq++
 	if ev.ID == "" {
 		ev.ID = fmt.Sprintf("%d", rs.seq)
+	}
+	if ev.Timestamp.IsZero() {
+		ev.Timestamp = now.UTC()
 	}
 	rs.events = append(rs.events, ev)
 
@@ -154,11 +166,15 @@ func (rs *runStream) add(ev Event, maxSize int, retention time.Duration, now tim
 	return ev
 }
 
-func (rs *runStream) addSubscriber(ctx context.Context, ch chan<- []byte, keepAlive time.Duration) {
+func (rs *runStream) addSubscriber(ctx context.Context, ch chan<- []byte, keepAlive time.Duration, nowFn func() time.Time) {
+	if nowFn == nil {
+		nowFn = time.Now
+	}
 	sub := &subscriber{
 		ctx:       ctx,
 		ch:        ch,
 		keepAlive: keepAlive,
+		nowFn:     nowFn,
 	}
 	rs.mu.Lock()
 	rs.subscribers[sub] = struct{}{}
@@ -240,7 +256,7 @@ func (s *subscriber) run(onClose func()) {
 			return
 		case <-s.keepTicker.C:
 			select {
-			case s.ch <- []byte(":keep-alive\n\n"):
+			case s.ch <- FormatHeartbeat(s.nowFn()):
 			default:
 			}
 		}
@@ -248,18 +264,90 @@ func (s *subscriber) run(onClose func()) {
 }
 
 func formatEvent(ev Event) []byte {
+	payload, err := EncodeEvent(ev)
+	if err != nil {
+		payload = []byte("event: " + flowdEventName + "\n" + "retry: 3000\n" + "data: {}\n\n")
+	}
+	return payload
+}
+
+type envelope struct {
+	Seq    int64     `json:"seq"`
+	TS     time.Time `json:"ts"`
+	Type   string    `json:"type"`
+	RunID  string    `json:"run_id,omitempty"`
+	Tenant string    `json:"tenant,omitempty"`
+	Data   any       `json:"data,omitempty"`
+}
+
+// EncodeEvent formats the event using the Core SoT v1.0.1 envelope and SSE framing.
+func EncodeEvent(ev Event) ([]byte, error) {
+	if ev.Timestamp.IsZero() {
+		ev.Timestamp = time.Now().UTC()
+	}
+	seq := parseEventSeq(ev.ID)
+	data := dataValue(ev.Data)
+	if data == nil && ev.Data != "" {
+		data = ev.Data
+	}
+	payload, err := json.Marshal(envelope{
+		Seq:    seq,
+		TS:     ev.Timestamp.UTC(),
+		Type:   ev.Event,
+		RunID:  ev.RunID,
+		Tenant: ev.Tenant,
+		Data:   data,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return formatPayload(ev.ID, payload), nil
+}
+
+// FormatHeartbeat returns the SSE heartbeat comment payload.
+func FormatHeartbeat(ts time.Time) []byte {
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	}
+	return []byte(fmt.Sprintf(":hb %s\n\n", ts.UTC().Format(time.RFC3339)))
+}
+
+func parseEventSeq(id string) int64 {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return 0
+	}
+	seq, err := strconv.ParseInt(id, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return seq
+}
+
+func dataValue(input string) any {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return nil
+	}
+	var raw json.RawMessage
+	if err := json.Unmarshal([]byte(input), &raw); err != nil {
+		return input
+	}
+	return raw
+}
+
+func formatPayload(id string, payload []byte) []byte {
 	var builder strings.Builder
-	if ev.ID != "" {
+	if strings.TrimSpace(id) != "" {
 		builder.WriteString("id: ")
-		builder.WriteString(ev.ID)
+		builder.WriteString(strings.TrimSpace(id))
 		builder.WriteByte('\n')
 	}
-	if ev.Event != "" {
-		builder.WriteString("event: ")
-		builder.WriteString(ev.Event)
-		builder.WriteByte('\n')
-	}
-	for _, line := range strings.Split(ev.Data, "\n") {
+	builder.WriteString("event: ")
+	builder.WriteString(flowdEventName)
+	builder.WriteByte('\n')
+	builder.WriteString("retry: 3000\n")
+	for _, line := range strings.Split(string(payload), "\n") {
 		builder.WriteString("data: ")
 		builder.WriteString(line)
 		builder.WriteByte('\n')

--- a/internal/server/sse/hub_test.go
+++ b/internal/server/sse/hub_test.go
@@ -22,12 +22,18 @@ func TestHubPublishSubscribeReplay(t *testing.T) {
 	sub := h.Subscribe(ctx, "run-1", "")
 	defer sub.Close()
 
-	h.Publish("run-1", Event{Event: "run.start", Data: `{"status":"queued"}`})
+	h.Publish("run-1", Event{Event: "run.started", Data: `{"status":"queued"}`})
 
 	select {
 	case payload := <-sub.C:
 		if got := string(payload); got == "" || !strings.HasPrefix(got, "id: 1\n") {
 			t.Fatalf("expected payload with id 1, got %q", got)
+		}
+		if !strings.Contains(string(payload), "event: flowd") {
+			t.Fatalf("expected flowd envelope, got %q", payload)
+		}
+		if !strings.Contains(string(payload), "retry: 3000") {
+			t.Fatalf("expected retry directive, got %q", payload)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for event")
@@ -38,8 +44,8 @@ func TestHubReplayFromLastEventID(t *testing.T) {
 	h := New(Config{KeepAliveInterval: 0})
 	h.nowFn = func() time.Time { return time.Unix(0, 0) }
 
-	h.Publish("run-2", Event{ID: "1", Event: "run.start", Data: "{}"})
-	h.Publish("run-2", Event{ID: "2", Event: "step.log", Data: `{"msg":"hello"}`})
+	h.Publish("run-2", Event{ID: "1", Event: "run.started", Data: "{}"})
+	h.Publish("run-2", Event{ID: "2", Event: "step.output", Data: `{"msg":"hello"}`})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -50,6 +56,9 @@ func TestHubReplayFromLastEventID(t *testing.T) {
 	case payload := <-sub.C:
 		if want := "id: 2\n"; string(payload)[:len(want)] != want {
 			t.Fatalf("expected replay starting at id 2, got %q", payload)
+		}
+		if !strings.Contains(string(payload), "\"type\":\"step.output\"") {
+			t.Fatalf("expected step.output type in payload, got %q", payload)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for replay")
@@ -66,8 +75,8 @@ func TestHubKeepAlive(t *testing.T) {
 
 	select {
 	case payload := <-sub.C:
-		if string(payload) != ":keep-alive\n\n" {
-			t.Fatalf("expected keep-alive payload, got %q", payload)
+		if !strings.HasPrefix(string(payload), ":hb ") {
+			t.Fatalf("expected heartbeat payload, got %q", payload)
 		}
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("timeout waiting for keep-alive")

--- a/internal/server/sse/hub_test.go
+++ b/internal/server/sse/hub_test.go
@@ -2,6 +2,8 @@ package sse
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -78,7 +80,83 @@ func TestHubKeepAlive(t *testing.T) {
 		if !strings.HasPrefix(string(payload), ":hb ") {
 			t.Fatalf("expected heartbeat payload, got %q", payload)
 		}
+		if _, err := parseHeartbeatTimestamp(string(payload)); err != nil {
+			t.Fatalf("expected RFC3339 heartbeat timestamp, got %q: %v", payload, err)
+		}
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("timeout waiting for keep-alive")
 	}
+}
+
+func TestEncodeEventEnvelope(t *testing.T) {
+	ts := time.Date(2026, 1, 10, 10, 0, 15, 0, time.UTC)
+	payload, err := EncodeEvent(Event{
+		ID:        "12",
+		Event:     "run.started",
+		Data:      `{"status":"queued"}`,
+		Timestamp: ts,
+		RunID:     "run-123",
+		Tenant:    "tenant-a",
+	})
+	if err != nil {
+		t.Fatalf("unexpected encode error: %v", err)
+	}
+	text := string(payload)
+	if !strings.Contains(text, "event: flowd") {
+		t.Fatalf("expected flowd envelope, got %q", text)
+	}
+	if !strings.Contains(text, "retry: 3000") {
+		t.Fatalf("expected retry directive, got %q", text)
+	}
+	if !strings.HasPrefix(text, "id: 12\n") {
+		t.Fatalf("expected id 12 prefix, got %q", text)
+	}
+
+	dataJSON := extractSSEData(text)
+	var got struct {
+		Seq    int64           `json:"seq"`
+		TS     time.Time       `json:"ts"`
+		Type   string          `json:"type"`
+		RunID  string          `json:"run_id"`
+		Tenant string          `json:"tenant"`
+		Data   json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(dataJSON), &got); err != nil {
+		t.Fatalf("failed to unmarshal data envelope: %v (data=%q)", err, dataJSON)
+	}
+	if got.Seq != 12 {
+		t.Fatalf("expected seq 12, got %d", got.Seq)
+	}
+	if !got.TS.Equal(ts) {
+		t.Fatalf("expected timestamp %s, got %s", ts.Format(time.RFC3339), got.TS.Format(time.RFC3339))
+	}
+	if got.Type != "run.started" {
+		t.Fatalf("expected type run.started, got %q", got.Type)
+	}
+	if got.RunID != "run-123" {
+		t.Fatalf("expected run_id run-123, got %q", got.RunID)
+	}
+	if got.Tenant != "tenant-a" {
+		t.Fatalf("expected tenant tenant-a, got %q", got.Tenant)
+	}
+}
+
+func parseHeartbeatTimestamp(payload string) (time.Time, error) {
+	payload = strings.TrimSpace(payload)
+	if !strings.HasPrefix(payload, ":hb ") {
+		return time.Time{}, fmt.Errorf("missing :hb prefix")
+	}
+	stamp := strings.TrimPrefix(payload, ":hb ")
+	stamp = strings.TrimSpace(stamp)
+	return time.Parse(time.RFC3339, stamp)
+}
+
+func extractSSEData(payload string) string {
+	var builder strings.Builder
+	for _, line := range strings.Split(payload, "\n") {
+		if strings.HasPrefix(line, "data: ") {
+			builder.WriteString(strings.TrimPrefix(line, "data: "))
+		}
+	}
+	return builder.String()
 }

--- a/internal/types/arguments.go
+++ b/internal/types/arguments.go
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 package types
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Legacy/compat definition for simple maps in config.yaml
 type ArgumentDefinition struct {
 	Type        string      `yaml:"type"`
@@ -29,4 +34,41 @@ type Arg struct {
 
 type ArgSpec struct {
 	Args []Arg `yaml:"args" json:"args"`
+}
+
+var reservedArgNames = map[string]struct{}{
+	"help":        {},
+	"h":           {},
+	"version":     {},
+	"dry-run":     {},
+	"verbose":     {},
+	"quiet":       {},
+	"strict":      {},
+	"on-error":    {},
+	"report":      {},
+	"report-file": {},
+	"profile":     {},
+	"json":        {},
+	"server":      {},
+}
+
+// ValidateArgName validates arg names against reserved tokens and unsafe characters.
+func ValidateArgName(name string) error {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return fmt.Errorf("name is required")
+	}
+	if strings.ContainsAny(trimmed, " \t\n\r") {
+		return fmt.Errorf("name must not contain whitespace")
+	}
+	if strings.HasPrefix(trimmed, "-") {
+		return fmt.Errorf("name must not start with '-'")
+	}
+	if strings.Contains(trimmed, "=") {
+		return fmt.Errorf("name must not contain '='")
+	}
+	if _, ok := reservedArgNames[strings.ToLower(trimmed)]; ok {
+		return fmt.Errorf("name is reserved")
+	}
+	return nil
 }

--- a/internal/types/orchestrator.go
+++ b/internal/types/orchestrator.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package types
+
+// StartRunRequest is a shared, server-agnostic request shape for starting a run.
+// It is intentionally minimal; follow-up tasks will extend it as orchestration is rewired.
+type StartRunRequest struct {
+	JobID     string                 `json:"job_id"`
+	ScriptDir string                 `json:"script_dir,omitempty"`
+	Args      map[string]interface{} `json:"args,omitempty"`
+}

--- a/internal/types/orchestrator.go
+++ b/internal/types/orchestrator.go
@@ -7,4 +7,5 @@ type StartRunRequest struct {
 	JobID     string                 `json:"job_id"`
 	ScriptDir string                 `json:"script_dir,omitempty"`
 	Args      map[string]interface{} `json:"args,omitempty"`
+	RequestID string                 `json:"request_id,omitempty"`
 }

--- a/internal/types/plan.go
+++ b/internal/types/plan.go
@@ -12,6 +12,7 @@ type Plan struct {
 	Outputs          map[string]any         `json:"outputs"`
 	SecurityProfile  string                 `json:"security_profile"`
 	PolicyFindings   []Finding              `json:"policy_findings"`
+	RequestID        string                 `json:"request_id,omitempty"`
 	ImageTrust       *ImageTrustPreview     `json:"image_trust,omitempty"`
 	Steps            []PlanStepPreview      `json:"steps"`
 	Provenance       map[string]interface{} `json:"provenance"`

--- a/internal/types/plan.go
+++ b/internal/types/plan.go
@@ -9,11 +9,12 @@ type Plan struct {
 	ExecutorPreview  map[string]interface{} `json:"executor_preview,omitempty"`
 	Requirements     *PlanRequirements      `json:"requirements,omitempty"`
 	ResolvedArgs     map[string]interface{} `json:"resolved_args,omitempty"`
-	SecurityProfile  string                 `json:"security_profile,omitempty"`
-	PolicyFindings   []Finding              `json:"policy_findings,omitempty"`
+	Outputs          map[string]any         `json:"outputs"`
+	SecurityProfile  string                 `json:"security_profile"`
+	PolicyFindings   []Finding              `json:"policy_findings"`
 	ImageTrust       *ImageTrustPreview     `json:"image_trust,omitempty"`
-	Steps            []PlanStepPreview      `json:"steps,omitempty"`
-	Provenance       map[string]interface{} `json:"provenance,omitempty"`
+	Steps            []PlanStepPreview      `json:"steps"`
+	Provenance       map[string]interface{} `json:"provenance"`
 }
 
 type PlanRequirements struct {

--- a/scripts/demo/100_main.sh
+++ b/scripts/demo/100_main.sh
@@ -15,7 +15,7 @@ fi
 
 echo "demo: $greeting"
 
-if [ "${FLWD_ARGS_JSON:-}" != "" ]; then
+if [ "${FLOWD_ARGS_JSON:-}" != "" ] || [ "${FLWD_ARGS_JSON:-}" != "" ]; then
     echo "demo: arguments captured (see events/artifacts)"
 fi
 


### PR DESCRIPTION
# SOT-101: Core SoT v1.0.1 alignment (runs/persistence/SSE/ArgSpec)

## Summary
Align run orchestration, persistence-backed runs/journal/idempotency, SSE endpoint set + envelope/replay semantics, ArgSpec binding, policy findings, observability layering, and secret-handle/no-leak guarantees to Core SoT v1.0.1. Includes docs updates for SSE/idempotency/secrets/persistence.

## Key changes
- Engine orchestration + binding + plan: `internal/engine/*`, `internal/types/*`
- Persistence/journal/idempotency: `internal/coredb/*`, `internal/server/handlers/*`
- SSE endpoints/envelope/replay: `internal/server/handlers/events_global.go`, `run_events.go`, `internal/server/sse/*`
- Secrets: `internal/secrets/*`, executor env + orchestration integration
- Observability + metrics: `internal/observability/*`, `internal/metrics/*`, `internal/server/metrics/*`
- Docs: `docs/*.md`

## Docs
- `docs/api-reference.md`
- `docs/configuration.md`
- `docs/container-executor.md`
- `docs/job-configuration.md`
- `docs/serve-mode.md`

## Testing
- `go test ./...` (passed)

## Related issues
- #1 — Decouple core tracing/logging from server request context
- #2 — Introduce a single engine-owned run orchestration entrypoint (interfaces + wiring)
- #3 — Rewire CLI run execution to call the shared engine orchestration
- #4 — Rewire HTTP POST /runs to call the shared engine orchestration
- #5 — Add CoreDB run records store (schema + store methods) and switch list/read to persisted source of truth
- #6 — Ensure all run lifecycle + output events are appended to CoreDB journal for replay/resume
- #7 — Bring HTTP idempotency into Core SoT v1.0.1 conformance (TTL defaults/bounds + replay payload)
- #9 — Implement CoreDB journal retention/eviction so storage growth is bounded and stale-cursor bounds are deterministic
- #10 — Update SSE formatting to Core SoT v1.0.1 envelope + heartbeat + resume token
- #11 — Implement global SSE endpoint `GET /events/stream` and alias `GET /events` using the shared SSE streamer
- #12 — Align RFC7807 problem type URLs to Core SoT v1.0.1 for idempotency + SSE stale cursor
- #15 — Implement minimal policy findings plumbing and emit `policy.denied` SSE events on denial
- …plus 39 additional task issues created for this work.

## Notes / risks
- Must-fix:
  - None.
- Should-fix:
  - None.

<details>
<summary>Git context</summary>

```text
Diffstat vs main:
cmd/bootstrap.go                                   | 106 +++-
 cmd/plan.go                                        |   2 +-
 docs/api-reference.md                              |  96 +++-
 docs/configuration.md                              |   7 +
 docs/container-executor.md                         |   6 +-
 docs/job-configuration.md                          |  20 +
 docs/serve-mode.md                                 |  25 +
 internal/argsloader/loader.go                      |   3 +
 internal/coredb/idempotency.go                     |  60 +++
 internal/coredb/journal.go                         | 100 +++-
 internal/coredb/journal_test.go                    | 170 ++++++-
 internal/coredb/migrations.go                      |  46 ++
 internal/coredb/runs.go                            | 207 ++++++++
 internal/e2e/cli_e2e_test.go                       |  32 +-
 internal/engine/bind_map.go                        | 157 ++++++
 internal/engine/engine.go                          | 142 +++++-
 internal/engine/engine_test.go                     |  57 +++
 internal/engine/exec_mode.go                       |  25 +
 internal/engine/layering_guard_test.go             |  88 ++++
 internal/engine/orchestrator.go                    | 134 +++++
 internal/engine/orchestrator_interfaces.go         |  52 ++
 internal/engine/orchestrator_test.go               |  79 +++
 internal/engine/plan.go                            |  14 +-
 internal/engine/plan_test.go                       |   6 +
 internal/engine/secrets.go                         |  94 ++++
 internal/events/emitter.go                         |  10 +-
 internal/events/journal_sink.go                    | 102 ++++
 internal/events/redact.go                          |   4 +-
 internal/events/redact_test.go                     |  10 +-
 internal/executor/env_test.go                      |  88 ++++
 internal/executor/executor.go                      |  28 +-
 internal/executor/profile.go                       |  22 +
 internal/metrics/persistence.go                    |  82 ++-
 internal/metrics/sink.go                           |  72 +++
 internal/metrics/sse.go                            |  24 +-
 internal/observability/logctx/logctx.go            | 132 +++++
 internal/observability/logctx/logctx_test.go       | 116 +++++
 internal/observability/tracing/tracing.go          |   4 +-
 internal/secrets/buffer.go                         |  45 ++
 internal/secrets/buffer_test.go                    |  24 +
 internal/secrets/errors.go                         |  32 ++
 internal/secrets/handle_posix.go                   |  82 +++
 internal/secrets/handle_posix_test.go              |  41 ++
 internal/secrets/handle_windows.go                 |  57 +++
 internal/secrets/handle_windows_test.go            |  38 ++
 internal/secrets/secrets.go                        | 154 ++++++
 internal/secrets/secrets_test.go                   | 109 ++++
 internal/server/authz/scopes.go                    |   2 +
 internal/server/authz/scopes_test.go               |   1 +
 internal/server/handlers/alias_problem.go          |   2 +
 internal/server/handlers/dag_plan.go               |  15 +-
 internal/server/handlers/events_global.go          | 149 +++++-
 internal/server/handlers/events_global_test.go     | 233 ++++++++-
 internal/server/handlers/health_storage.go         |   4 +-
 internal/server/handlers/idempotency_hash_test.go  |  37 ++
 internal/server/handlers/idempotency_store.go      |  70 +++
 internal/server/handlers/journal_sink.go           |   3 +
 internal/server/handlers/kv.go                     |   2 +-
 internal/server/handlers/oci_plan.go               |  17 +-
 internal/server/handlers/persistence_scrub.go      | 278 ++++++++++
 internal/server/handlers/plans.go                  |  92 ++--
 internal/server/handlers/plans_test.go             |  48 ++
 internal/server/handlers/problem_scrub.go          |  51 ++
 internal/server/handlers/request_id_test.go        | 109 ++++
 internal/server/handlers/run_events.go             |  77 +--
 internal/server/handlers/run_events_export.go      |   2 +-
 internal/server/handlers/run_events_export_test.go |  12 +-
 internal/server/handlers/run_events_test.go        | 209 +++++++-
 internal/server/handlers/run_get.go                |  26 +-
 internal/server/handlers/run_payload.go            |  38 +-
 internal/server/handlers/runs.go                   | 558 +++++++++++++++------
 internal/server/handlers/runs_test.go              | 367 +++++++++++++-
 internal/server/handlers/runtime_helpers.go        |   4 +-
 internal/server/handlers/sources.go                |  71 +--
 internal/server/handlers/sse_sink.go               |  10 +-
 internal/server/metrics/metrics.go                 | 191 ++++++-
 internal/server/metrics/metrics_test.go            |  72 +++
 internal/server/middleware.go                      |  21 +
 internal/server/requestctx/requestctx.go           |  57 ++-
 internal/server/router.go                          |   9 +-
 internal/server/router_test.go                     |   2 +-
 internal/server/runstore/store.go                  |  20 +-
 internal/server/sse/hub.go                         | 121 ++++-
 internal/server/sse/hub_test.go                    |  97 +++-
 internal/types/arguments.go                        |  42 ++
 internal/types/orchestrator.go                     |  11 +
 internal/types/plan.go                             |  10 +-
 scripts/demo/100_main.sh                           |   2 +-
 88 files changed, 5651 insertions(+), 495 deletions(-)

Commits:
653b09a [T-020-T-022, T-028-T-029 & T-053] Documentation updates (issues #46, #47, #48, #49, #50 & #51)
0b8c0a1 [T-035] Add/confirm metrics for idempotency, journal, SSE, run lifecycle, and secret-handle lifecycle (issue #44)
c5280aa [T-034] Implement request ID propagation/persistence (X-Request-ID) across CLI + HTTP orchestration  (issue #43)
fed3664 [T-031] Align Plan output schema with Core SoT v1.0.1 (provenance, steps, outputs, security profile, policy findings) (issue #42)
1e388e1 [T-039 - T-042] Integration test: SSE resume works across process restart with persisted journal & Add tests that idempotency replay storage never persists secret values or secret-handle paths (issues #40 & #41)
47da941 [T-038] Add tests that exercise journal retention/eviction behavior and ensure bounds remain consistent (issue #39)
a37e178 [T-018] Add a guardrail test/check to prevent core packages importing internal/server/* (issue #38)
a66d91d [T-016] Integration test: run-scoped SSE resume via Last-Event-ID backed by persisted journal (issue #37)
2a35a23 [T-015] Integration test: POST /runs idempotency replay vs conflict behavior (CoreDB-backed) (issue #36)
c13c322 [T-050] Integration test: run-scoped SSE invalid Last-Event-ID returns 400  (issue #35)
40d898f [T-026] Unit tests for executor env: secrets never exported; handles only (issue #34)
d0e4343 [T-010 - T-013] Update redaction tests to assert 80688REDACTED80688 and enforce non-leak invariants, Add deterministic canonical JSON hashing tests for idempotency, Unit tests for idempotency TTL default (24h) and max bound (72h) & Unit tests for SSE envelope formatting and heartbeat comment shape (issues #30, #31, #32 & #33)
e664669 [T-048] Ensure logs/traces never include secret values or secret-handle paths (issue #29)
b45c299 [T-049] Ensure RFC7807 errors never leak secrets or secret-handle paths (all failure modes) (issue #28)
a86ec51 [T-047] Prevent secret values and secret-handle paths from being persisted (runs/journal/idempotency) (issue #27)
82fc062 [T-032] Centralize redaction utilities and enforce 80688REDACTED80688 marker on user-visible outputs (issue #26)
1e20c75 [T-024] Enforce executor env contract: no secret values in env vars; deliver secret handles via SoT channel (issue #25)
00d03d9 [T-023] Create secret handles for secret args during orchestration (no persistence; cleanup on completion) (issue #24)
83dde12 [T-025] Unit tests for file-based secret handle lifecycle (0600 perms + cleanup) (issue #20)
aa94846 [T-044 - T-046] POSIX secret consumption: unlink-on-open and fd-backed handle path strategy (issue #22) & Windows secret consumption: delete-on-close semantics (build-tagged) (issue #23) & Add a zeroizable secret buffer helper and use it on all secret value handling paths (issue #21)
2c72b98 [T-019] Add file-based secret handle module (base dir + perms + janitor; no path leakage) (issue #19)
8bf76af [T-036] Resolve executor env naming drift: write FLOWD_ARGS_JSON, keep FLWD_ARGS_JSON as an alias (issue #18)
7972b71 [T-030] Expand ArgSpec validation/binding to meet Core SoT v1.0.1 (arrays/objects/reserved names/errors) (issue #17)
cc274e5 [T-009 & T-027] Implement minimal policy findings plumbing and emit policy.denied SSE events on denial (issue #15) & Integration test: policy denial emits policy.denied SSE event (persisted and live) (issue #16)
f06b072 [T-052 & T-054] Integration tests: global SSE (/events/stream) and alias (/events) resume + stale cursor behavior (issue #13) & Integration tests: global SSE invalid Last-Event-ID returns 400 (issue #14)
797fdf7 [T-033] Align RFC7807 problem type URLs to Core SoT v1.0.1 for idempotency + SSE stale cursor (issue #12)
0b737e3 [T-008 & T-051] Update SSE formatting to Core SoT v1.0.1 envelope + heartbeat + resume token (issue #10) & Implement global SSE endpoint GET /events/stream and alias GET /events using the shared SSE streamer (issue #11)
bb0e30d [T-037] Implement CoreDB journal retention/eviction so storage growth is bounded and stale-cursor bounds are deterministic (issue #9)
b835bdb [T-040] Validate CoreDB transaction semantics needed for atomic journal eviction+append (issue #8)
e519210 [T-007] Bring HTTP idempotency into Core SoT v1.0.1 conformance (TTL defaults/bounds + replay payload) (issue #7)
494283c [T-006] Ensure all run lifecycle + output events are appended to CoreDB journal for replay/resume (issue #6)
b6de35c [T-005] Add CoreDB run records store (schema + store methods) and switch list/read to persisted source of truth (issue #5)
219b9d3 [T-003 & T-004] Rewire CLI run execution to call the shared engine orchestration (issue #3) & Rewire HTTP POST /runs to call the shared engine orchestration (issue #4)
2d08dac [T-002] Introduce a single engine-owned run orchestration entrypoint (interfaces + wiring) (issue #2)
5ac7865 T-001 decouple observability/metrics from server context (issue #1)
```

</details>

