### PR TITLE
M1/PR1 identity spine (tenants + sources + job identity)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -43,23 +43,22 @@ Job IDs are always returned as canonical slash IDs. When a job is defined at the
 
 **Response:**
 ```json
-{
-  "jobs": [
-    {
-      "id": "backup/daily",
-      "name": "daily",
-      "namespace": "backup",
-      "version": "1.0.0",
-      "description": "Daily backup job",
-      "tenant": "default",
-      "origin": {
-        "source_kind": "fs",
-        "source_name": "local-fs"
-      },
-      "source": "local-fs"
+[
+  {
+    "id": "backup/daily",
+    "name": "backup/daily",
+    "tenant": "default",
+    "origin": {
+      "source_kind": "fs",
+      "source_name": "local"
+    },
+    "description": "Daily backup job",
+    "source": {
+      "name": "local-fs",
+      "type": "local"
     }
-  ]
-}
+  }
+]
 ```
 
 #### Get Job Details
@@ -161,7 +160,7 @@ Job references are input-compatible (aliases, existing dot-form IDs, and case-in
 **Response:**
 ```json
 {
-  "run_id": "run_01HX...",
+  "id": "run_01HX...",
   "job_id": "backup/daily",
   "tenant": "default",
   "origin": {
@@ -169,7 +168,7 @@ Job references are input-compatible (aliases, existing dot-form IDs, and case-in
     "source_name": "local-fs"
   },
   "status": "running",
-  "created_at": "2024-01-15T10:30:00Z"
+  "started_at": "2024-01-15T10:30:00Z"
 }
 ```
 
@@ -189,23 +188,20 @@ Returns a list of all runs.
 
 **Response:**
 ```json
-{
-  "runs": [
-    {
-      "run_id": "run_01HX...",
-      "job_id": "backup/daily",
-      "tenant": "default",
-      "origin": {
-        "source_kind": "fs",
-        "source_name": "local-fs"
-      },
-      "status": "success",
-      "created_at": "2024-01-15T10:30:00Z",
-      "finished_at": "2024-01-15T10:35:00Z"
-    }
-  ],
-  "total": 42
-}
+[
+  {
+    "id": "run_01HX...",
+    "job_id": "backup/daily",
+    "tenant": "default",
+    "origin": {
+      "source_kind": "fs",
+      "source_name": "local-fs"
+    },
+    "status": "success",
+    "started_at": "2024-01-15T10:30:00Z",
+    "finished_at": "2024-01-15T10:35:00Z"
+  }
+]
 ```
 
 #### Get Run Details
@@ -219,7 +215,7 @@ Returns detailed information about a specific run.
 **Response:**
 ```json
 {
-  "run_id": "run_01HX...",
+  "id": "run_01HX...",
   "job_id": "backup/daily",
   "tenant": "default",
   "origin": {
@@ -227,11 +223,8 @@ Returns detailed information about a specific run.
     "source_name": "local-fs"
   },
   "status": "success",
-  "created_at": "2024-01-15T10:30:00Z",
+  "started_at": "2024-01-15T10:30:00Z",
   "finished_at": "2024-01-15T10:35:00Z",
-  "args": {
-    "target": "/mnt/backup"
-  },
   "result": {
     "value": {
       "files_backed_up": 1234,

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -53,10 +53,10 @@ Job IDs are always returned as canonical slash IDs. When a job is defined at the
       "source_name": "local"
     },
     "description": "Daily backup job",
-  "source": {
-    "name": "local-fs",
-    "type": "local"
-  }
+    "source": {
+      "name": "local-fs",
+      "type": "local"
+    }
   }
 ]
 ```

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -53,10 +53,10 @@ Job IDs are always returned as canonical slash IDs. When a job is defined at the
       "source_name": "local"
     },
     "description": "Daily backup job",
-    "source": {
-      "name": "local-fs",
-      "type": "local"
-    }
+  "source": {
+    "name": "local-fs",
+    "type": "local"
+  }
   }
 ]
 ```
@@ -92,7 +92,9 @@ Returns detailed information about a specific job, including its configuration a
     },
     "required": ["target"]
   },
-  "source": "local-fs"
+  "source": {
+    "name": "local-fs"
+  }
 }
 ```
 
@@ -144,7 +146,7 @@ Job references are input-compatible (aliases, existing dot-form IDs, and case-in
     "target": "/mnt/backup"
   },
   "tenant": "default",
-  "async": true
+  "source": {"name": "local-fs"}
 }
 ```
 
@@ -361,8 +363,8 @@ Returns system information and configuration.
   "sources": [
     {
       "name": "local-fs",
-      "type": "fs",
-      "path": "/opt/flwd/jobs"
+      "type": "local",
+      "ref": "/opt/flwd/jobs"
     }
   ],
   "extensions": ["tui", "mcp"]

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -35,6 +35,8 @@ GET /api/v1/jobs
 
 Returns a list of all discovered jobs across all sources.
 
+Job IDs are always returned as canonical slash IDs. When a job is defined at the source root and `mountPath` is `.`, the canonical job ID is the empty string (`""`).
+
 **Query Parameters:**
 - `source` (optional): Filter by source name
 - `namespace` (optional): Filter by namespace
@@ -49,6 +51,11 @@ Returns a list of all discovered jobs across all sources.
       "namespace": "backup",
       "version": "1.0.0",
       "description": "Daily backup job",
+      "tenant": "default",
+      "origin": {
+        "source_kind": "fs",
+        "source_name": "local-fs"
+      },
       "source": "local-fs"
     }
   ]
@@ -71,6 +78,11 @@ Returns detailed information about a specific job, including its configuration a
   "namespace": "backup",
   "version": "1.0.0",
   "description": "Daily backup job",
+  "tenant": "default",
+  "origin": {
+    "source_kind": "fs",
+    "source_name": "local-fs"
+  },
   "args": {
     "type": "object",
     "properties": {
@@ -95,6 +107,8 @@ POST /api/v1/runs
 
 Creates and executes a new run of a job.
 
+Job references are input-compatible (aliases, existing dot-form IDs, and case-insensitive slash IDs), but responses, persistence, SSE, and journal entries always use canonical slash IDs.
+
 ##### Idempotency
 
 `POST /api/v1/runs` requires an idempotency key so clients can safely retry without duplicate effects.
@@ -112,6 +126,9 @@ Creates and executes a new run of a job.
 
 **Replay behavior**
 - If the same `Idempotency-Key` and request body are replayed after a successful run creation, the server returns the cached response and sets `Idempotent-Replay: true`.
+
+**Tenant scoping**
+- Idempotency keys are scoped by the resolved tenant. The same key in different tenants does not collide.
 
 **Failure modes (RFC7807)**
 - **409 Conflict** — key reuse with a different request body or hash mismatch:
@@ -132,11 +149,25 @@ Creates and executes a new run of a job.
 }
 ```
 
+**Tenant resolution rules (summary)**
+- If a principal tenant claim is present, it is authoritative.
+- If both a principal tenant and a request `tenant` are present and differ, the request is rejected (RFC7807).
+- If no principal tenant is available, `tenant` defaults to `default` when omitted.
+- If the principal exists but has no tenant claim, treat it as "no principal tenant" for resolution.
+
+**Root job aliases**
+- If the resolved canonical job ID is `""`, `job_id` may be sent as `""`, `"."`, or `"/"` and will be normalized to `""`.
+
 **Response:**
 ```json
 {
   "run_id": "run_01HX...",
   "job_id": "backup/daily",
+  "tenant": "default",
+  "origin": {
+    "source_kind": "fs",
+    "source_name": "local-fs"
+  },
   "status": "running",
   "created_at": "2024-01-15T10:30:00Z"
 }
@@ -163,6 +194,11 @@ Returns a list of all runs.
     {
       "run_id": "run_01HX...",
       "job_id": "backup/daily",
+      "tenant": "default",
+      "origin": {
+        "source_kind": "fs",
+        "source_name": "local-fs"
+      },
       "status": "success",
       "created_at": "2024-01-15T10:30:00Z",
       "finished_at": "2024-01-15T10:35:00Z"
@@ -185,6 +221,11 @@ Returns detailed information about a specific run.
 {
   "run_id": "run_01HX...",
   "job_id": "backup/daily",
+  "tenant": "default",
+  "origin": {
+    "source_kind": "fs",
+    "source_name": "local-fs"
+  },
   "status": "success",
   "created_at": "2024-01-15T10:30:00Z",
   "finished_at": "2024-01-15T10:35:00Z",
@@ -367,7 +408,7 @@ All SSE endpoints use a single `flowd` envelope and a fixed retry hint:
 event: flowd
 retry: 3000
 id: 42
-data: {"seq":42,"ts":"2026-01-10T10:00:15Z","type":"run.output","run_id":"run_01HX...","tenant":"default","data":{...}}
+data: {"seq":42,"ts":"2026-01-10T10:00:15Z","type":"run.output","run_id":"run_01HX...","tenant":"default","origin":{"source_kind":"fs","source_name":"local-fs"},"data":{...}}
 ```
 
 Heartbeat comments are emitted at least every 15 seconds in the form:

--- a/docs/container-executor.md
+++ b/docs/container-executor.md
@@ -72,7 +72,7 @@ $ curl -s -X POST http://127.0.0.1:8080/runs \
     -H 'Authorization: Bearer dev-token' \
     -H 'Content-Type: application/json' \
     -d '{
-          "job":"demo-container",
+          "job_id":"demo-container",
           "args":{"name":"Alice"}
         }' | jq
 ```

--- a/docs/oci-addons.md
+++ b/docs/oci-addons.md
@@ -46,7 +46,7 @@ $ curl -s -X POST http://127.0.0.1:8080/plans \
     -H 'Authorization: Bearer dev-token' \
     -H 'Content-Type: application/json' \
     -d '{
-          "job":"addon/hello-world",
+          "job_id":"addon/hello-world",
           "args":{"name":"Alice"}
         }'
 ```

--- a/docs/serve-mode.md
+++ b/docs/serve-mode.md
@@ -46,7 +46,7 @@ Plan a job:
 $ curl -s -X POST http://127.0.0.1:8080/plans \
     -H 'Authorization: Bearer dev-token' \
     -H 'Content-Type: application/json' \
-    -d '{"job":"hello-world","args":{"name":"Alice"}}' | jq
+    -d '{"job_id":"hello-world","args":{"name":"Alice"}}' | jq
 ```
 
 Submit a run:
@@ -55,7 +55,7 @@ Submit a run:
 $ curl -s -X POST http://127.0.0.1:8080/runs \
     -H 'Authorization: Bearer dev-token' \
     -H 'Content-Type: application/json' \
-    -d '{"job":"hello-world","args":{"name":"Alice"}}' | jq
+    -d '{"job_id":"hello-world","args":{"name":"Alice"}}' | jq
 ```
 
 Stream events for a run:

--- a/docs/sources-structure.md
+++ b/docs/sources-structure.md
@@ -27,17 +27,15 @@ Points to a local directory containing jobs:
 ```yaml
 sources:
   - name: "local-ops"
-    type: "fs"
-    path: "/opt/flwd/jobs"
-    mountPath: "ops"
+    type: "local"
+    ref: "/opt/flwd/jobs"
     watch: true  # Auto-reload on changes
 ```
 
 **Fields:**
 - `name`: Unique identifier for the source
-- `type`: Must be `"fs"`
-- `path`: Absolute path to the jobs directory
-- `mountPath`: Prefix for job IDs (e.g., `ops/backup`)
+- `type`: Must be `"local"`
+- `ref`: Absolute path to the jobs directory
 - `watch`: Enable filesystem watching for auto-reload
 
 ### Git Source
@@ -50,7 +48,6 @@ sources:
     type: "git"
     url: "https://github.com/org/flwd-jobs.git"
     ref: "main"
-    mountPath: "shared"
     pull_policy: "on-run"
     auto_sync: true
     poll_interval: "5m"
@@ -61,7 +58,6 @@ sources:
 - `type`: Must be `"git"`
 - `url`: Git repository URL
 - `ref`: Branch, tag, or commit SHA
-- `mountPath`: Prefix for job IDs
 - `pull_policy`: When to pull updates (`on-run`, `manual`, `disabled`)
 - `auto_sync`: Periodically sync to latest commit (for branches)
 - `poll_interval`: How often to check for updates
@@ -74,15 +70,13 @@ Loads jobs from OCI container images:
 sources:
   - name: "backup-addon"
     type: "oci"
-    image: "ghcr.io/org/backup-tools:v1.0.0@sha256:..."
-    mountPath: "addons/backup"
+    ref: "ghcr.io/org/backup-tools:v1.0.0@sha256:..."
 ```
 
 **Fields:**
 - `name`: Unique identifier for the source
 - `type`: Must be `"oci"`
-- `image`: OCI image reference (must be digest-pinned)
-- `mountPath`: Prefix for job IDs
+- `ref`: OCI image reference (must be digest-pinned)
 
 See [Add-on Manifests]({{< ref "addon-manifests" >}}) for details on OCI add-ons.
 
@@ -117,24 +111,24 @@ jobs/                    # Source root
 Job IDs are derived from the directory path relative to the source root and always emitted as canonical slash IDs.
 
 Canonicalization rules:
-- `mountPath` is a **prefix** for job IDs. If `mountPath` is `.`, the prefix is empty.
+- `mountPath` is derived from the source name in this release (each source is mounted under its name). If the source name is `.`, the prefix is empty.
 - Job directory paths are normalized to lowercase kebab-case per path segment.
 - Outputs, persistence, and events use canonical slash IDs only.
 
 ```
-Source mountPath: "ops"
+Source mountPath (derived from source name): "local-ops"
 Directory path: backup/daily
 
-Resulting job ID: ops/backup/daily
+Resulting job ID: local-ops/backup/daily
 ```
 
 **Examples:**
 
 | Source mountPath | Directory Path      | Job ID                    |
 |------------------|---------------------|---------------------------|
-| `ops`            | `backup/daily`      | `ops/backup/daily`        |
+| `local-ops`      | `backup/daily`      | `local-ops/backup/daily`  |
 | `tools`          | `deploy/staging`    | `tools/deploy/staging`    |
-| `shared`         | `db/migrate`        | `shared/db/migrate`       |
+| `shared-tools`   | `db/migrate`        | `shared-tools/db/migrate` |
 | `.`              | `hello`             | `hello`                   |
 
 ### Root Job
@@ -146,16 +140,16 @@ jobs/
 └── config.yaml    # Root job
 ```
 
-This creates a job with ID equal to the `mountPath` (or empty string if `mountPath` is `.`).
+This creates a job with ID equal to the source name (or empty string if the source name is `.`).
 
 ## Discovery Process
 
 flwd discovers jobs using the following process:
 
-1. **Mount sources**: Each source is mounted at its `mountPath` under the tenant's scripts root
+1. **Mount sources**: Each source is mounted at its name under the tenant's scripts root
 2. **Walk directories**: Recursively walk the directory tree
 3. **Identify jobs**: Any directory containing `config.yaml` is a job (legacy `config.d/config.yaml` is accepted during PR1)
-4. **Resolve IDs**: Job ID = `mountPath` + relative directory path (canonical slash IDs only)
+4. **Resolve IDs**: Job ID = source name + relative directory path (canonical slash IDs only)
 5. **Check collisions**: Fail if multiple jobs resolve to the same ID
 
 ### Discovery Example
@@ -165,15 +159,13 @@ flwd discovers jobs using the following process:
 ```yaml
 sources:
   - name: "local-ops"
-    type: "fs"
-    path: "/opt/flwd/jobs"
-    mountPath: "ops"
+    type: "local"
+    ref: "/opt/flwd/jobs"
   
   - name: "shared-tools"
     type: "git"
     url: "https://github.com/org/tools.git"
     ref: "main"
-    mountPath: "shared"
 ```
 
 **Directory Structure:**
@@ -192,8 +184,8 @@ sources:
 
 **Discovered Jobs:**
 
-- `ops/backup/daily` (from local-ops)
-- `shared/deploy/app` (from shared-tools)
+- `local-ops/backup/daily` (from local-ops)
+- `shared-tools/deploy/app` (from shared-tools)
 
 ## Job Collision Detection
 
@@ -204,20 +196,20 @@ type: https://flowd.org/problems/job-id-collision
 status: 409
 code: job_id.collision
 detail: Multiple job definitions resolve to the same canonical job_id
-canonical_job_id: ops/backup/daily
+canonical_job_id: local-ops/backup/daily
 contenders:
   - source_kind: fs
     source_name: local-ops
-    mountPath: ops
+    mountPath: local-ops
     job_dir: backup/daily
   - source_kind: git
     source_name: remote-ops
-    mountPath: ops
+    mountPath: /var/lib/flwd/git/remote-ops
     job_dir: backup/daily
 ```
 
 **Resolution:**
-- Change `mountPath` for one of the sources
+- Change the source name for one of the sources
 - Reorganize directory structure
 - Remove duplicate job
 
@@ -308,9 +300,8 @@ Add sources to `flwd.yaml`:
 ```yaml
 sources:
   - name: "my-jobs"
-    type: "fs"
-    path: "/path/to/jobs"
-    mountPath: "custom"
+    type: "local"
+    ref: "/path/to/jobs"
 ```
 
 Reload configuration:
@@ -346,9 +337,8 @@ Enable `watch: true` for automatic reloading:
 ```yaml
 sources:
   - name: "local-dev"
-    type: "fs"
-    path: "./jobs"
-    mountPath: "dev"
+    type: "local"
+    ref: "./jobs"
     watch: true  # Auto-reload on file changes
 ```
 
@@ -400,9 +390,8 @@ instance:
 sources:
   # Local development jobs
   - name: "local-dev"
-    type: "fs"
-    path: "/opt/flwd/dev-jobs"
-    mountPath: "dev"
+    type: "local"
+    ref: "/opt/flwd/dev-jobs"
     watch: true
   
   # Shared team jobs from Git
@@ -410,7 +399,6 @@ sources:
     type: "git"
     url: "https://github.com/org/platform-tools.git"
     ref: "main"
-    mountPath: "platform"
     pull_policy: "on-run"
     auto_sync: true
     poll_interval: "10m"
@@ -420,14 +408,12 @@ sources:
     type: "git"
     url: "https://github.com/org/prod-ops.git"
     ref: "v2.1.0"  # Pinned tag
-    mountPath: "ops"
     pull_policy: "manual"
   
   # Backup tools add-on
   - name: "backup-addon"
     type: "oci"
-    image: "ghcr.io/org/backup-tools:v1.0.0@sha256:abc123..."
-    mountPath: "addons/backup"
+    ref: "ghcr.io/org/backup-tools:v1.0.0@sha256:abc123..."
 ```
 
 **Directory Structure:**
@@ -454,11 +440,11 @@ sources:
 
 **Discovered Jobs:**
 
-- `dev/test/hello`
-- `platform/deploy/app`
-- `ops/backup/database`
-- `addons/backup/backup` (from OCI add-on)
-- `addons/backup/restore` (from OCI add-on)
+- `local-dev/test/hello`
+- `platform-tools/deploy/app`
+- `prod-ops/backup/database`
+- `backup-addon/backup` (from OCI add-on)
+- `backup-addon/restore` (from OCI add-on)
 
 ## Validation
 

--- a/docs/sources-structure.md
+++ b/docs/sources-structure.md
@@ -90,6 +90,8 @@ See [Add-on Manifests]({{< ref "addon-manifests" >}}) for details on OCI add-ons
 
 The **tree-v1** layout organizes jobs in a hierarchical directory structure where each directory containing a `config.yaml` file defines a job.
 
+During PR1, flwd also accepts a legacy sentinel file at `config.d/config.yaml` as a temporary compatibility bridge. If **both** `config.yaml` and `config.d/config.yaml` exist in the same job directory, discovery fails with a 409 RFC7807 error (dual-config invalidity).
+
 ### Basic Structure
 
 ```
@@ -112,7 +114,12 @@ jobs/                    # Source root
 
 ### Job ID Resolution
 
-Job IDs are derived from the directory path relative to the source root:
+Job IDs are derived from the directory path relative to the source root and always emitted as canonical slash IDs.
+
+Canonicalization rules:
+- `mountPath` is a **prefix** for job IDs. If `mountPath` is `.`, the prefix is empty.
+- Job directory paths are normalized to lowercase kebab-case per path segment.
+- Outputs, persistence, and events use canonical slash IDs only.
 
 ```
 Source mountPath: "ops"
@@ -147,8 +154,8 @@ flwd discovers jobs using the following process:
 
 1. **Mount sources**: Each source is mounted at its `mountPath` under the tenant's scripts root
 2. **Walk directories**: Recursively walk the directory tree
-3. **Identify jobs**: Any directory containing `config.yaml` is a job
-4. **Resolve IDs**: Job ID = `mountPath` + relative directory path
+3. **Identify jobs**: Any directory containing `config.yaml` is a job (legacy `config.d/config.yaml` is accepted during PR1)
+4. **Resolve IDs**: Job ID = `mountPath` + relative directory path (canonical slash IDs only)
 5. **Check collisions**: Fail if multiple jobs resolve to the same ID
 
 ### Discovery Example
@@ -190,14 +197,23 @@ sources:
 
 ## Job Collision Detection
 
-If two or more jobs resolve to the same job ID, discovery fails with an error:
+If two or more jobs resolve to the same job ID, discovery fails with an RFC7807 **409 Conflict** error that includes a deterministic `contenders` list to help you identify the colliding jobs.
 
 ```
-Error: Job ID collision detected
-Job ID: ops/backup/daily
-Sources:
-  - local-ops (mountPath: ops, path: backup/daily)
-  - remote-ops (mountPath: ops, path: backup/daily)
+type: https://flowd.org/problems/job-id-collision
+status: 409
+code: job_id.collision
+detail: Multiple job definitions resolve to the same canonical job_id
+canonical_job_id: ops/backup/daily
+contenders:
+  - source_kind: fs
+    source_name: local-ops
+    mountPath: ops
+    job_dir: backup/daily
+  - source_kind: git
+    source_name: remote-ops
+    mountPath: ops
+    job_dir: backup/daily
 ```
 
 **Resolution:**

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -26,7 +26,7 @@ hint to resolve ambiguous names.
 
 `GET /sources` returns a Core-aligned view of sources, including `tenant`, `kind`, `mountPath`, `layout`, `pull_policy`, and `config`. The `kind` value `oci` is a flowd extension to the Core source kind set. Secret-shaped values inside `config` are redacted (rendered as `REDACTED`).
 
-This response is additive for compatibility: legacy fields such as `name`, `type`, `ref`, `url`, `resolved_ref`, `resolved_commit`, `provenance`, `expose`, and `aliases` (when enabled) may also appear.
+This response is additive for compatibility: legacy fields such as `name`, `type`, `ref`, `url`, `resolved_ref`, `resolved_commit`, `expose`, and `aliases` (when enabled) may also appear.
 
 `mountPath` in this view reflects the local materialized path for the source (for example, a checked-out git directory or cached OCI manifest directory).
 
@@ -68,10 +68,6 @@ Example response (redacted):
     "pull_policy": "always",
     "config": {
       "path": "/home/me/tools"
-    },
-    "provenance": {
-      "type": "local",
-      "ref": "/home/me/tools"
     }
   },
   {
@@ -86,12 +82,6 @@ Example response (redacted):
     "pull_policy": "ifNotPresent",
     "digest": "sha256:...",
     "config": {
-      "ref": "ghcr.io/org/backup-tools:v1.0.0",
-      "digest": "sha256:...",
-      "pull_policy": "ifNotPresent"
-    },
-    "provenance": {
-      "type": "oci",
       "ref": "ghcr.io/org/backup-tools:v1.0.0",
       "digest": "sha256:...",
       "pull_policy": "ifNotPresent"

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -26,6 +26,8 @@ hint to resolve ambiguous names.
 
 `GET /sources` returns a Core-aligned view of sources, including `tenant`, `kind`, `mountPath`, `layout`, `pull_policy`, and `config`. The `kind` value `oci` is a flowd extension to the Core source kind set. Secret-shaped values inside `config` are redacted (rendered as `REDACTED`).
 
+`mountPath` in this view reflects the local materialized path for the source (for example, a checked-out git directory or cached OCI manifest directory).
+
 ## Add a local source (API)
 
 Assuming `flwd :serve` is running:
@@ -35,9 +37,9 @@ $ curl -s -X POST http://127.0.0.1:8080/sources \
     -H 'Authorization: Bearer dev-token' \
     -H 'Content-Type: application/json' \
     -d '{
-          "type":"fs",
+          "type":"local",
           "name":"local-tools",
-          "path":"/home/me/tools"
+          "ref":"/home/me/tools"
         }'
 ```
 
@@ -72,6 +74,7 @@ Example response (redacted):
     "pull_policy": "ifNotPresent",
     "config": {
       "ref": "ghcr.io/org/backup-tools:v1.0.0",
+      "digest": "sha256:...",
       "pull_policy": "ifNotPresent",
       "registry_password": "REDACTED"
     }
@@ -116,8 +119,8 @@ $ curl -s -X POST http://127.0.0.1:8080/plans \
     -H 'Authorization: Bearer dev-token' \
     -H 'Content-Type: application/json' \
     -d '{
-          "job":"hello-world",
-          "source":"tools",
+          "job_id":"hello-world",
+          "source":{"name":"tools"},
           "args":{"name":"Alice"}
         }'
 ```

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -26,6 +26,8 @@ hint to resolve ambiguous names.
 
 `GET /sources` returns a Core-aligned view of sources, including `tenant`, `kind`, `mountPath`, `layout`, `pull_policy`, and `config`. The `kind` value `oci` is a flowd extension to the Core source kind set. Secret-shaped values inside `config` are redacted (rendered as `REDACTED`).
 
+This response is additive for compatibility: legacy fields such as `name`, `type`, `ref`, `url`, `resolved_ref`, `resolved_commit`, `provenance`, `expose`, and `aliases` (when enabled) may also appear.
+
 `mountPath` in this view reflects the local materialized path for the source (for example, a checked-out git directory or cached OCI manifest directory).
 
 ## Add a local source (API)
@@ -56,6 +58,9 @@ Example response (redacted):
 [
   {
     "id": "local-tools",
+    "name": "local-tools",
+    "type": "local",
+    "ref": "/home/me/tools",
     "tenant": "default",
     "kind": "fs",
     "mountPath": "/home/me/tools",
@@ -63,20 +68,33 @@ Example response (redacted):
     "pull_policy": "always",
     "config": {
       "path": "/home/me/tools"
+    },
+    "provenance": {
+      "type": "local",
+      "ref": "/home/me/tools"
     }
   },
   {
     "id": "backup-addon",
+    "name": "backup-addon",
+    "type": "oci",
+    "ref": "ghcr.io/org/backup-tools:v1.0.0",
     "tenant": "default",
     "kind": "oci",
     "mountPath": "/var/lib/flwd/sources/oci/backup-addon",
     "layout": "",
     "pull_policy": "ifNotPresent",
+    "digest": "sha256:...",
     "config": {
       "ref": "ghcr.io/org/backup-tools:v1.0.0",
       "digest": "sha256:...",
-      "pull_policy": "ifNotPresent",
-      "registry_password": "REDACTED"
+      "pull_policy": "ifNotPresent"
+    },
+    "provenance": {
+      "type": "oci",
+      "ref": "ghcr.io/org/backup-tools:v1.0.0",
+      "digest": "sha256:...",
+      "pull_policy": "ifNotPresent"
     }
   }
 ]

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -51,34 +51,32 @@ $ curl -s -H 'Authorization: Bearer dev-token' http://127.0.0.1:8080/sources | j
 Example response (redacted):
 
 ```json
-{
-  "sources": [
-    {
-      "id": "local-tools",
-      "tenant": "default",
-      "kind": "fs",
-      "mountPath": "tools",
-      "layout": "tree-v1",
-      "pull_policy": "manual",
-      "config": {
-        "path": "/home/me/tools",
-        "watch": true
-      }
-    },
-    {
-      "id": "backup-addon",
-      "tenant": "default",
-      "kind": "oci",
-      "mountPath": "addons/backup",
-      "layout": "tree-v1",
-      "pull_policy": "on-run",
-      "config": {
-        "image": "ghcr.io/org/backup-tools:v1.0.0@sha256:...",
-        "token": "REDACTED"
-      }
+[
+  {
+    "id": "local-tools",
+    "tenant": "default",
+    "kind": "fs",
+    "mountPath": "/home/me/tools",
+    "layout": "tree-v1",
+    "pull_policy": "always",
+    "config": {
+      "path": "/home/me/tools"
     }
-  ]
-}
+  },
+  {
+    "id": "backup-addon",
+    "tenant": "default",
+    "kind": "oci",
+    "mountPath": "/var/lib/flwd/sources/oci/backup-addon",
+    "layout": "",
+    "pull_policy": "ifNotPresent",
+    "config": {
+      "ref": "ghcr.io/org/backup-tools:v1.0.0",
+      "pull_policy": "ifNotPresent",
+      "registry_password": "REDACTED"
+    }
+  }
+]
 ```
 
 ## Add a Git source (API)

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -24,6 +24,8 @@ When a source is configured, its jobs appear in `/jobs` and are available to the
 CLI and TUI. API calls to `/plans` and `/runs` can optionally include a `source`
 hint to resolve ambiguous names.
 
+`GET /sources` returns a Core-aligned view of sources, including `tenant`, `kind`, `mountPath`, `layout`, `pull_policy`, and `config`. The `kind` value `oci` is a flowd extension to the Core source kind set. Secret-shaped values inside `config` are redacted (rendered as `REDACTED`).
+
 ## Add a local source (API)
 
 Assuming `flwd :serve` is running:
@@ -41,6 +43,43 @@ $ curl -s -X POST http://127.0.0.1:8080/sources \
 
 After this, any jobs discovered under `/home/me/tools` are visible via `/jobs`
 and can be run like any other job.
+
+```bash
+$ curl -s -H 'Authorization: Bearer dev-token' http://127.0.0.1:8080/sources | jq
+```
+
+Example response (redacted):
+
+```json
+{
+  "sources": [
+    {
+      "id": "local-tools",
+      "tenant": "default",
+      "kind": "fs",
+      "mountPath": "tools",
+      "layout": "tree-v1",
+      "pull_policy": "manual",
+      "config": {
+        "path": "/home/me/tools",
+        "watch": true
+      }
+    },
+    {
+      "id": "backup-addon",
+      "tenant": "default",
+      "kind": "oci",
+      "mountPath": "addons/backup",
+      "layout": "tree-v1",
+      "pull_policy": "on-run",
+      "config": {
+        "image": "ghcr.io/org/backup-tools:v1.0.0@sha256:...",
+        "token": "REDACTED"
+      }
+    }
+  ]
+}
+```
 
 ## Add a Git source (API)
 

--- a/internal/configloader/loader.go
+++ b/internal/configloader/loader.go
@@ -3,6 +3,7 @@
 package configloader
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,8 +16,46 @@ import (
 
 // fullConfig retained for potential future extended parsing; current path decodes directly into types.Config
 
+const DualConfigCode = "job.config.dual_sentinel"
+
+// DualConfigError indicates that both primary and legacy config sentinels exist.
+type DualConfigError struct {
+	ScriptDir   string
+	PrimaryPath string
+	LegacyPath  string
+}
+
+func (e *DualConfigError) Error() string {
+	return fmt.Sprintf("both config.yaml and config.d/config.yaml exist in %s", e.ScriptDir)
+}
+
+func (e *DualConfigError) Code() string {
+	return DualConfigCode
+}
+
 func LoadConfig(scriptDir string) (*types.Config, error) {
-	configPath := filepath.Join(scriptDir, "config.d", "config.yaml")
+	primaryPath := filepath.Join(scriptDir, "config.yaml")
+	legacyPath := filepath.Join(scriptDir, "config.d", "config.yaml")
+	primaryExists, err := fileExists(primaryPath)
+	if err != nil {
+		return nil, fmt.Errorf("stat config: %w", err)
+	}
+	legacyExists, err := fileExists(legacyPath)
+	if err != nil {
+		return nil, fmt.Errorf("stat legacy config: %w", err)
+	}
+	if primaryExists && legacyExists {
+		return nil, &DualConfigError{
+			ScriptDir:   scriptDir,
+			PrimaryPath: primaryPath,
+			LegacyPath:  legacyPath,
+		}
+	}
+
+	configPath := legacyPath
+	if primaryExists {
+		configPath = primaryPath
+	}
 
 	f, err := os.Open(configPath)
 	if err != nil {
@@ -100,4 +139,15 @@ func LoadConfig(scriptDir string) (*types.Config, error) {
 	}
 
 	return &cfg, nil
+}
+
+func fileExists(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err == nil {
+		return !info.IsDir(), nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
 }

--- a/internal/e2e/cli_e2e_test.go
+++ b/internal/e2e/cli_e2e_test.go
@@ -253,7 +253,12 @@ func TestCLIServeMode(t *testing.T) {
 		t.Fatalf("GET /jobs status=%d body=%s", jobsResp.StatusCode, string(body))
 	}
 	var jobs []struct {
-		ID string `json:"id"`
+		ID     string `json:"id"`
+		Tenant string `json:"tenant"`
+		Origin struct {
+			SourceKind string `json:"source_kind"`
+			SourceName string `json:"source_name"`
+		} `json:"origin"`
 	}
 	if err := json.NewDecoder(jobsResp.Body).Decode(&jobs); err != nil {
 		t.Fatalf("decode jobs: %v", err)
@@ -262,6 +267,12 @@ func TestCLIServeMode(t *testing.T) {
 	for _, job := range jobs {
 		if job.ID == "demo" {
 			foundDemo = true
+			if job.Tenant != "default" {
+				t.Fatalf("expected demo tenant default, got %q", job.Tenant)
+			}
+			if job.Origin.SourceKind != "fs" || job.Origin.SourceName != "local" {
+				t.Fatalf("expected demo origin fs/local, got %s/%s", job.Origin.SourceKind, job.Origin.SourceName)
+			}
 			break
 		}
 	}
@@ -311,12 +322,23 @@ func TestCLIServeMode(t *testing.T) {
 	var runPayload struct {
 		ID     string `json:"id"`
 		Status string `json:"status"`
+		Tenant string `json:"tenant"`
+		Origin struct {
+			SourceKind string `json:"source_kind"`
+			SourceName string `json:"source_name"`
+		} `json:"origin"`
 	}
 	if err := json.NewDecoder(runResp.Body).Decode(&runPayload); err != nil {
 		t.Fatalf("decode run: %v", err)
 	}
 	if runPayload.ID == "" {
 		t.Fatalf("expected run id in response")
+	}
+	if runPayload.Tenant != "default" {
+		t.Fatalf("expected run tenant default, got %q", runPayload.Tenant)
+	}
+	if runPayload.Origin.SourceKind != "fs" || runPayload.Origin.SourceName != "local" {
+		t.Fatalf("expected run origin fs/local, got %s/%s", runPayload.Origin.SourceKind, runPayload.Origin.SourceName)
 	}
 
 	runStatus := awaitRunCompletion(t, client, addr, runPayload.ID)
@@ -555,6 +577,11 @@ func TestCLIServeConformanceErrors(t *testing.T) {
 	var runPayload struct {
 		ID     string `json:"id"`
 		Status string `json:"status"`
+		Tenant string `json:"tenant"`
+		Origin struct {
+			SourceKind string `json:"source_kind"`
+			SourceName string `json:"source_name"`
+		} `json:"origin"`
 	}
 	if err := json.NewDecoder(respRun.Body).Decode(&runPayload); err != nil {
 		respRun.Body.Close()
@@ -563,6 +590,12 @@ func TestCLIServeConformanceErrors(t *testing.T) {
 	respRun.Body.Close()
 	if runPayload.ID == "" {
 		t.Fatalf("expected run id in response")
+	}
+	if runPayload.Tenant != "default" {
+		t.Fatalf("expected run tenant default, got %q", runPayload.Tenant)
+	}
+	if runPayload.Origin.SourceKind != "fs" || runPayload.Origin.SourceName != "local" {
+		t.Fatalf("expected run origin fs/local, got %s/%s", runPayload.Origin.SourceKind, runPayload.Origin.SourceName)
 	}
 
 	// 409 — same key, different body.

--- a/internal/engine/orchestrator.go
+++ b/internal/engine/orchestrator.go
@@ -58,7 +58,7 @@ var ErrSecretContainerUnsupported = errors.New("container execution does not sup
 func (o *Orchestrator) StartRun(ctx context.Context, req types.StartRunRequest) (StartRunResult, error) {
 	_ = ctx
 	var res StartRunResult
-	if req.JobID == "" {
+	if req.JobID == "" && req.ScriptDir == "" {
 		return res, errors.New("job_id required")
 	}
 

--- a/internal/indexer/aliases.go
+++ b/internal/indexer/aliases.go
@@ -178,7 +178,9 @@ func normalizeAliasTarget(from string) (targetPath, targetID string) {
 	if normalized == "" {
 		return "", ""
 	}
-	targetPath = normalized
-	targetID = strings.ReplaceAll(normalized, "/", ".")
-	return targetPath, targetID
+	canonical := DotJobIDToSlash(normalized)
+	if canonical == "" {
+		return "", ""
+	}
+	return canonical, canonical
 }

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -14,8 +14,8 @@ import (
 )
 
 // JobInfo summarizes a discovered local job.
-// Path refers to the directory containing config.d/config.yaml.
-// ID defaults to the relative path when not provided explicitly.
+// Path refers to the job directory containing the config sentinel.
+// ID uses canonical slash format derived from the job directory path.
 // Summary is optional and may be empty.
 type JobInfo struct {
 	ID      string `json:"id"`
@@ -39,8 +39,8 @@ type Result struct {
 	Errors          []DiscoveryError           `json:"errors,omitempty"`
 }
 
-// Discover scans root (typically "scripts") for config.d/config.yaml files
-// and returns job metadata according to the Runner specification.
+// Discover scans root (typically "scripts") for config.yaml (primary)
+// and config.d/config.yaml (legacy) sentinels and returns job metadata.
 func Discover(root string) (Result, error) {
 	var res Result
 
@@ -55,14 +55,33 @@ func Discover(root string) (Result, error) {
 		return res, fmt.Errorf("root %s is not a directory", root)
 	}
 
-	var cfgPaths []string
+	type sentinelPaths struct {
+		primary string
+		legacy  string
+	}
+
+	cfgByDir := make(map[string]*sentinelPaths)
 	walkErr := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if !d.IsDir() && strings.EqualFold(d.Name(), "config.yaml") {
-			if filepath.Base(filepath.Dir(path)) == "config.d" {
-				cfgPaths = append(cfgPaths, path)
+			dir := filepath.Dir(path)
+			jobDir := dir
+			legacy := false
+			if filepath.Base(dir) == "config.d" {
+				legacy = true
+				jobDir = filepath.Dir(dir)
+			}
+			sentinel := cfgByDir[jobDir]
+			if sentinel == nil {
+				sentinel = &sentinelPaths{}
+				cfgByDir[jobDir] = sentinel
+			}
+			if legacy {
+				sentinel.legacy = path
+			} else {
+				sentinel.primary = path
 			}
 		}
 		return nil
@@ -71,11 +90,33 @@ func Discover(root string) (Result, error) {
 		return res, fmt.Errorf("walk root: %w", walkErr)
 	}
 
-	sort.Strings(cfgPaths)
-	for _, cfgPath := range cfgPaths {
-		jobs, err := parseConfig(root, cfgPath)
+	jobDirs := make([]string, 0, len(cfgByDir))
+	for jobDir, sentinels := range cfgByDir {
+		if sentinels.primary != "" && sentinels.legacy != "" {
+			return res, &configloader.DualConfigError{
+				ScriptDir:   jobDir,
+				PrimaryPath: sentinels.primary,
+				LegacyPath:  sentinels.legacy,
+			}
+		}
+		jobDirs = append(jobDirs, jobDir)
+	}
+
+	sort.Strings(jobDirs)
+	for _, jobDir := range jobDirs {
+		sentinels := cfgByDir[jobDir]
+		cfgPath := sentinels.primary
+		if cfgPath == "" {
+			cfgPath = sentinels.legacy
+		}
+		jobs, err := parseConfig(root, jobDir, cfgPath)
 		if err != nil {
-			res.Errors = append(res.Errors, DiscoveryError{Path: cfgPath, Err: err.Error()})
+			errPath := cfgPath
+			var idErr JobIDError
+			if errors.As(err, &idErr) {
+				errPath = jobDir
+			}
+			res.Errors = append(res.Errors, DiscoveryError{Path: errPath, Err: err.Error()})
 			continue
 		}
 		res.Jobs = append(res.Jobs, jobs...)
@@ -121,10 +162,15 @@ type jobBlock struct {
 	Summary string `yaml:"summary"`
 }
 
-func parseConfig(root, cfgPath string) ([]JobInfo, error) {
+func parseConfig(root, jobDir, cfgPath string) ([]JobInfo, error) {
 	data, err := os.ReadFile(cfgPath)
 	if err != nil {
 		return nil, fmt.Errorf("read config: %w", err)
+	}
+
+	canonicalID, err := canonicalJobIDFromDir(root, jobDir)
+	if err != nil {
+		return nil, err
 	}
 
 	var cfg singleJob
@@ -140,44 +186,37 @@ func parseConfig(root, cfgPath string) ([]JobInfo, error) {
 		blocks = append(blocks, cfg.Jobs...)
 	}
 	if len(blocks) == 0 {
-		derived := deriveID(root, cfgPath)
 		return []JobInfo{{
-			ID:   derived,
-			Name: derived,
-			Path: filepath.Dir(cfgPath),
+			ID:   canonicalID,
+			Name: canonicalID,
+			Path: jobDir,
 		}}, nil
 	}
 
 	jobs := make([]JobInfo, 0, len(blocks))
 	for _, block := range blocks {
-		id := block.ID
-		if id == "" {
-			id = deriveID(root, cfgPath)
-		}
 		name := block.Name
 		if name == "" {
-			name = id
+			name = canonicalID
 		}
 		jobs = append(jobs, JobInfo{
-			ID:      id,
+			ID:      canonicalID,
 			Name:    name,
 			Summary: block.Summary,
-			Path:    filepath.Dir(cfgPath),
+			Path:    jobDir,
 		})
 	}
 	return jobs, nil
 }
 
-func deriveID(root, cfgPath string) string {
-	jobDir := filepath.Dir(filepath.Dir(cfgPath)) // strip config.d/config.yaml
+func canonicalJobIDFromDir(root, jobDir string) (string, error) {
 	rel, err := filepath.Rel(root, jobDir)
 	if err != nil {
-		return filepath.ToSlash(jobDir)
+		rel = jobDir
 	}
 	rel = filepath.ToSlash(rel)
-	rel = strings.Trim(rel, "/")
 	if rel == "" {
-		return filepath.Base(jobDir)
+		rel = "."
 	}
-	return strings.ReplaceAll(rel, "/", ".")
+	return CanonicalJobID(".", rel)
 }

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -42,6 +42,20 @@ type Result struct {
 // Discover scans root (typically "scripts") for config.yaml (primary)
 // and config.d/config.yaml (legacy) sentinels and returns job metadata.
 func Discover(root string) (Result, error) {
+	return discoverWithMountPath(root, ".")
+}
+
+// DiscoverWithMountPath scans root for job sentinels and applies mountPath
+// as the canonical ID prefix (Core SoT 1.5).
+func DiscoverWithMountPath(root, mountPath string) (Result, error) {
+	mountPath = strings.TrimSpace(mountPath)
+	if mountPath == "" {
+		mountPath = "."
+	}
+	return discoverWithMountPath(root, mountPath)
+}
+
+func discoverWithMountPath(root, mountPath string) (Result, error) {
 	var res Result
 
 	info, err := os.Stat(root)
@@ -109,7 +123,7 @@ func Discover(root string) (Result, error) {
 		if cfgPath == "" {
 			cfgPath = sentinels.legacy
 		}
-		jobs, err := parseConfig(root, jobDir, cfgPath)
+		jobs, err := parseConfig(root, jobDir, cfgPath, mountPath)
 		if err != nil {
 			errPath := cfgPath
 			var idErr JobIDError
@@ -162,13 +176,13 @@ type jobBlock struct {
 	Summary string `yaml:"summary"`
 }
 
-func parseConfig(root, jobDir, cfgPath string) ([]JobInfo, error) {
+func parseConfig(root, jobDir, cfgPath, mountPath string) ([]JobInfo, error) {
 	data, err := os.ReadFile(cfgPath)
 	if err != nil {
 		return nil, fmt.Errorf("read config: %w", err)
 	}
 
-	canonicalID, err := canonicalJobIDFromDir(root, jobDir)
+	canonicalID, err := canonicalJobIDFromDir(root, jobDir, mountPath)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +223,7 @@ func parseConfig(root, jobDir, cfgPath string) ([]JobInfo, error) {
 	return jobs, nil
 }
 
-func canonicalJobIDFromDir(root, jobDir string) (string, error) {
+func canonicalJobIDFromDir(root, jobDir, mountPath string) (string, error) {
 	rel, err := filepath.Rel(root, jobDir)
 	if err != nil {
 		rel = jobDir
@@ -218,5 +232,5 @@ func canonicalJobIDFromDir(root, jobDir string) (string, error) {
 	if rel == "" {
 		rel = "."
 	}
-	return CanonicalJobID(".", rel)
+	return CanonicalJobID(mountPath, rel)
 }

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -128,7 +128,12 @@ func discoverWithMountPath(root, mountPath string) (Result, error) {
 			errPath := cfgPath
 			var idErr JobIDError
 			if errors.As(err, &idErr) {
-				errPath = jobDir
+				return res, InvalidJobIDError{
+					JobDir:  jobDir,
+					Path:    idErr.Path,
+					Segment: idErr.Segment,
+					Reason:  idErr.Reason,
+				}
 			}
 			res.Errors = append(res.Errors, DiscoveryError{Path: errPath, Err: err.Error()})
 			continue

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -35,7 +35,7 @@ job:
 		t.Fatalf("expected 1 job, got %d", len(res.Jobs))
 	}
 	job := res.Jobs[0]
-	if job.ID != "demo.hello" {
+	if job.ID != "demo/hello" {
 		t.Fatalf("unexpected id %s", job.ID)
 	}
 	if res.AliasCollisions != nil {
@@ -55,13 +55,13 @@ job:
 func TestDiscoverIncludesAliases(t *testing.T) {
 	root := t.TempDir()
 	scriptsDir := filepath.Join(root, "scripts")
-	jobDir := filepath.Join(scriptsDir, "demo")
+	jobDir := filepath.Join(scriptsDir, "demo", "build")
 	if err := os.MkdirAll(filepath.Join(jobDir, "config.d"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	config := `version: v1
 job:
-  id: demo.build
+  id: demo/build
   name: Demo Build
 `
 	if err := os.WriteFile(filepath.Join(jobDir, "config.d", "config.yaml"), []byte(config), 0o644); err != nil {
@@ -87,8 +87,8 @@ job:
 	if alias.Name != "build-demo" {
 		t.Fatalf("expected alias name build-demo, got %s", alias.Name)
 	}
-	if alias.TargetID != "demo.build" {
-		t.Fatalf("expected target id demo.build, got %s", alias.TargetID)
+	if alias.TargetID != "demo/build" {
+		t.Fatalf("expected target id demo/build, got %s", alias.TargetID)
 	}
 	if alias.TargetPath != "demo/build" {
 		t.Fatalf("expected target path demo/build, got %s", alias.TargetPath)

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -160,6 +160,33 @@ func TestDiscoverInvalidYaml(t *testing.T) {
 	}
 }
 
+func TestDiscoverInvalidJobIDSegment(t *testing.T) {
+	root := t.TempDir()
+	jobDir := filepath.Join(root, "!!!")
+	if err := os.MkdirAll(jobDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	config := `version: v1
+job:
+  name: Bad Job
+`
+	if err := os.WriteFile(filepath.Join(jobDir, "config.yaml"), []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Discover(root)
+	if err == nil {
+		t.Fatal("expected invalid job id error, got nil")
+	}
+	var invalid InvalidJobIDError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("expected InvalidJobIDError, got %v", err)
+	}
+	if invalid.Segment == "" {
+		t.Fatalf("expected invalid segment to be set")
+	}
+}
+
 func TestDiscoverPrimaryAndLegacySentinels(t *testing.T) {
 	root := t.TempDir()
 	primaryDir := filepath.Join(root, "alpha", "one")

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -294,3 +294,32 @@ job:
 		t.Fatalf("expected tools job id, got %+v", res.Jobs)
 	}
 }
+
+func TestDiscoverWithMountPathPrefix(t *testing.T) {
+	root := t.TempDir()
+	jobDir := filepath.Join(root, "Demo")
+	if err := os.MkdirAll(jobDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	config := `version: v1
+job:
+  name: Demo
+`
+	if err := os.WriteFile(filepath.Join(jobDir, "config.yaml"), []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := DiscoverWithMountPath(root, "Scripts")
+	if err != nil {
+		t.Fatalf("DiscoverWithMountPath error: %v", err)
+	}
+	if len(res.Errors) != 0 {
+		t.Fatalf("unexpected errors: %+v", res.Errors)
+	}
+	if len(res.Jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(res.Jobs))
+	}
+	if res.Jobs[0].ID != "scripts/demo" {
+		t.Fatalf("expected prefixed job id scripts/demo, got %s", res.Jobs[0].ID)
+	}
+}

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -3,9 +3,12 @@
 package indexer
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/flowd-org/flowd/internal/configloader"
 )
 
 func TestDiscoverJobMetadata(t *testing.T) {
@@ -154,5 +157,140 @@ func TestDiscoverInvalidYaml(t *testing.T) {
 	}
 	if len(res.Jobs) != 0 {
 		t.Fatalf("expected 0 jobs, got %d", len(res.Jobs))
+	}
+}
+
+func TestDiscoverPrimaryAndLegacySentinels(t *testing.T) {
+	root := t.TempDir()
+	primaryDir := filepath.Join(root, "alpha", "one")
+	if err := os.MkdirAll(primaryDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	primaryConfig := `version: v1
+job:
+  name: Alpha One
+`
+	if err := os.WriteFile(filepath.Join(primaryDir, "config.yaml"), []byte(primaryConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	legacyDir := filepath.Join(root, "beta", "two", "config.d")
+	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacyConfig := `version: v1
+job:
+  name: Beta Two
+`
+	if err := os.WriteFile(filepath.Join(legacyDir, "config.yaml"), []byte(legacyConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Discover(root)
+	if err != nil {
+		t.Fatalf("Discover error: %v", err)
+	}
+	if len(res.Errors) != 0 {
+		t.Fatalf("unexpected errors: %+v", res.Errors)
+	}
+	if len(res.Jobs) != 2 {
+		t.Fatalf("expected 2 jobs, got %d", len(res.Jobs))
+	}
+	ids := make(map[string]struct{}, len(res.Jobs))
+	for _, job := range res.Jobs {
+		ids[job.ID] = struct{}{}
+	}
+	for _, expected := range []string{"alpha/one", "beta/two"} {
+		if _, ok := ids[expected]; !ok {
+			t.Fatalf("expected job id %s in results: %+v", expected, res.Jobs)
+		}
+	}
+}
+
+func TestDiscoverDualConfigSentinelError(t *testing.T) {
+	root := t.TempDir()
+	jobDir := filepath.Join(root, "demo")
+	if err := os.MkdirAll(filepath.Join(jobDir, "config.d"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	config := `version: v1
+job:
+  name: Demo
+`
+	if err := os.WriteFile(filepath.Join(jobDir, "config.yaml"), []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(jobDir, "config.d", "config.yaml"), []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Discover(root)
+	if err == nil {
+		t.Fatal("expected dual-config error, got nil")
+	}
+	var dual *configloader.DualConfigError
+	if !errors.As(err, &dual) {
+		t.Fatalf("expected DualConfigError, got %v", err)
+	}
+	if dual.PrimaryPath == "" || dual.LegacyPath == "" {
+		t.Fatalf("expected dual config paths set, got %+v", dual)
+	}
+}
+
+func TestDiscoverRootJobMapping(t *testing.T) {
+	root := t.TempDir()
+	rootConfig := `version: v1
+job:
+  name: Root Job
+`
+	if err := os.WriteFile(filepath.Join(root, "config.yaml"), []byte(rootConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	toolDir := filepath.Join(root, "Tools")
+	if err := os.MkdirAll(toolDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	toolConfig := `version: v1
+job:
+  name: Tools Job
+`
+	if err := os.WriteFile(filepath.Join(toolDir, "config.yaml"), []byte(toolConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Discover(root)
+	if err != nil {
+		t.Fatalf("Discover error: %v", err)
+	}
+	if len(res.Errors) != 0 {
+		t.Fatalf("unexpected errors: %+v", res.Errors)
+	}
+	if len(res.Jobs) != 2 {
+		t.Fatalf("expected 2 jobs, got %d", len(res.Jobs))
+	}
+	var (
+		foundRoot bool
+		foundTool bool
+	)
+	for _, job := range res.Jobs {
+		switch job.ID {
+		case "":
+			foundRoot = true
+			if job.Name != "Root Job" {
+				t.Fatalf("expected root job name Root Job, got %s", job.Name)
+			}
+		case "tools":
+			foundTool = true
+			if job.Name != "Tools Job" {
+				t.Fatalf("expected tools job name Tools Job, got %s", job.Name)
+			}
+		}
+	}
+	if !foundRoot {
+		t.Fatalf("expected root job with empty id, got %+v", res.Jobs)
+	}
+	if !foundTool {
+		t.Fatalf("expected tools job id, got %+v", res.Jobs)
 	}
 }

--- a/internal/indexer/jobid.go
+++ b/internal/indexer/jobid.go
@@ -25,6 +25,26 @@ func (e JobIDError) Error() string {
 	return fmt.Sprintf("invalid job id segment %q in %q: %s", e.Segment, e.Path, e.Reason)
 }
 
+// InvalidJobIDError reports a canonical job ID normalization failure for discovery.
+type InvalidJobIDError struct {
+	JobDir  string
+	Path    string
+	Segment string
+	Reason  string
+}
+
+func (e InvalidJobIDError) Error() string {
+	base := JobIDError{Path: e.Path, Segment: e.Segment, Reason: e.Reason}.Error()
+	if e.JobDir == "" {
+		return base
+	}
+	return fmt.Sprintf("%s (job dir %s)", base, e.JobDir)
+}
+
+func (e InvalidJobIDError) Unwrap() error {
+	return JobIDError{Path: e.Path, Segment: e.Segment, Reason: e.Reason}
+}
+
 type segmentError struct {
 	Segment string
 	Reason  string

--- a/internal/indexer/jobid.go
+++ b/internal/indexer/jobid.go
@@ -112,13 +112,27 @@ func splitJobIDSegments(input string) []string {
 	if normalized == "" {
 		return nil
 	}
-	normalized = strings.Trim(normalized, "./")
-	if normalized == "" {
+
+	var segments []string
+	var current strings.Builder
+	for _, r := range normalized {
+		switch r {
+		case '/', '.':
+			if current.Len() > 0 {
+				segments = append(segments, current.String())
+				current.Reset()
+			}
+		default:
+			current.WriteRune(r)
+		}
+	}
+	if current.Len() > 0 {
+		segments = append(segments, current.String())
+	}
+	if len(segments) == 0 {
 		return nil
 	}
-	return strings.FieldsFunc(normalized, func(r rune) bool {
-		return r == '/' || r == '.'
-	})
+	return segments
 }
 
 func normalizePathInput(value string) string {

--- a/internal/indexer/jobid.go
+++ b/internal/indexer/jobid.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package indexer
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+var jobIDSegmentPattern = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$`)
+
+// JobIDError reports invalid job ID segments during normalization.
+// Path is the slash-delimited path being normalized and Segment is the raw segment value.
+type JobIDError struct {
+	Path    string
+	Segment string
+	Reason  string
+}
+
+func (e JobIDError) Error() string {
+	if e.Path == "" {
+		return fmt.Sprintf("invalid job id segment %q: %s", e.Segment, e.Reason)
+	}
+	return fmt.Sprintf("invalid job id segment %q in %q: %s", e.Segment, e.Path, e.Reason)
+}
+
+type segmentError struct {
+	Segment string
+	Reason  string
+}
+
+func (e segmentError) Error() string {
+	return e.Reason
+}
+
+// CanonicalJobID returns a canonical slash job ID using mountPath-prefix semantics.
+// mountPath "." uses an empty prefix. jobDirRel maps "." to the empty string.
+func CanonicalJobID(mountPath, jobDirRel string) (string, error) {
+	prefix := strings.TrimSpace(mountPath)
+	if prefix == "." {
+		prefix = ""
+	}
+
+	rel := normalizePathInput(jobDirRel)
+	if rel == "." {
+		rel = ""
+	}
+
+	normalizedPrefix, err := normalizePath(prefix)
+	if err != nil {
+		return "", err
+	}
+	normalizedRel, err := normalizePath(rel)
+	if err != nil {
+		return "", err
+	}
+
+	if normalizedPrefix == "" && normalizedRel == "" {
+		return "", nil
+	}
+	if normalizedPrefix == "" {
+		return normalizedRel, nil
+	}
+	if normalizedRel == "" {
+		return normalizedPrefix, nil
+	}
+	return normalizedPrefix + "/" + normalizedRel, nil
+}
+
+// DotJobIDToSlash normalizes legacy dot-delimited job IDs into slash-delimited paths.
+func DotJobIDToSlash(input string) string {
+	trimmed := normalizePathInput(input)
+	if trimmed == "" {
+		return ""
+	}
+	trimmed = strings.ReplaceAll(trimmed, ".", "/")
+	trimmed = strings.ReplaceAll(trimmed, "//", "/")
+	trimmed = strings.Trim(trimmed, "/")
+	return trimmed
+}
+
+// SlashJobIDToDot derives a dot-delimited identifier from a slash path.
+func SlashJobIDToDot(input string) string {
+	trimmed := normalizePathInput(input)
+	if trimmed == "" {
+		return ""
+	}
+	trimmed = strings.ReplaceAll(trimmed, "//", "/")
+	trimmed = strings.Trim(trimmed, "/")
+	if trimmed == "" {
+		return ""
+	}
+	return strings.ReplaceAll(trimmed, "/", ".")
+}
+
+func normalizePathInput(value string) string {
+	normalized := strings.TrimSpace(value)
+	normalized = strings.ReplaceAll(normalized, "\\", "/")
+	return normalized
+}
+
+func normalizePath(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	normalized := normalizePathInput(path)
+	normalized = strings.Trim(normalized, "/")
+	if normalized == "" {
+		return "", nil
+	}
+
+	segments := strings.Split(normalized, "/")
+	out := make([]string, 0, len(segments))
+	for _, seg := range segments {
+		if seg == "" {
+			return "", JobIDError{Path: normalized, Segment: seg, Reason: "empty segment"}
+		}
+		normalizedSegment, err := normalizeSegment(seg)
+		if err != nil {
+			reason := err.Error()
+			return "", JobIDError{Path: normalized, Segment: seg, Reason: reason}
+		}
+		out = append(out, normalizedSegment)
+	}
+	return strings.Join(out, "/"), nil
+}
+
+func normalizeSegment(segment string) (string, error) {
+	trimmed := strings.TrimSpace(segment)
+	if trimmed == "" {
+		return "", segmentError{Segment: segment, Reason: "empty segment"}
+	}
+
+	var b strings.Builder
+	b.Grow(len(trimmed))
+	lastDash := false
+	for _, r := range trimmed {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(unicode.ToLower(r))
+			lastDash = false
+			continue
+		}
+		if !lastDash && b.Len() > 0 {
+			b.WriteByte('-')
+			lastDash = true
+		} else if b.Len() == 0 {
+			lastDash = true
+		}
+	}
+
+	normalized := b.String()
+	normalized = strings.TrimSuffix(normalized, "-")
+	if normalized == "" {
+		return "", segmentError{Segment: segment, Reason: "segment normalizes to empty"}
+	}
+	if !jobIDSegmentPattern.MatchString(normalized) {
+		return "", segmentError{Segment: segment, Reason: "segment does not match required pattern"}
+	}
+	return normalized, nil
+}

--- a/internal/indexer/jobid.go
+++ b/internal/indexer/jobid.go
@@ -95,9 +95,7 @@ func DotJobIDToSlash(input string) string {
 		return ""
 	}
 	trimmed = strings.ReplaceAll(trimmed, ".", "/")
-	trimmed = strings.ReplaceAll(trimmed, "//", "/")
-	trimmed = strings.Trim(trimmed, "/")
-	return trimmed
+	return compactSlashPath(trimmed)
 }
 
 // SlashJobIDToDot derives a dot-delimited identifier from a slash path.
@@ -106,12 +104,26 @@ func SlashJobIDToDot(input string) string {
 	if trimmed == "" {
 		return ""
 	}
-	trimmed = strings.ReplaceAll(trimmed, "//", "/")
-	trimmed = strings.Trim(trimmed, "/")
+	trimmed = compactSlashPath(trimmed)
 	if trimmed == "" {
 		return ""
 	}
 	return strings.ReplaceAll(trimmed, "/", ".")
+}
+
+func compactSlashPath(input string) string {
+	if input == "" {
+		return ""
+	}
+	segments := strings.Split(strings.Trim(input, "/"), "/")
+	filtered := segments[:0]
+	for _, seg := range segments {
+		if seg == "" {
+			continue
+		}
+		filtered = append(filtered, seg)
+	}
+	return strings.Join(filtered, "/")
 }
 
 func normalizePathInput(value string) string {

--- a/internal/indexer/jobid.go
+++ b/internal/indexer/jobid.go
@@ -90,40 +90,35 @@ func CanonicalJobID(mountPath, jobDirRel string) (string, error) {
 
 // DotJobIDToSlash normalizes legacy dot-delimited job IDs into slash-delimited paths.
 func DotJobIDToSlash(input string) string {
-	trimmed := normalizePathInput(input)
-	if trimmed == "" {
+	segments := splitJobIDSegments(input)
+	if len(segments) == 0 {
 		return ""
 	}
-	trimmed = strings.ReplaceAll(trimmed, ".", "/")
-	return compactSlashPath(trimmed)
+	return strings.Join(segments, "/")
 }
 
 // SlashJobIDToDot derives a dot-delimited identifier from a slash path.
 func SlashJobIDToDot(input string) string {
-	trimmed := normalizePathInput(input)
-	if trimmed == "" {
+	segments := splitJobIDSegments(input)
+	if len(segments) == 0 {
 		return ""
 	}
-	trimmed = compactSlashPath(trimmed)
-	if trimmed == "" {
-		return ""
-	}
-	return strings.ReplaceAll(trimmed, "/", ".")
+	return strings.Join(segments, ".")
 }
 
-func compactSlashPath(input string) string {
-	if input == "" {
-		return ""
+func splitJobIDSegments(input string) []string {
+	normalized := normalizePathInput(input)
+	normalized = strings.TrimSpace(normalized)
+	if normalized == "" {
+		return nil
 	}
-	segments := strings.Split(strings.Trim(input, "/"), "/")
-	filtered := segments[:0]
-	for _, seg := range segments {
-		if seg == "" {
-			continue
-		}
-		filtered = append(filtered, seg)
+	normalized = strings.Trim(normalized, "./")
+	if normalized == "" {
+		return nil
 	}
-	return strings.Join(filtered, "/")
+	return strings.FieldsFunc(normalized, func(r rune) bool {
+		return r == '/' || r == '.'
+	})
 }
 
 func normalizePathInput(value string) string {

--- a/internal/indexer/jobid_test.go
+++ b/internal/indexer/jobid_test.go
@@ -173,6 +173,12 @@ func TestJobIDHelpers(t *testing.T) {
 		if got := DotJobIDToSlash("a...b"); got != "a/b" {
 			t.Fatalf("expected a/b, got %q", got)
 		}
+		if got := DotJobIDToSlash("a///b"); got != "a/b" {
+			t.Fatalf("expected a/b, got %q", got)
+		}
+		if got := DotJobIDToSlash("a././b"); got != "a/b" {
+			t.Fatalf("expected a/b, got %q", got)
+		}
 	})
 
 	t.Run("slash to dot", func(t *testing.T) {
@@ -188,6 +194,12 @@ func TestJobIDHelpers(t *testing.T) {
 			t.Fatalf("expected demo.Build, got %q", got)
 		}
 		if got := SlashJobIDToDot("a///b"); got != "a.b" {
+			t.Fatalf("expected a.b, got %q", got)
+		}
+		if got := SlashJobIDToDot("a...b"); got != "a.b" {
+			t.Fatalf("expected a.b, got %q", got)
+		}
+		if got := SlashJobIDToDot("a././b"); got != "a.b" {
 			t.Fatalf("expected a.b, got %q", got)
 		}
 	})

--- a/internal/indexer/jobid_test.go
+++ b/internal/indexer/jobid_test.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package indexer
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestCanonicalJobIDNormalization(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		mountPath string
+		jobDirRel string
+		want      string
+	}{
+		{
+			name:      "mixed-case and spaces",
+			mountPath: ".",
+			jobDirRel: "Foo/Bar Baz",
+			want:      "foo/bar-baz",
+		},
+		{
+			name:      "mountPath prefix normalized",
+			mountPath: "Scripts",
+			jobDirRel: "Jobs/Hello_World",
+			want:      "scripts/jobs/hello-world",
+		},
+		{
+			name:      "characters require normalization",
+			mountPath: "root",
+			jobDirRel: "demo@job/ci+run",
+			want:      "root/demo-job/ci-run",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := CanonicalJobID(tc.mountPath, tc.jobDirRel)
+			if err != nil {
+				t.Fatalf("CanonicalJobID error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+			if strings.Contains(got, ".") {
+				t.Fatalf("expected slash-only canonical ID, got %q", got)
+			}
+		})
+	}
+}
+
+func TestCanonicalJobIDRootMapping(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		mountPath string
+		jobDirRel string
+		want      string
+	}{
+		{
+			name:      "mountPath dot and job root",
+			mountPath: ".",
+			jobDirRel: ".",
+			want:      "",
+		},
+		{
+			name:      "mountPath dot and empty rel",
+			mountPath: ".",
+			jobDirRel: "",
+			want:      "",
+		},
+		{
+			name:      "mountPath prefix and job root",
+			mountPath: "Scripts",
+			jobDirRel: ".",
+			want:      "scripts",
+		},
+		{
+			name:      "mountPath prefix and empty rel",
+			mountPath: "Scripts",
+			jobDirRel: "",
+			want:      "scripts",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := CanonicalJobID(tc.mountPath, tc.jobDirRel)
+			if err != nil {
+				t.Fatalf("CanonicalJobID error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestCanonicalJobIDInvalidSegments(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		mountPath string
+		jobDirRel string
+		wantErr   string
+		wantSeg   string
+	}{
+		{
+			name:      "empty segment",
+			mountPath: ".",
+			jobDirRel: "demo//child",
+			wantErr:   "empty segment",
+			wantSeg:   "",
+		},
+		{
+			name:      "segment normalizes to empty",
+			mountPath: "!!!",
+			jobDirRel: "demo",
+			wantErr:   "segment normalizes to empty",
+			wantSeg:   "!!!",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := CanonicalJobID(tc.mountPath, tc.jobDirRel)
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			var jobErr JobIDError
+			if !errors.As(err, &jobErr) {
+				t.Fatalf("expected JobIDError, got %T", err)
+			}
+			if tc.wantErr != "" && !strings.Contains(jobErr.Reason, tc.wantErr) {
+				t.Fatalf("expected error to contain %q, got %q", tc.wantErr, jobErr.Reason)
+			}
+			if jobErr.Segment != tc.wantSeg {
+				t.Fatalf("expected segment %q, got %q", tc.wantSeg, jobErr.Segment)
+			}
+		})
+	}
+}
+
+func TestJobIDHelpers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("dot to slash", func(t *testing.T) {
+		t.Parallel()
+
+		if got := DotJobIDToSlash("demo.build"); got != "demo/build" {
+			t.Fatalf("expected demo/build, got %q", got)
+		}
+		if got := DotJobIDToSlash(" . "); got != "" {
+			t.Fatalf("expected empty string, got %q", got)
+		}
+		if got := DotJobIDToSlash("Demo..Build"); got != "Demo/Build" {
+			t.Fatalf("expected Demo/Build, got %q", got)
+		}
+	})
+
+	t.Run("slash to dot", func(t *testing.T) {
+		t.Parallel()
+
+		if got := SlashJobIDToDot("demo/build"); got != "demo.build" {
+			t.Fatalf("expected demo.build, got %q", got)
+		}
+		if got := SlashJobIDToDot("/"); got != "" {
+			t.Fatalf("expected empty string, got %q", got)
+		}
+		if got := SlashJobIDToDot("demo//Build"); got != "demo.Build" {
+			t.Fatalf("expected demo.Build, got %q", got)
+		}
+	})
+}

--- a/internal/indexer/jobid_test.go
+++ b/internal/indexer/jobid_test.go
@@ -170,6 +170,9 @@ func TestJobIDHelpers(t *testing.T) {
 		if got := DotJobIDToSlash("Demo..Build"); got != "Demo/Build" {
 			t.Fatalf("expected Demo/Build, got %q", got)
 		}
+		if got := DotJobIDToSlash("a...b"); got != "a/b" {
+			t.Fatalf("expected a/b, got %q", got)
+		}
 	})
 
 	t.Run("slash to dot", func(t *testing.T) {
@@ -183,6 +186,9 @@ func TestJobIDHelpers(t *testing.T) {
 		}
 		if got := SlashJobIDToDot("demo//Build"); got != "demo.Build" {
 			t.Fatalf("expected demo.Build, got %q", got)
+		}
+		if got := SlashJobIDToDot("a///b"); got != "a.b" {
+			t.Fatalf("expected a.b, got %q", got)
 		}
 	})
 }

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -17,6 +17,7 @@ type authInfo struct {
 	token   string
 	subject string
 	scopes  map[string]struct{}
+	tenant  string
 }
 
 func (a *authInfo) hasScopes(required []string) bool {
@@ -51,6 +52,13 @@ func (a *authInfo) principal() string {
 		return "token:" + hex.EncodeToString(sum[:])
 	}
 	return "anonymous"
+}
+
+func (a *authInfo) tenantClaim() (string, bool) {
+	if a == nil || a.tenant == "" {
+		return "", false
+	}
+	return a.tenant, true
 }
 
 type authContextKey struct{}
@@ -120,11 +128,14 @@ func parseToken(token string, secret string, allowUnsigned bool) (*authInfo, err
 		return nil, err
 	}
 	subject, _ := claims["sub"].(string)
+	tenant, _ := claims["tenant"].(string)
+	tenant = strings.TrimSpace(tenant)
 	scopes := extractScopes(claims)
 	return &authInfo{
 		token:   token,
 		subject: subject,
 		scopes:  scopes,
+		tenant:  tenant,
 	}, nil
 }
 

--- a/internal/server/handlers/discovery_problem.go
+++ b/internal/server/handlers/discovery_problem.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+package handlers
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/flowd-org/flowd/internal/configloader"
+	"github.com/flowd-org/flowd/internal/server/response"
+)
+
+func discoveryProblem(err error) (*response.Problem, bool) {
+	var dual *configloader.DualConfigError
+	if errors.As(err, &dual) {
+		prob := response.New(http.StatusConflict, "invalid job configuration",
+			response.WithExtension("code", configloader.DualConfigCode),
+			response.WithDetail(dual.Error()),
+			response.WithExtension("primary_path", dual.PrimaryPath),
+			response.WithExtension("legacy_path", dual.LegacyPath),
+		)
+		return &prob, true
+	}
+	return nil, false
+}

--- a/internal/server/handlers/discovery_problem.go
+++ b/internal/server/handlers/discovery_problem.go
@@ -13,6 +13,7 @@ func discoveryProblem(err error) (*response.Problem, bool) {
 	var dual *configloader.DualConfigError
 	if errors.As(err, &dual) {
 		prob := response.New(http.StatusConflict, "invalid job configuration",
+			response.WithType(response.ProblemTypeJobConfigDualSentinel),
 			response.WithExtension("code", configloader.DualConfigCode),
 			response.WithDetail(dual.Error()),
 			response.WithExtension("primary_path", dual.PrimaryPath),

--- a/internal/server/handlers/discovery_problem.go
+++ b/internal/server/handlers/discovery_problem.go
@@ -6,10 +6,38 @@ import (
 	"net/http"
 
 	"github.com/flowd-org/flowd/internal/configloader"
+	"github.com/flowd-org/flowd/internal/indexer"
 	"github.com/flowd-org/flowd/internal/server/response"
 )
 
 func discoveryProblem(err error) (*response.Problem, bool) {
+	var invalid indexer.InvalidJobIDError
+	if errors.As(err, &invalid) {
+		prob := response.New(http.StatusConflict, "invalid job id",
+			response.WithType(response.ProblemTypeJobIDInvalidSegment),
+			response.WithExtension("code", response.ProblemCodeJobIDInvalidSegment),
+			response.WithDetail(invalid.Error()),
+			response.WithExtension("segment", invalid.Segment),
+			response.WithExtension("path", invalid.Path),
+			response.WithExtension("reason", invalid.Reason),
+		)
+		if invalid.JobDir != "" {
+			prob.Ext["job_dir"] = invalid.JobDir
+		}
+		return &prob, true
+	}
+	var idErr indexer.JobIDError
+	if errors.As(err, &idErr) {
+		prob := response.New(http.StatusConflict, "invalid job id",
+			response.WithType(response.ProblemTypeJobIDInvalidSegment),
+			response.WithExtension("code", response.ProblemCodeJobIDInvalidSegment),
+			response.WithDetail(idErr.Error()),
+			response.WithExtension("segment", idErr.Segment),
+			response.WithExtension("path", idErr.Path),
+			response.WithExtension("reason", idErr.Reason),
+		)
+		return &prob, true
+	}
 	var dual *configloader.DualConfigError
 	if errors.As(err, &dual) {
 		prob := response.New(http.StatusConflict, "invalid job configuration",

--- a/internal/server/handlers/job_collision.go
+++ b/internal/server/handlers/job_collision.go
@@ -1,0 +1,127 @@
+package handlers
+
+import (
+	"net/http"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/flowd-org/flowd/internal/indexer"
+	"github.com/flowd-org/flowd/internal/server/response"
+	"github.com/flowd-org/flowd/internal/server/sourcestore"
+)
+
+type jobCollisionOrigin struct {
+	SourceKind string `json:"source_kind"`
+	SourceName string `json:"source_name"`
+}
+
+type jobCollisionContender struct {
+	CanonicalJobID string             `json:"canonical_job_id"`
+	Origin         jobCollisionOrigin `json:"origin"`
+	MountPath      string             `json:"mountPath"`
+	JobDir         string             `json:"job_dir"`
+}
+
+func buildCollisionCandidates(jobs []indexer.JobInfo, root string, src *sourcestore.Source) []jobCollisionContender {
+	if len(jobs) == 0 {
+		return nil
+	}
+	candidates := make([]jobCollisionContender, 0, len(jobs))
+	for _, job := range jobs {
+		candidates = append(candidates, buildJobCollisionContender(job, root, src))
+	}
+	return candidates
+}
+
+func buildJobCollisionContender(job indexer.JobInfo, root string, src *sourcestore.Source) jobCollisionContender {
+	jobDir := job.Path
+	if root != "" && job.Path != "" {
+		if rel, err := filepath.Rel(root, job.Path); err == nil {
+			jobDir = rel
+		}
+	}
+	jobDir = filepath.ToSlash(strings.TrimSpace(jobDir))
+	if jobDir == "" {
+		jobDir = "."
+	}
+	origin := jobCollisionOrigin{
+		SourceKind: normalizeJobCollisionSourceKind(""),
+		SourceName: "local",
+	}
+	if src != nil {
+		origin.SourceKind = normalizeJobCollisionSourceKind(src.Type)
+		origin.SourceName = src.Name
+	}
+	return jobCollisionContender{
+		CanonicalJobID: job.ID,
+		Origin:         origin,
+		MountPath:      ".",
+		JobDir:         jobDir,
+	}
+}
+
+func normalizeJobCollisionSourceKind(kind string) string {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "", "fs", "local":
+		return "fs"
+	case "git":
+		return "git"
+	case "oci":
+		return "oci"
+	default:
+		return strings.ToLower(strings.TrimSpace(kind))
+	}
+}
+
+func findJobIDCollision(candidates []jobCollisionContender) (string, []jobCollisionContender, bool) {
+	byID := make(map[string][]jobCollisionContender, len(candidates))
+	for _, candidate := range candidates {
+		key := strings.ToLower(candidate.CanonicalJobID)
+		byID[key] = append(byID[key], candidate)
+	}
+	keys := make([]string, 0, len(byID))
+	for key, list := range byID {
+		if len(list) > 1 {
+			keys = append(keys, key)
+		}
+	}
+	if len(keys) == 0 {
+		return "", nil, false
+	}
+	sort.Strings(keys)
+	key := keys[0]
+	contenders := byID[key]
+	sort.Slice(contenders, func(i, j int) bool {
+		left := contenders[i]
+		right := contenders[j]
+		if left.CanonicalJobID != right.CanonicalJobID {
+			return left.CanonicalJobID < right.CanonicalJobID
+		}
+		if left.Origin.SourceKind != right.Origin.SourceKind {
+			return left.Origin.SourceKind < right.Origin.SourceKind
+		}
+		if left.Origin.SourceName != right.Origin.SourceName {
+			return left.Origin.SourceName < right.Origin.SourceName
+		}
+		if left.MountPath != right.MountPath {
+			return left.MountPath < right.MountPath
+		}
+		return left.JobDir < right.JobDir
+	})
+	canonicalID := contenders[0].CanonicalJobID
+	return canonicalID, contenders, true
+}
+
+func jobIDCollisionProblem(canonicalID string, contenders []jobCollisionContender) response.Problem {
+	detail := "multiple job definitions resolve to the same canonical id"
+	if canonicalID != "" {
+		detail = "multiple job definitions resolve to canonical id \"" + canonicalID + "\""
+	}
+	return response.New(http.StatusConflict, "job id collision",
+		response.WithExtension("code", "job_id.collision"),
+		response.WithDetail(detail),
+		response.WithExtension("canonical_job_id", canonicalID),
+		response.WithExtension("contenders", contenders),
+	)
+}

--- a/internal/server/handlers/job_collision.go
+++ b/internal/server/handlers/job_collision.go
@@ -119,7 +119,8 @@ func jobIDCollisionProblem(canonicalID string, contenders []jobCollisionContende
 		detail = "multiple job definitions resolve to canonical id \"" + canonicalID + "\""
 	}
 	return response.New(http.StatusConflict, "job id collision",
-		response.WithExtension("code", "job_id.collision"),
+		response.WithType(response.ProblemTypeJobIDCollision),
+		response.WithExtension("code", response.ProblemCodeJobIDCollision),
 		response.WithDetail(detail),
 		response.WithExtension("canonical_job_id", canonicalID),
 		response.WithExtension("contenders", contenders),

--- a/internal/server/handlers/job_collision.go
+++ b/internal/server/handlers/job_collision.go
@@ -49,14 +49,19 @@ func buildJobCollisionContender(job indexer.JobInfo, root string, src *sourcesto
 		SourceKind: normalizeJobCollisionSourceKind(""),
 		SourceName: "local",
 	}
+	mountPath := "."
 	if src != nil {
 		origin.SourceKind = normalizeJobCollisionSourceKind(src.Type)
 		origin.SourceName = src.Name
+		mountPath = sourceMountPath(*src)
+		if strings.TrimSpace(mountPath) == "" {
+			mountPath = "."
+		}
 	}
 	return jobCollisionContender{
 		CanonicalJobID: job.ID,
 		Origin:         origin,
-		MountPath:      ".",
+		MountPath:      mountPath,
 		JobDir:         jobDir,
 	}
 }

--- a/internal/server/handlers/job_collision.go
+++ b/internal/server/handlers/job_collision.go
@@ -66,6 +66,27 @@ func buildJobCollisionContender(job indexer.JobInfo, root string, src *sourcesto
 	}
 }
 
+func buildOCIJobCollisionContender(src sourcestore.Source, canonicalID, jobID string) jobCollisionContender {
+	jobDir := filepath.ToSlash(strings.TrimSpace(jobID))
+	if jobDir == "" {
+		jobDir = "."
+	}
+	origin := jobCollisionOrigin{
+		SourceKind: normalizeJobCollisionSourceKind(src.Type),
+		SourceName: src.Name,
+	}
+	mountPath := sourceMountPath(src)
+	if strings.TrimSpace(mountPath) == "" {
+		mountPath = "."
+	}
+	return jobCollisionContender{
+		CanonicalJobID: canonicalID,
+		Origin:         origin,
+		MountPath:      mountPath,
+		JobDir:         jobDir,
+	}
+}
+
 func normalizeJobCollisionSourceKind(kind string) string {
 	switch strings.ToLower(strings.TrimSpace(kind)) {
 	case "", "fs", "local":

--- a/internal/server/handlers/jobs.go
+++ b/internal/server/handlers/jobs.go
@@ -377,6 +377,10 @@ func discoverJobsWithMountPath(target jobTarget, discoverFn func(string) (indexe
 }
 
 func sourceNameMountPath(src sourcestore.Source) string {
+	return sourceLogicalMountPath(src)
+}
+
+func sourceLogicalMountPath(src sourcestore.Source) string {
 	name := strings.TrimSpace(src.Name)
 	if name == "" {
 		return "."

--- a/internal/server/handlers/jobs.go
+++ b/internal/server/handlers/jobs.go
@@ -89,6 +89,7 @@ func NewJobsHandler(cfg JobsConfig) http.Handler {
 			allJobs  []indexer.JobInfo
 			errorCnt int
 		)
+		var collisionCandidates []jobCollisionContender
 
 		aliasSets := make([]indexer.AliasSet, 0)
 		aliasSources := make(map[string]struct{})
@@ -139,8 +140,14 @@ func NewJobsHandler(cfg JobsConfig) http.Handler {
 				}
 				allViews = append(allViews, view)
 				allJobs = append(allJobs, job)
+				collisionCandidates = append(collisionCandidates, buildJobCollisionContender(job, target.root, target.source))
 			}
 			errorCnt += len(discovered.Errors)
+		}
+
+		if canonicalID, contenders, ok := findJobIDCollision(collisionCandidates); ok {
+			response.Write(w, jobIDCollisionProblem(canonicalID, contenders))
+			return
 		}
 
 		aliasIndex, aliasErrs := indexer.BuildAliasIndex(allJobs, aliasSets)

--- a/internal/server/handlers/jobs.go
+++ b/internal/server/handlers/jobs.go
@@ -143,7 +143,6 @@ func NewJobsHandler(cfg JobsConfig) http.Handler {
 				allViews = append(allViews, ociViews...)
 				for _, view := range ociViews {
 					allJobs = append(allJobs, indexer.JobInfo{ID: view.ID, Name: view.Name})
-					logJobEvent(logger, "job.discovered", resolvedTenant, view.ID, view.Origin)
 				}
 				errorCnt += len(ociErrors)
 				continue
@@ -172,13 +171,14 @@ func NewJobsHandler(cfg JobsConfig) http.Handler {
 						Type: target.source.Type,
 					}
 				}
-				logJobEvent(logger, "job.discovered", resolvedTenant, job.ID, origin)
 				allViews = append(allViews, view)
 				allJobs = append(allJobs, job)
 				collisionCandidates = append(collisionCandidates, buildJobCollisionContender(job, target.root, target.source))
 			}
 			errorCnt += len(discovered.Errors)
 		}
+
+		logJobsDiscoverySummary(logger, resolvedTenant, len(allJobs), len(targets), errorCnt)
 
 		if canonicalID, contenders, ok := findJobIDCollision(collisionCandidates); ok {
 			response.Write(w, jobIDCollisionProblem(canonicalID, contenders))
@@ -262,9 +262,7 @@ func NewJobsHandler(cfg JobsConfig) http.Handler {
 			views = allViews[start:end]
 		}
 
-		for _, view := range views {
-			logJobEvent(logger, "job.listed", resolvedTenant, view.ID, view.Origin)
-		}
+		logJobsListedSummary(logger, resolvedTenant, page, perPage, len(allViews), len(views), errorCnt)
 
 		payload, err := json.Marshal(views)
 		if err != nil {
@@ -426,16 +424,28 @@ func mapSourceKind(sourceType string) string {
 	return strings.ToLower(strings.TrimSpace(sourceType))
 }
 
-func logJobEvent(logger *slog.Logger, msg, tenant, jobID string, origin jobOrigin) {
+func logJobsDiscoverySummary(logger *slog.Logger, tenant string, discovered, targets, discoveryErrors int) {
 	if logger == nil {
 		return
 	}
-	logger.Info(msg,
+	logger.Info("jobs.discovered",
 		slog.String("tenant", tenant),
-		slog.String("job_id", jobID),
-		slog.Group("origin",
-			slog.String("source_kind", origin.SourceKind),
-			slog.String("source_name", origin.SourceName),
-		),
+		slog.Int("discovered", discovered),
+		slog.Int("targets", targets),
+		slog.Int("discovery_errors", discoveryErrors),
+	)
+}
+
+func logJobsListedSummary(logger *slog.Logger, tenant string, page, perPage, total, returned, discoveryErrors int) {
+	if logger == nil {
+		return
+	}
+	logger.Info("jobs.listed",
+		slog.String("tenant", tenant),
+		slog.Int("page", page),
+		slog.Int("per_page", perPage),
+		slog.Int("total", total),
+		slog.Int("returned", returned),
+		slog.Int("discovery_errors", discoveryErrors),
 	)
 }

--- a/internal/server/handlers/jobs.go
+++ b/internal/server/handlers/jobs.go
@@ -118,6 +118,10 @@ func NewJobsHandler(cfg JobsConfig) http.Handler {
 
 			discovered, dErr := discoverFn(target.root)
 			if dErr != nil {
+				if prob, ok := discoveryProblem(dErr); ok {
+					response.Write(w, *prob)
+					return
+				}
 				response.Write(w, response.New(http.StatusInternalServerError, "job discovery failed", response.WithDetail(dErr.Error())))
 				return
 			}

--- a/internal/server/handlers/jobs.go
+++ b/internal/server/handlers/jobs.go
@@ -369,11 +369,19 @@ func discoverJobsWithMountPath(target jobTarget, discoverFn func(string) (indexe
 	if target.source == nil {
 		return discoverFn(target.root)
 	}
-	mountPath := sourceMountPath(*target.source)
+	mountPath := sourceNameMountPath(*target.source)
 	if strings.TrimSpace(mountPath) == "" || mountPath == "." {
 		return discoverFn(target.root)
 	}
 	return indexer.DiscoverWithMountPath(target.root, mountPath)
+}
+
+func sourceNameMountPath(src sourcestore.Source) string {
+	name := strings.TrimSpace(src.Name)
+	if name == "" {
+		return "."
+	}
+	return name
 }
 
 func discoverOCIJobs(src sourcestore.Source, tenant string, origin jobOrigin) ([]jobView, []indexer.DiscoveryError) {

--- a/internal/server/handlers/jobs.go
+++ b/internal/server/handlers/jobs.go
@@ -35,12 +35,19 @@ type JobsConfig struct {
 type jobView struct {
 	ID          string        `json:"id"`
 	Name        string        `json:"name"`
+	Tenant      string        `json:"tenant"`
+	Origin      jobOrigin     `json:"origin"`
 	Description string        `json:"description,omitempty"`
 	Args        []interface{} `json:"args,omitempty"`
 	Extends     []string      `json:"extends,omitempty"`
 	Source      *jobSource    `json:"source,omitempty"`
 	AliasOf     string        `json:"alias_of,omitempty"`
 	AliasDetail string        `json:"alias_detail,omitempty"`
+}
+
+type jobOrigin struct {
+	SourceKind string `json:"source_kind"`
+	SourceName string `json:"source_name"`
 }
 
 type jobSource struct {
@@ -78,6 +85,12 @@ func NewJobsHandler(cfg JobsConfig) http.Handler {
 			return
 		}
 
+		resolvedTenant, prob := resolveTenant(r.Context(), "")
+		if prob != nil {
+			response.Write(w, *prob)
+			return
+		}
+
 		targets, err := resolveJobTargets(cfg.Root, cfg.Sources)
 		if err != nil {
 			response.Write(w, response.New(http.StatusInternalServerError, "resolve sources failed", response.WithDetail(err.Error())))
@@ -100,7 +113,21 @@ func NewJobsHandler(cfg JobsConfig) http.Handler {
 			aliasSets = append(aliasSets, indexer.AliasSet{Source: "", Aliases: aliases})
 		}
 
+		sourceKindByName := make(map[string]string)
 		for _, target := range targets {
+			if target.source != nil {
+				sourceKindByName[target.source.Name] = mapSourceKind(target.source.Type)
+			}
+		}
+
+		for _, target := range targets {
+			origin := defaultJobOrigin()
+			if target.source != nil {
+				origin = jobOrigin{
+					SourceKind: mapSourceKind(target.source.Type),
+					SourceName: target.source.Name,
+				}
+			}
 			if target.source != nil && len(target.source.Aliases) > 0 {
 				if _, ok := aliasSources[target.source.Name]; !ok {
 					aliasSets = append(aliasSets, indexer.AliasSet{Source: target.source.Name, Aliases: target.source.Aliases})
@@ -108,7 +135,7 @@ func NewJobsHandler(cfg JobsConfig) http.Handler {
 				}
 			}
 			if target.source != nil && strings.EqualFold(target.source.Type, "oci") {
-				ociViews, ociErrors := discoverOCIJobs(*target.source)
+				ociViews, ociErrors := discoverOCIJobs(*target.source, resolvedTenant, origin)
 				allViews = append(allViews, ociViews...)
 				for _, view := range ociViews {
 					allJobs = append(allJobs, indexer.JobInfo{ID: view.ID, Name: view.Name})
@@ -130,6 +157,8 @@ func NewJobsHandler(cfg JobsConfig) http.Handler {
 				view := jobView{
 					ID:          job.ID,
 					Name:        job.Name,
+					Tenant:      resolvedTenant,
+					Origin:      origin,
 					Description: job.Summary,
 				}
 				if target.source != nil {
@@ -165,9 +194,17 @@ func NewJobsHandler(cfg JobsConfig) http.Handler {
 					continue
 				}
 				seenAliases[key] = struct{}{}
+				origin := defaultJobOrigin()
+				if alias.Source != "" {
+					if kind, ok := sourceKindByName[alias.Source]; ok {
+						origin = jobOrigin{SourceKind: kind, SourceName: alias.Source}
+					}
+				}
 				aliasView := jobView{
 					ID:      alias.Name,
 					Name:    alias.Name,
+					Tenant:  resolvedTenant,
+					Origin:  origin,
 					AliasOf: alias.TargetPath,
 				}
 				aliasView.Description = fmt.Sprintf("[alias] %s", alias.TargetPath)
@@ -320,7 +357,7 @@ func resolveJobTargets(defaultRoot string, store *sourcestore.Store) ([]jobTarge
 	return targets, nil
 }
 
-func discoverOCIJobs(src sourcestore.Source) ([]jobView, []indexer.DiscoveryError) {
+func discoverOCIJobs(src sourcestore.Source, tenant string, origin jobOrigin) ([]jobView, []indexer.DiscoveryError) {
 	manifest, err := loadAddonManifestFromSource(src)
 	if err != nil {
 		return nil, []indexer.DiscoveryError{{
@@ -344,6 +381,8 @@ func discoverOCIJobs(src sourcestore.Source) ([]jobView, []indexer.DiscoveryErro
 		view := jobView{
 			ID:          id,
 			Name:        name,
+			Tenant:      tenant,
+			Origin:      origin,
 			Description: job.Summary,
 			Source: &jobSource{
 				Name: src.Name,
@@ -353,4 +392,15 @@ func discoverOCIJobs(src sourcestore.Source) ([]jobView, []indexer.DiscoveryErro
 		views = append(views, view)
 	}
 	return views, nil
+}
+
+func defaultJobOrigin() jobOrigin {
+	return jobOrigin{SourceKind: "fs", SourceName: "local"}
+}
+
+func mapSourceKind(sourceType string) string {
+	if strings.EqualFold(sourceType, "local") {
+		return "fs"
+	}
+	return strings.ToLower(strings.TrimSpace(sourceType))
 }

--- a/internal/server/handlers/jobs.go
+++ b/internal/server/handlers/jobs.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"sort"
@@ -12,6 +13,7 @@ import (
 	"github.com/flowd-org/flowd/internal/configloader"
 	"github.com/flowd-org/flowd/internal/indexer"
 	"github.com/flowd-org/flowd/internal/server/headers"
+	"github.com/flowd-org/flowd/internal/server/requestctx"
 	"github.com/flowd-org/flowd/internal/server/response"
 	"github.com/flowd-org/flowd/internal/server/sourcestore"
 )
@@ -91,6 +93,8 @@ func NewJobsHandler(cfg JobsConfig) http.Handler {
 			return
 		}
 
+		logger := requestctx.Logger(r.Context())
+
 		targets, err := resolveJobTargets(cfg.Root, cfg.Sources)
 		if err != nil {
 			response.Write(w, response.New(http.StatusInternalServerError, "resolve sources failed", response.WithDetail(err.Error())))
@@ -139,6 +143,7 @@ func NewJobsHandler(cfg JobsConfig) http.Handler {
 				allViews = append(allViews, ociViews...)
 				for _, view := range ociViews {
 					allJobs = append(allJobs, indexer.JobInfo{ID: view.ID, Name: view.Name})
+					logJobEvent(logger, "job.discovered", resolvedTenant, view.ID, view.Origin)
 				}
 				errorCnt += len(ociErrors)
 				continue
@@ -167,6 +172,7 @@ func NewJobsHandler(cfg JobsConfig) http.Handler {
 						Type: target.source.Type,
 					}
 				}
+				logJobEvent(logger, "job.discovered", resolvedTenant, job.ID, origin)
 				allViews = append(allViews, view)
 				allJobs = append(allJobs, job)
 				collisionCandidates = append(collisionCandidates, buildJobCollisionContender(job, target.root, target.source))
@@ -254,6 +260,10 @@ func NewJobsHandler(cfg JobsConfig) http.Handler {
 				end = len(allViews)
 			}
 			views = allViews[start:end]
+		}
+
+		for _, view := range views {
+			logJobEvent(logger, "job.listed", resolvedTenant, view.ID, view.Origin)
 		}
 
 		payload, err := json.Marshal(views)
@@ -403,4 +413,18 @@ func mapSourceKind(sourceType string) string {
 		return "fs"
 	}
 	return strings.ToLower(strings.TrimSpace(sourceType))
+}
+
+func logJobEvent(logger *slog.Logger, msg, tenant, jobID string, origin jobOrigin) {
+	if logger == nil {
+		return
+	}
+	logger.Info(msg,
+		slog.String("tenant", tenant),
+		slog.String("job_id", jobID),
+		slog.Group("origin",
+			slog.String("source_kind", origin.SourceKind),
+			slog.String("source_name", origin.SourceName),
+		),
+	)
 }

--- a/internal/server/handlers/jobs.go
+++ b/internal/server/handlers/jobs.go
@@ -149,7 +149,7 @@ func NewJobsHandler(cfg JobsConfig) http.Handler {
 				continue
 			}
 
-			discovered, dErr := discoverFn(target.root)
+			discovered, dErr := discoverJobsWithMountPath(target, discoverFn)
 			if dErr != nil {
 				if prob, ok := discoveryProblem(dErr); ok {
 					response.Write(w, *prob)
@@ -365,6 +365,17 @@ func resolveJobTargets(defaultRoot string, store *sourcestore.Store) ([]jobTarge
 	}
 
 	return targets, nil
+}
+
+func discoverJobsWithMountPath(target jobTarget, discoverFn func(string) (indexer.Result, error)) (indexer.Result, error) {
+	if target.source == nil {
+		return discoverFn(target.root)
+	}
+	mountPath := sourceMountPath(*target.source)
+	if strings.TrimSpace(mountPath) == "" || mountPath == "." {
+		return discoverFn(target.root)
+	}
+	return indexer.DiscoverWithMountPath(target.root, mountPath)
 }
 
 func discoverOCIJobs(src sourcestore.Source, tenant string, origin jobOrigin) ([]jobView, []indexer.DiscoveryError) {

--- a/internal/server/handlers/jobs.go
+++ b/internal/server/handlers/jobs.go
@@ -139,11 +139,12 @@ func NewJobsHandler(cfg JobsConfig) http.Handler {
 				}
 			}
 			if target.source != nil && strings.EqualFold(target.source.Type, "oci") {
-				ociViews, ociErrors := discoverOCIJobs(*target.source, resolvedTenant, origin)
+				ociViews, ociCandidates, ociErrors := discoverOCIJobs(*target.source, resolvedTenant, origin)
 				allViews = append(allViews, ociViews...)
 				for _, view := range ociViews {
 					allJobs = append(allJobs, indexer.JobInfo{ID: view.ID, Name: view.Name})
 				}
+				collisionCandidates = append(collisionCandidates, ociCandidates...)
 				errorCnt += len(ociErrors)
 				continue
 			}
@@ -388,18 +389,19 @@ func sourceLogicalMountPath(src sourcestore.Source) string {
 	return name
 }
 
-func discoverOCIJobs(src sourcestore.Source, tenant string, origin jobOrigin) ([]jobView, []indexer.DiscoveryError) {
+func discoverOCIJobs(src sourcestore.Source, tenant string, origin jobOrigin) ([]jobView, []jobCollisionContender, []indexer.DiscoveryError) {
 	manifest, err := loadAddonManifestFromSource(src)
 	if err != nil {
-		return nil, []indexer.DiscoveryError{{
+		return nil, nil, []indexer.DiscoveryError{{
 			Path: fmt.Sprintf("oci://%s", src.Name),
 			Err:  err.Error(),
 		}}
 	}
 	if manifest == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
-	var views []jobView
+	views := make([]jobView, 0, len(manifest.Jobs))
+	candidates := make([]jobCollisionContender, 0, len(manifest.Jobs))
 	for _, job := range manifest.Jobs {
 		if strings.TrimSpace(job.ID) == "" {
 			continue
@@ -421,8 +423,9 @@ func discoverOCIJobs(src sourcestore.Source, tenant string, origin jobOrigin) ([
 			},
 		}
 		views = append(views, view)
+		candidates = append(candidates, buildOCIJobCollisionContender(src, id, job.ID))
 	}
-	return views, nil
+	return views, candidates, nil
 }
 
 func defaultJobOrigin() jobOrigin {

--- a/internal/server/handlers/jobs_test.go
+++ b/internal/server/handlers/jobs_test.go
@@ -223,6 +223,50 @@ func TestJobsHandlerDualConfigProblem(t *testing.T) {
 	}
 }
 
+func TestJobsHandlerInvalidJobIDProblem(t *testing.T) {
+	root := t.TempDir()
+	jobDir := filepath.Join(root, "!!!")
+	if err := os.MkdirAll(jobDir, 0o755); err != nil {
+		t.Fatalf("mkdir job dir: %v", err)
+	}
+	config := `version: v1
+job:
+  name: Bad Job
+`
+	if err := os.WriteFile(filepath.Join(jobDir, "config.yaml"), []byte(config), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	handler := NewJobsHandler(JobsConfig{Root: root})
+	req := httptest.NewRequest(http.MethodGet, "/jobs", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+	contentType := rec.Header().Get("Content-Type")
+	if !strings.HasPrefix(contentType, "application/problem+json") {
+		t.Fatalf("expected problem+json content type, got %s", contentType)
+	}
+	var prob map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&prob); err != nil {
+		t.Fatalf("decode problem: %v", err)
+	}
+	if prob["code"] != response.ProblemCodeJobIDInvalidSegment {
+		t.Fatalf("expected code %q, got %+v", response.ProblemCodeJobIDInvalidSegment, prob["code"])
+	}
+	if prob["type"] != response.ProblemTypeJobIDInvalidSegment {
+		t.Fatalf("expected type %q, got %+v", response.ProblemTypeJobIDInvalidSegment, prob["type"])
+	}
+	if seg, ok := prob["segment"].(string); !ok || seg == "" {
+		t.Fatalf("expected segment string, got %+v", prob["segment"])
+	}
+	if path, ok := prob["path"].(string); !ok || path == "" {
+		t.Fatalf("expected path string, got %+v", prob["path"])
+	}
+}
+
 func TestJobsHandlerCollisionDeterministicOrder(t *testing.T) {
 	root := t.TempDir()
 	config := `version: v1

--- a/internal/server/handlers/jobs_test.go
+++ b/internal/server/handlers/jobs_test.go
@@ -117,6 +117,104 @@ func TestJobsHandlerOCIManifestErrorCounts(t *testing.T) {
 	}
 }
 
+func TestJobsHandlerCollisionIncludesOCIJobs(t *testing.T) {
+	root := t.TempDir()
+	jobDir := filepath.Join(root, "addon", "build")
+	if err := os.MkdirAll(jobDir, 0o755); err != nil {
+		t.Fatalf("mkdir job dir: %v", err)
+	}
+	config := `version: v1
+job:
+  name: Local Build
+`
+	if err := os.WriteFile(filepath.Join(jobDir, "config.yaml"), []byte(config), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	store := sourcestore.New()
+	tempDir := t.TempDir()
+	manifestPath := filepath.Join(tempDir, "manifest.yaml")
+	if err := os.WriteFile(manifestPath, []byte(`
+apiVersion: flwd.addon/v1
+kind: AddOn
+metadata:
+  name: Example Addon
+  id: example.addon
+  version: 1.0.0
+requires: {}
+jobs:
+  - id: build
+    name: Build Project
+    summary: Compile the project
+    argspec:
+      args: []
+`), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	store.Upsert(sourcestore.Source{
+		Name:      "addon",
+		Type:      "oci",
+		LocalPath: tempDir,
+		Metadata: map[string]any{
+			"manifest_path": manifestPath,
+		},
+	})
+
+	handler := NewJobsHandler(JobsConfig{
+		Root:    root,
+		Sources: store,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/jobs", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+	contentType := rec.Header().Get("Content-Type")
+	if !strings.HasPrefix(contentType, "application/problem+json") {
+		t.Fatalf("expected problem+json content type, got %s", contentType)
+	}
+
+	var prob map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&prob); err != nil {
+		t.Fatalf("decode problem: %v", err)
+	}
+	if prob["code"] != response.ProblemCodeJobIDCollision {
+		t.Fatalf("expected code %q, got %+v", response.ProblemCodeJobIDCollision, prob["code"])
+	}
+	if prob["canonical_job_id"] != "addon/build" {
+		t.Fatalf("expected canonical_job_id addon/build, got %+v", prob["canonical_job_id"])
+	}
+	contendersRaw, ok := prob["contenders"].([]any)
+	if !ok {
+		t.Fatalf("expected contenders array, got %+v", prob["contenders"])
+	}
+	if len(contendersRaw) != 2 {
+		t.Fatalf("expected 2 contenders, got %d", len(contendersRaw))
+	}
+
+	seenKinds := map[string]bool{}
+	for _, entry := range contendersRaw {
+		contender, ok := entry.(map[string]any)
+		if !ok {
+			t.Fatalf("expected contender map, got %+v", entry)
+		}
+		origin, ok := contender["origin"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected origin map, got %+v", contender["origin"])
+		}
+		if kind, ok := origin["source_kind"].(string); ok && kind != "" {
+			seenKinds[kind] = true
+		}
+	}
+	if !seenKinds["fs"] || !seenKinds["oci"] {
+		t.Fatalf("expected contenders for fs and oci, got %+v", seenKinds)
+	}
+}
+
 func TestJobsHandlerAliasVisibilityPolicy(t *testing.T) {
 	root := t.TempDir()
 	aliasConfig := []byte(`aliases:

--- a/internal/server/handlers/jobs_test.go
+++ b/internal/server/handlers/jobs_test.go
@@ -9,10 +9,13 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/flowd-org/flowd/internal/configloader"
 	"github.com/flowd-org/flowd/internal/indexer"
 	"github.com/flowd-org/flowd/internal/server/headers"
+	"github.com/flowd-org/flowd/internal/server/response"
 	"github.com/flowd-org/flowd/internal/server/sourcestore"
 )
 
@@ -182,5 +185,128 @@ func TestJobsHandlerAliasVisibilityPolicy(t *testing.T) {
 	}
 	if !foundAlias {
 		t.Fatalf("expected alias entry hello-demo in job list: %#v", jobs)
+	}
+}
+
+func TestJobsHandlerDualConfigProblem(t *testing.T) {
+	handler := NewJobsHandler(JobsConfig{
+		Discover: func(string) (indexer.Result, error) {
+			return indexer.Result{}, &configloader.DualConfigError{
+				ScriptDir:   "/tmp/scripts/demo",
+				PrimaryPath: "/tmp/scripts/demo/config.yaml",
+				LegacyPath:  "/tmp/scripts/demo/config.d/config.yaml",
+			}
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/jobs", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+	contentType := rec.Header().Get("Content-Type")
+	if !strings.HasPrefix(contentType, "application/problem+json") {
+		t.Fatalf("expected problem+json content type, got %s", contentType)
+	}
+
+	var prob map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&prob); err != nil {
+		t.Fatalf("decode problem: %v", err)
+	}
+	if prob["code"] != configloader.DualConfigCode {
+		t.Fatalf("expected code %q, got %+v", configloader.DualConfigCode, prob["code"])
+	}
+	if prob["type"] != response.ProblemTypeJobConfigDualSentinel {
+		t.Fatalf("expected type %q, got %+v", response.ProblemTypeJobConfigDualSentinel, prob["type"])
+	}
+}
+
+func TestJobsHandlerCollisionDeterministicOrder(t *testing.T) {
+	root := t.TempDir()
+	localDir := filepath.Join(root, "demo")
+	if err := os.MkdirAll(localDir, 0o755); err != nil {
+		t.Fatalf("mkdir local: %v", err)
+	}
+	config := `version: v1
+job:
+  name: Demo
+`
+	if err := os.WriteFile(filepath.Join(localDir, "config.yaml"), []byte(config), 0o644); err != nil {
+		t.Fatalf("write local config: %v", err)
+	}
+
+	remoteRoot := t.TempDir()
+	remoteDir := filepath.Join(remoteRoot, "demo")
+	if err := os.MkdirAll(remoteDir, 0o755); err != nil {
+		t.Fatalf("mkdir remote: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(remoteDir, "config.yaml"), []byte(config), 0o644); err != nil {
+		t.Fatalf("write remote config: %v", err)
+	}
+
+	store := sourcestore.New()
+	store.Upsert(sourcestore.Source{
+		Name:      "alpha",
+		Type:      "git",
+		LocalPath: remoteRoot,
+	})
+
+	handler := NewJobsHandler(JobsConfig{
+		Root:    root,
+		Sources: store,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/jobs", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+	contentType := rec.Header().Get("Content-Type")
+	if !strings.HasPrefix(contentType, "application/problem+json") {
+		t.Fatalf("expected problem+json content type, got %s", contentType)
+	}
+
+	var prob map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&prob); err != nil {
+		t.Fatalf("decode problem: %v", err)
+	}
+	if prob["code"] != response.ProblemCodeJobIDCollision {
+		t.Fatalf("expected code %q, got %+v", response.ProblemCodeJobIDCollision, prob["code"])
+	}
+	if prob["canonical_job_id"] != "demo" {
+		t.Fatalf("expected canonical_job_id demo, got %+v", prob["canonical_job_id"])
+	}
+	contendersRaw, ok := prob["contenders"].([]any)
+	if !ok {
+		t.Fatalf("expected contenders array, got %+v", prob["contenders"])
+	}
+	if len(contendersRaw) != 2 {
+		t.Fatalf("expected 2 contenders, got %d", len(contendersRaw))
+	}
+	first, ok := contendersRaw[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected contender map, got %+v", contendersRaw[0])
+	}
+	second, ok := contendersRaw[1].(map[string]any)
+	if !ok {
+		t.Fatalf("expected contender map, got %+v", contendersRaw[1])
+	}
+	firstOrigin, ok := first["origin"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected origin map, got %+v", first["origin"])
+	}
+	secondOrigin, ok := second["origin"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected origin map, got %+v", second["origin"])
+	}
+	if firstOrigin["source_kind"] != "fs" || firstOrigin["source_name"] != "local" {
+		t.Fatalf("expected local fs contender first, got %+v", firstOrigin)
+	}
+	if secondOrigin["source_kind"] != "git" || secondOrigin["source_name"] != "alpha" {
+		t.Fatalf("expected git contender second, got %+v", secondOrigin)
 	}
 }

--- a/internal/server/handlers/jobs_test.go
+++ b/internal/server/handlers/jobs_test.go
@@ -225,25 +225,26 @@ func TestJobsHandlerDualConfigProblem(t *testing.T) {
 
 func TestJobsHandlerCollisionDeterministicOrder(t *testing.T) {
 	root := t.TempDir()
-	localDir := filepath.Join(root, "demo")
-	if err := os.MkdirAll(localDir, 0o755); err != nil {
-		t.Fatalf("mkdir local: %v", err)
-	}
 	config := `version: v1
 job:
   name: Demo
 `
-	if err := os.WriteFile(filepath.Join(localDir, "config.yaml"), []byte(config), 0o644); err != nil {
-		t.Fatalf("write local config: %v", err)
-	}
 
 	remoteRoot := t.TempDir()
-	remoteDir := filepath.Join(remoteRoot, "demo")
-	if err := os.MkdirAll(remoteDir, 0o755); err != nil {
-		t.Fatalf("mkdir remote: %v", err)
+	remoteBase := filepath.Join(remoteRoot, "demo")
+	if err := os.MkdirAll(remoteBase, 0o755); err != nil {
+		t.Fatalf("mkdir remote base: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(remoteDir, "config.yaml"), []byte(config), 0o644); err != nil {
-		t.Fatalf("write remote config: %v", err)
+	if err := os.WriteFile(filepath.Join(remoteBase, "config.yaml"), []byte(config), 0o644); err != nil {
+		t.Fatalf("write remote base config: %v", err)
+	}
+
+	remoteAlt := filepath.Join(remoteRoot, "demo!")
+	if err := os.MkdirAll(remoteAlt, 0o755); err != nil {
+		t.Fatalf("mkdir remote alt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(remoteAlt, "config.yaml"), []byte(config), 0o644); err != nil {
+		t.Fatalf("write remote alt config: %v", err)
 	}
 
 	store := sourcestore.New()
@@ -277,8 +278,12 @@ job:
 	if prob["code"] != response.ProblemCodeJobIDCollision {
 		t.Fatalf("expected code %q, got %+v", response.ProblemCodeJobIDCollision, prob["code"])
 	}
-	if prob["canonical_job_id"] != "demo" {
-		t.Fatalf("expected canonical_job_id demo, got %+v", prob["canonical_job_id"])
+	expectedID, err := indexer.CanonicalJobID(remoteRoot, "demo")
+	if err != nil {
+		t.Fatalf("canonical id: %v", err)
+	}
+	if prob["canonical_job_id"] != expectedID {
+		t.Fatalf("expected canonical_job_id %s, got %+v", expectedID, prob["canonical_job_id"])
 	}
 	contendersRaw, ok := prob["contenders"].([]any)
 	if !ok {
@@ -303,10 +308,16 @@ job:
 	if !ok {
 		t.Fatalf("expected origin map, got %+v", second["origin"])
 	}
-	if firstOrigin["source_kind"] != "fs" || firstOrigin["source_name"] != "local" {
-		t.Fatalf("expected local fs contender first, got %+v", firstOrigin)
+	if firstOrigin["source_kind"] != "git" || firstOrigin["source_name"] != "alpha" {
+		t.Fatalf("expected git contender first, got %+v", firstOrigin)
 	}
 	if secondOrigin["source_kind"] != "git" || secondOrigin["source_name"] != "alpha" {
 		t.Fatalf("expected git contender second, got %+v", secondOrigin)
+	}
+	if first["mountPath"] != remoteRoot || second["mountPath"] != remoteRoot {
+		t.Fatalf("expected contenders mountPath %s, got %+v and %+v", remoteRoot, first["mountPath"], second["mountPath"])
+	}
+	if first["job_dir"] != "demo" || second["job_dir"] != "demo!" {
+		t.Fatalf("expected deterministic job_dir order demo then demo!, got %+v and %+v", first["job_dir"], second["job_dir"])
 	}
 }

--- a/internal/server/handlers/jobs_test.go
+++ b/internal/server/handlers/jobs_test.go
@@ -322,7 +322,7 @@ job:
 	if prob["code"] != response.ProblemCodeJobIDCollision {
 		t.Fatalf("expected code %q, got %+v", response.ProblemCodeJobIDCollision, prob["code"])
 	}
-	expectedID, err := indexer.CanonicalJobID(remoteRoot, "demo")
+	expectedID, err := indexer.CanonicalJobID("alpha", "demo")
 	if err != nil {
 		t.Fatalf("canonical id: %v", err)
 	}

--- a/internal/server/handlers/journal_sink.go
+++ b/internal/server/handlers/journal_sink.go
@@ -43,6 +43,7 @@ func (s *journalEventSink) Publish(runID string, ev sse.Event) {
 	data := ev.Data
 	if data != "" {
 		data = ensureJournalIdentityPayload(data, ev.Tenant)
+		ev.Data = data
 	}
 	entry, err := s.journal.Append(context.Background(), runID, ev.Event, []byte(data), ts)
 	if err != nil {

--- a/internal/server/handlers/journal_sink.go
+++ b/internal/server/handlers/journal_sink.go
@@ -67,20 +67,23 @@ func ensureJournalIdentityPayload(data string, tenant string) string {
 		return data
 	}
 
-	if tenant != "" {
-		if _, ok := payload["tenant"]; !ok {
-			payload["tenant"] = tenant
-		}
+	var (
+		provenanceTenant string
+		provenanceOrigin jobOrigin
+		hasProvenance    bool
+	)
+	if provenance, ok := payload["provenance"].(map[string]any); ok {
+		provenanceTenant, provenanceOrigin, hasProvenance = runIdentityFromProvenance(provenance)
 	}
 
-	if _, ok := payload["origin"]; !ok {
-		provenance, ok := payload["provenance"].(map[string]any)
-		if ok {
-			_, origin, found := runIdentityFromProvenance(provenance)
-			if found && (origin.SourceKind != "" || origin.SourceName != "") {
-				payload["origin"] = origin
-			}
-		}
+	if tenant != "" {
+		payload["tenant"] = tenant
+	} else if hasProvenance && provenanceTenant != "" {
+		payload["tenant"] = provenanceTenant
+	}
+
+	if hasProvenance && (provenanceOrigin.SourceKind != "" || provenanceOrigin.SourceName != "") {
+		payload["origin"] = provenanceOrigin
 	}
 
 	bytes, err := json.Marshal(payload)

--- a/internal/server/handlers/journal_sink.go
+++ b/internal/server/handlers/journal_sink.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"strconv"
 	"time"
@@ -39,7 +40,11 @@ func (s *journalEventSink) Publish(runID string, ev sse.Event) {
 	if ts.IsZero() {
 		ts = time.Now().UTC()
 	}
-	entry, err := s.journal.Append(context.Background(), runID, ev.Event, []byte(ev.Data), ts)
+	data := ev.Data
+	if data != "" {
+		data = ensureJournalIdentityPayload(data, ev.Tenant)
+	}
+	entry, err := s.journal.Append(context.Background(), runID, ev.Event, []byte(data), ts)
 	if err != nil {
 		if s.logger != nil {
 			s.logger.Error("persist run event", slog.String("run_id", runID), slog.String("event", ev.Event), slog.String("error", err.Error()))
@@ -54,4 +59,33 @@ func (s *journalEventSink) Publish(runID string, ev sse.Event) {
 	if s.next != nil {
 		s.next.Publish(runID, ev)
 	}
+}
+
+func ensureJournalIdentityPayload(data string, tenant string) string {
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(data), &payload); err != nil || len(payload) == 0 {
+		return data
+	}
+
+	if tenant != "" {
+		if _, ok := payload["tenant"]; !ok {
+			payload["tenant"] = tenant
+		}
+	}
+
+	if _, ok := payload["origin"]; !ok {
+		provenance, ok := payload["provenance"].(map[string]any)
+		if ok {
+			_, origin, found := runIdentityFromProvenance(provenance)
+			if found && (origin.SourceKind != "" || origin.SourceName != "") {
+				payload["origin"] = origin
+			}
+		}
+	}
+
+	bytes, err := json.Marshal(payload)
+	if err != nil {
+		return data
+	}
+	return string(bytes)
 }

--- a/internal/server/handlers/journal_sink_test.go
+++ b/internal/server/handlers/journal_sink_test.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/flowd-org/flowd/internal/server/sse"
 )
 
 func TestEnsureJournalIdentityPayloadPrefersEnvelopeTenantAndProvenanceOrigin(t *testing.T) {
@@ -44,6 +46,36 @@ func TestEnsureJournalIdentityPayloadFallsBackToProvenanceTenant(t *testing.T) {
 
 	if got := payload["tenant"]; got != "prov-tenant" {
 		t.Fatalf("tenant = %v, want prov-tenant", got)
+	}
+}
+
+func TestJournalEventSinkPublishSanitizesForwardedPayload(t *testing.T) {
+	t.Parallel()
+
+	journal := newTestJournal(t)
+	var forwarded sse.Event
+	sink := NewJournalEventSink(journal, EventSinkFunc(func(_ string, ev sse.Event) {
+		forwarded = ev
+	}))
+
+	input := `{
+		"tenant":"stale-tenant",
+		"origin":{"source_kind":"stale-kind","source_name":"stale-name"},
+		"provenance":{
+			"tenant":"prov-tenant",
+			"origin":{"source_kind":"git","source_name":"repo-a"}
+		}
+	}`
+
+	sink.Publish("run-1", sse.Event{Event: "run.started", Tenant: "event-tenant", Data: input})
+
+	payload := decodeJSONMap(t, forwarded.Data)
+	if got := payload["tenant"]; got != "event-tenant" {
+		t.Fatalf("forwarded tenant = %v, want event-tenant", got)
+	}
+	origin := originFromAny(payload["origin"])
+	if origin.SourceKind != "git" || origin.SourceName != "repo-a" {
+		t.Fatalf("forwarded origin = %+v, want {source_kind:git source_name:repo-a}", origin)
 	}
 }
 

--- a/internal/server/handlers/journal_sink_test.go
+++ b/internal/server/handlers/journal_sink_test.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestEnsureJournalIdentityPayloadPrefersEnvelopeTenantAndProvenanceOrigin(t *testing.T) {
+	t.Parallel()
+
+	input := `{
+		"tenant":"stale-tenant",
+		"origin":{"source_kind":"stale-kind","source_name":"stale-name"},
+		"provenance":{
+			"tenant":"prov-tenant",
+			"origin":{"source_kind":"git","source_name":"repo-a"}
+		}
+	}`
+
+	out := ensureJournalIdentityPayload(input, "event-tenant")
+	payload := decodeJSONMap(t, out)
+
+	if got := payload["tenant"]; got != "event-tenant" {
+		t.Fatalf("tenant = %v, want event-tenant", got)
+	}
+	origin := originFromAny(payload["origin"])
+	if origin.SourceKind != "git" || origin.SourceName != "repo-a" {
+		t.Fatalf("origin = %+v, want {source_kind:git source_name:repo-a}", origin)
+	}
+}
+
+func TestEnsureJournalIdentityPayloadFallsBackToProvenanceTenant(t *testing.T) {
+	t.Parallel()
+
+	input := `{
+		"tenant":"stale-tenant",
+		"provenance":{
+			"tenant":"prov-tenant"
+		}
+	}`
+
+	out := ensureJournalIdentityPayload(input, "")
+	payload := decodeJSONMap(t, out)
+
+	if got := payload["tenant"]; got != "prov-tenant" {
+		t.Fatalf("tenant = %v, want prov-tenant", got)
+	}
+}
+
+func decodeJSONMap(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	return payload
+}

--- a/internal/server/handlers/plans.go
+++ b/internal/server/handlers/plans.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -96,6 +95,10 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 
 		result, err := discoverFn(discoverRoot)
 		if err != nil {
+			if prob, ok := discoveryProblem(err); ok {
+				response.Write(w, *prob)
+				return
+			}
 			response.Write(w, response.New(http.StatusInternalServerError, "job discovery failed", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 			return
 		}
@@ -112,7 +115,7 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 		var jobPath string
 		setJobPath := func(id string) bool {
 			if job, ok := jobMap[strings.ToLower(id)]; ok {
-				jobPath = filepath.Dir(job.Path)
+				jobPath = job.Path
 				return true
 			}
 			return false
@@ -221,6 +224,10 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 
 		cfgObj, err := loadConfig(jobPath)
 		if err != nil {
+			if prob, ok := discoveryProblem(err); ok {
+				response.Write(w, *prob)
+				return
+			}
 			response.Write(w, response.New(http.StatusInternalServerError, "load config failed", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 			return
 		}

--- a/internal/server/handlers/plans.go
+++ b/internal/server/handlers/plans.go
@@ -467,7 +467,7 @@ func discoverPlans(root string, src *sourcestore.Source, discoverFn func(string)
 	if src == nil {
 		return discoverFn(root)
 	}
-	mountPath := sourceMountPath(*src)
+	mountPath := sourceNameMountPath(*src)
 	if strings.TrimSpace(mountPath) == "" || mountPath == "." {
 		return discoverFn(root)
 	}

--- a/internal/server/handlers/plans.go
+++ b/internal/server/handlers/plans.go
@@ -71,10 +71,12 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 		})
 		r = r.WithContext(ctx)
 
-		discoverRoot := cfg.Root
-		if discoverRoot == "" {
-			discoverRoot = "scripts"
+		defaultDiscoverRoot := cfg.Root
+		if defaultDiscoverRoot == "" {
+			defaultDiscoverRoot = "scripts"
 		}
+		discoverRoot := defaultDiscoverRoot
+		var discoverSource *sourcestore.Source
 
 		if req.Source != nil && req.Source.Name != "" {
 			if cfg.Sources == nil {
@@ -91,15 +93,20 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 				return
 			}
 			discoverRoot = source.LocalPath
+			discoverSource = &source
 		}
 
-		result, err := discoverFn(discoverRoot)
+		result, err := discoverPlans(discoverRoot, discoverSource, discoverFn)
 		if err != nil {
 			if prob, ok := discoveryProblem(err); ok {
 				response.Write(w, *prob)
 				return
 			}
 			response.Write(w, response.New(http.StatusInternalServerError, "job discovery failed", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
+			return
+		}
+		if canonicalID, contenders, ok := findJobIDCollision(buildCollisionCandidates(result.Jobs, discoverRoot, discoverSource)); ok {
+			response.Write(w, jobIDCollisionProblem(canonicalID, contenders))
 			return
 		}
 
@@ -180,8 +187,12 @@ func NewPlansHandler(cfg PlansConfig) http.Handler {
 		}
 
 		if jobPath == "" {
-			if req.Source != nil && req.Source.Name != "" && discoverRoot != cfg.Root {
-				if alt, err := discoverFn(cfg.Root); err == nil {
+			if req.Source != nil && req.Source.Name != "" && discoverRoot != defaultDiscoverRoot {
+				if alt, err := discoverFn(defaultDiscoverRoot); err == nil {
+					if canonicalID, contenders, ok := findJobIDCollision(buildCollisionCandidates(alt.Jobs, defaultDiscoverRoot, nil)); ok {
+						response.Write(w, jobIDCollisionProblem(canonicalID, contenders))
+						return
+					}
 					mergeJobInfo(jobMap, alt)
 					lookup.merge(alt)
 					if aliasUsed == nil {
@@ -450,6 +461,17 @@ func decodePlanRequest(body io.ReadCloser) (planRequest, error) {
 		req.Args = map[string]interface{}{}
 	}
 	return req, nil
+}
+
+func discoverPlans(root string, src *sourcestore.Source, discoverFn func(string) (indexer.Result, error)) (indexer.Result, error) {
+	if src == nil {
+		return discoverFn(root)
+	}
+	mountPath := sourceMountPath(*src)
+	if strings.TrimSpace(mountPath) == "" || mountPath == "." {
+		return discoverFn(root)
+	}
+	return indexer.DiscoverWithMountPath(root, mountPath)
 }
 
 // resolveEffectiveProfile is defined in runs.go for the handlers package.

--- a/internal/server/handlers/plans.go
+++ b/internal/server/handlers/plans.go
@@ -467,7 +467,7 @@ func discoverPlans(root string, src *sourcestore.Source, discoverFn func(string)
 	if src == nil {
 		return discoverFn(root)
 	}
-	mountPath := sourceNameMountPath(*src)
+	mountPath := sourceLogicalMountPath(*src)
 	if strings.TrimSpace(mountPath) == "" || mountPath == "." {
 		return discoverFn(root)
 	}

--- a/internal/server/handlers/plans_test.go
+++ b/internal/server/handlers/plans_test.go
@@ -325,7 +325,7 @@ argspec:
 	if !ok {
 		t.Fatalf("expected external source in store")
 	}
-	discovered, err := indexer.DiscoverWithMountPath(source.LocalPath, sourceNameMountPath(source))
+	discovered, err := indexer.DiscoverWithMountPath(source.LocalPath, sourceLogicalMountPath(source))
 	if err != nil {
 		t.Fatalf("discover source jobs: %v", err)
 	}
@@ -388,7 +388,7 @@ func TestPlansHandlerUsesGitSource(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected git source in store")
 	}
-	discovered, err := indexer.DiscoverWithMountPath(source.LocalPath, sourceNameMountPath(source))
+	discovered, err := indexer.DiscoverWithMountPath(source.LocalPath, sourceLogicalMountPath(source))
 	if err != nil {
 		t.Fatalf("discover source jobs: %v", err)
 	}

--- a/internal/server/handlers/plans_test.go
+++ b/internal/server/handlers/plans_test.go
@@ -325,7 +325,7 @@ argspec:
 	if !ok {
 		t.Fatalf("expected external source in store")
 	}
-	discovered, err := indexer.DiscoverWithMountPath(source.LocalPath, sourceMountPath(source))
+	discovered, err := indexer.DiscoverWithMountPath(source.LocalPath, sourceNameMountPath(source))
 	if err != nil {
 		t.Fatalf("discover source jobs: %v", err)
 	}
@@ -388,7 +388,7 @@ func TestPlansHandlerUsesGitSource(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected git source in store")
 	}
-	discovered, err := indexer.DiscoverWithMountPath(source.LocalPath, sourceMountPath(source))
+	discovered, err := indexer.DiscoverWithMountPath(source.LocalPath, sourceNameMountPath(source))
 	if err != nil {
 		t.Fatalf("discover source jobs: %v", err)
 	}

--- a/internal/server/handlers/plans_test.go
+++ b/internal/server/handlers/plans_test.go
@@ -372,7 +372,7 @@ func TestPlansHandlerUsesGitSource(t *testing.T) {
 	}
 
 	h := NewPlansHandler(PlansConfig{Root: t.TempDir(), Sources: store})
-	body := `{"job_id":"gitjob","args":{"name":"Charlie"},"source":{"name":"git-remote"}}`
+	body := `{"job_id":"scripts/gitjob","args":{"name":"Charlie"},"source":{"name":"git-remote"}}`
 	req := httptest.NewRequest(http.MethodPost, "/plans", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	resp := httptest.NewRecorder()
@@ -386,8 +386,8 @@ func TestPlansHandlerUsesGitSource(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&plan); err != nil {
 		t.Fatalf("decode plan: %v", err)
 	}
-	if plan.JobID != "gitjob" {
-		t.Fatalf("expected job gitjob, got %s", plan.JobID)
+	if plan.JobID != "scripts/gitjob" {
+		t.Fatalf("expected job scripts/gitjob, got %s", plan.JobID)
 	}
 	if plan.Outputs == nil {
 		t.Fatalf("expected outputs in plan")

--- a/internal/server/handlers/plans_test.go
+++ b/internal/server/handlers/plans_test.go
@@ -321,7 +321,19 @@ argspec:
 		Sources: store,
 	})
 
-	body := `{"job_id":"remote","args":{"name":"Bob"},"source":{"name":"external"}}`
+	source, ok := store.Get("external")
+	if !ok {
+		t.Fatalf("expected external source in store")
+	}
+	discovered, err := indexer.DiscoverWithMountPath(source.LocalPath, sourceMountPath(source))
+	if err != nil {
+		t.Fatalf("discover source jobs: %v", err)
+	}
+	if len(discovered.Jobs) != 1 {
+		t.Fatalf("expected exactly one discovered job, got %d", len(discovered.Jobs))
+	}
+	jobID := discovered.Jobs[0].ID
+	body := `{"job_id":"` + jobID + `","args":{"name":"Bob"},"source":{"name":"external"}}`
 	req := httptest.NewRequest(http.MethodPost, "/plans", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
@@ -336,8 +348,8 @@ argspec:
 	if err := json.NewDecoder(rr.Body).Decode(&plan); err != nil {
 		t.Fatalf("decode plan: %v", err)
 	}
-	if plan.JobID != "remote" {
-		t.Fatalf("expected plan job_id remote, got %s", plan.JobID)
+	if plan.JobID != jobID {
+		t.Fatalf("expected plan job_id %s, got %s", jobID, plan.JobID)
 	}
 	if plan.Outputs == nil {
 		t.Fatalf("expected outputs in plan")
@@ -372,7 +384,19 @@ func TestPlansHandlerUsesGitSource(t *testing.T) {
 	}
 
 	h := NewPlansHandler(PlansConfig{Root: t.TempDir(), Sources: store})
-	body := `{"job_id":"scripts/gitjob","args":{"name":"Charlie"},"source":{"name":"git-remote"}}`
+	source, ok := store.Get("git-remote")
+	if !ok {
+		t.Fatalf("expected git source in store")
+	}
+	discovered, err := indexer.DiscoverWithMountPath(source.LocalPath, sourceMountPath(source))
+	if err != nil {
+		t.Fatalf("discover source jobs: %v", err)
+	}
+	if len(discovered.Jobs) != 1 {
+		t.Fatalf("expected exactly one discovered job, got %d", len(discovered.Jobs))
+	}
+	jobID := discovered.Jobs[0].ID
+	body := `{"job_id":"` + jobID + `","args":{"name":"Charlie"},"source":{"name":"git-remote"}}`
 	req := httptest.NewRequest(http.MethodPost, "/plans", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	resp := httptest.NewRecorder()
@@ -386,8 +410,8 @@ func TestPlansHandlerUsesGitSource(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&plan); err != nil {
 		t.Fatalf("decode plan: %v", err)
 	}
-	if plan.JobID != "scripts/gitjob" {
-		t.Fatalf("expected job scripts/gitjob, got %s", plan.JobID)
+	if plan.JobID != jobID {
+		t.Fatalf("expected job %s, got %s", jobID, plan.JobID)
 	}
 	if plan.Outputs == nil {
 		t.Fatalf("expected outputs in plan")

--- a/internal/server/handlers/problem_pr1_test.go
+++ b/internal/server/handlers/problem_pr1_test.go
@@ -1,0 +1,120 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/flowd-org/flowd/internal/configloader"
+	"github.com/flowd-org/flowd/internal/server/requestctx"
+	"github.com/flowd-org/flowd/internal/server/response"
+)
+
+func TestTenantMismatchProblemProperties(t *testing.T) {
+	ctx := requestctx.WithTenant(requestctx.WithPrincipal(context.Background(), "user"), "acme")
+	_, prob := resolveTenant(ctx, "other")
+	if prob == nil {
+		t.Fatalf("expected tenant mismatch problem")
+	}
+	if prob.Status != http.StatusForbidden {
+		t.Fatalf("expected status %d, got %d", http.StatusForbidden, prob.Status)
+	}
+	if prob.Type != response.ProblemTypeTenantMismatch {
+		t.Fatalf("expected type %q, got %q", response.ProblemTypeTenantMismatch, prob.Type)
+	}
+	if prob.Ext["code"] != response.ProblemCodeTenantMismatch {
+		t.Fatalf("expected code %q, got %v", response.ProblemCodeTenantMismatch, prob.Ext["code"])
+	}
+	if prob.Ext["request_tenant"] != "other" {
+		t.Fatalf("expected request_tenant other, got %v", prob.Ext["request_tenant"])
+	}
+	if prob.Ext["principal_tenant"] != "acme" {
+		t.Fatalf("expected principal_tenant acme, got %v", prob.Ext["principal_tenant"])
+	}
+	rec := httptest.NewRecorder()
+	response.Write(rec, *prob)
+	if rec.Header().Get("Content-Type") != "application/problem+json" {
+		t.Fatalf("expected application/problem+json, got %q", rec.Header().Get("Content-Type"))
+	}
+}
+
+func TestDiscoveryProblemDualConfigProperties(t *testing.T) {
+	err := &configloader.DualConfigError{
+		ScriptDir:   "/tmp/scripts/demo",
+		PrimaryPath: "/tmp/scripts/demo/config.yaml",
+		LegacyPath:  "/tmp/scripts/demo/config.d/config.yaml",
+	}
+	prob, ok := discoveryProblem(err)
+	if !ok || prob == nil {
+		t.Fatalf("expected discovery problem for dual config error")
+	}
+	if prob.Status != http.StatusConflict {
+		t.Fatalf("expected status %d, got %d", http.StatusConflict, prob.Status)
+	}
+	if prob.Type != response.ProblemTypeJobConfigDualSentinel {
+		t.Fatalf("expected type %q, got %q", response.ProblemTypeJobConfigDualSentinel, prob.Type)
+	}
+	if prob.Ext["code"] != configloader.DualConfigCode {
+		t.Fatalf("expected code %q, got %v", configloader.DualConfigCode, prob.Ext["code"])
+	}
+	if prob.Ext["primary_path"] != err.PrimaryPath {
+		t.Fatalf("expected primary_path %q, got %v", err.PrimaryPath, prob.Ext["primary_path"])
+	}
+	if prob.Ext["legacy_path"] != err.LegacyPath {
+		t.Fatalf("expected legacy_path %q, got %v", err.LegacyPath, prob.Ext["legacy_path"])
+	}
+	rec := httptest.NewRecorder()
+	response.Write(rec, *prob)
+	if rec.Header().Get("Content-Type") != "application/problem+json" {
+		t.Fatalf("expected application/problem+json, got %q", rec.Header().Get("Content-Type"))
+	}
+}
+
+func TestJobIDCollisionProblemProperties(t *testing.T) {
+	contenders := []jobCollisionContender{
+		{
+			CanonicalJobID: "demo",
+			Origin: jobCollisionOrigin{
+				SourceKind: "fs",
+				SourceName: "local",
+			},
+			MountPath: ".",
+			JobDir:    ".",
+		},
+		{
+			CanonicalJobID: "demo",
+			Origin: jobCollisionOrigin{
+				SourceKind: "git",
+				SourceName: "repo",
+			},
+			MountPath: "scripts",
+			JobDir:    "demo",
+		},
+	}
+	prob := jobIDCollisionProblem("demo", contenders)
+	if prob.Status != http.StatusConflict {
+		t.Fatalf("expected status %d, got %d", http.StatusConflict, prob.Status)
+	}
+	if prob.Type != response.ProblemTypeJobIDCollision {
+		t.Fatalf("expected type %q, got %q", response.ProblemTypeJobIDCollision, prob.Type)
+	}
+	if prob.Ext["code"] != response.ProblemCodeJobIDCollision {
+		t.Fatalf("expected code %q, got %v", response.ProblemCodeJobIDCollision, prob.Ext["code"])
+	}
+	if prob.Ext["canonical_job_id"] != "demo" {
+		t.Fatalf("expected canonical_job_id demo, got %v", prob.Ext["canonical_job_id"])
+	}
+	list, ok := prob.Ext["contenders"].([]jobCollisionContender)
+	if !ok {
+		t.Fatalf("expected contenders slice, got %T", prob.Ext["contenders"])
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 contenders, got %d", len(list))
+	}
+	rec := httptest.NewRecorder()
+	response.Write(rec, prob)
+	if rec.Header().Get("Content-Type") != "application/problem+json" {
+		t.Fatalf("expected application/problem+json, got %q", rec.Header().Get("Content-Type"))
+	}
+}

--- a/internal/server/handlers/run_identity.go
+++ b/internal/server/handlers/run_identity.go
@@ -1,0 +1,127 @@
+package handlers
+
+import (
+	"strings"
+
+	"github.com/flowd-org/flowd/internal/indexer"
+	"github.com/flowd-org/flowd/internal/server/sourcestore"
+)
+
+// Run tenant/origin are persisted in run provenance to keep a single source of
+// truth across API responses, SSE payloads, and journal entries.
+
+const (
+	runProvenanceTenantKey = "tenant"
+	runProvenanceOriginKey = "origin"
+	runOriginKindKey       = "source_kind"
+	runOriginNameKey       = "source_name"
+)
+
+func applyRunIdentityFromProvenance(payload *RunPayload) {
+	if payload == nil {
+		return
+	}
+	tenant, origin, ok := runIdentityFromProvenance(payload.Provenance)
+	if !ok {
+		return
+	}
+	if tenant != "" {
+		payload.Tenant = tenant
+	}
+	if origin.SourceKind != "" || origin.SourceName != "" {
+		payload.Origin = origin
+	}
+}
+
+func runIdentityFromProvenance(provenance map[string]any) (string, jobOrigin, bool) {
+	if len(provenance) == 0 {
+		return "", jobOrigin{}, false
+	}
+	var (
+		tenant string
+		origin jobOrigin
+		seen   bool
+	)
+	if value, ok := provenance[runProvenanceTenantKey]; ok {
+		if str, ok := value.(string); ok {
+			tenant = str
+			seen = true
+		}
+	}
+	if value, ok := provenance[runProvenanceOriginKey]; ok {
+		origin = originFromAny(value)
+		if origin.SourceKind != "" || origin.SourceName != "" {
+			seen = true
+		}
+	}
+	if !seen {
+		return "", jobOrigin{}, false
+	}
+	return tenant, origin, true
+}
+
+func setRunIdentityInProvenance(provenance map[string]any, tenant string, origin jobOrigin) map[string]any {
+	if provenance == nil {
+		provenance = map[string]any{}
+	}
+	if tenant != "" {
+		provenance[runProvenanceTenantKey] = tenant
+	}
+	if origin.SourceKind != "" || origin.SourceName != "" {
+		provenance[runProvenanceOriginKey] = map[string]any{
+			runOriginKindKey: origin.SourceKind,
+			runOriginNameKey: origin.SourceName,
+		}
+	}
+	return provenance
+}
+
+func originFromAny(value any) jobOrigin {
+	switch t := value.(type) {
+	case map[string]any:
+		return originFromMap(t)
+	case map[string]string:
+		out := jobOrigin{}
+		if kind, ok := t[runOriginKindKey]; ok {
+			out.SourceKind = kind
+		}
+		if name, ok := t[runOriginNameKey]; ok {
+			out.SourceName = name
+		}
+		return out
+	default:
+		return jobOrigin{}
+	}
+}
+
+func originFromMap(values map[string]any) jobOrigin {
+	var origin jobOrigin
+	if kind, ok := values[runOriginKindKey]; ok {
+		if str, ok := kind.(string); ok {
+			origin.SourceKind = str
+		}
+	}
+	if name, ok := values[runOriginNameKey]; ok {
+		if str, ok := name.(string); ok {
+			origin.SourceName = str
+		}
+	}
+	return origin
+}
+
+func mergeJobOrigins(dest map[string]jobOrigin, jobs []indexer.JobInfo, src *sourcestore.Source) {
+	if len(jobs) == 0 {
+		return
+	}
+	origin := defaultJobOrigin()
+	if src != nil {
+		origin = jobOrigin{SourceKind: mapSourceKind(src.Type), SourceName: src.Name}
+	}
+	for _, job := range jobs {
+		key := strings.ToLower(job.ID)
+		if _, ok := dest[key]; ok {
+			continue
+		}
+		dest[key] = origin
+	}
+}

--- a/internal/server/handlers/run_payload.go
+++ b/internal/server/handlers/run_payload.go
@@ -13,6 +13,8 @@ import (
 type RunPayload struct {
 	ID              string         `json:"id"`
 	JobID           string         `json:"job_id"`
+	Tenant          string         `json:"tenant,omitempty"`
+	Origin          jobOrigin      `json:"origin,omitempty"`
 	Status          string         `json:"status"`
 	StartedAt       time.Time      `json:"started_at"`
 	FinishedAt      *time.Time     `json:"finished_at,omitempty"`
@@ -34,7 +36,7 @@ func newRunPayload(id, jobID, status string, startedAt time.Time) RunPayload {
 }
 
 func payloadFromStore(run runstore.Run) RunPayload {
-	return RunPayload{
+	payload := RunPayload{
 		ID:              run.ID,
 		JobID:           run.JobID,
 		Status:          run.Status,
@@ -47,10 +49,12 @@ func payloadFromStore(run runstore.Run) RunPayload {
 		Provenance:      run.Provenance,
 		RequestID:       run.RequestID,
 	}
+	applyRunIdentityFromProvenance(&payload)
+	return payload
 }
 
 func payloadFromRecord(record coredb.RunRecord) RunPayload {
-	return RunPayload{
+	payload := RunPayload{
 		ID:              record.ID,
 		JobID:           record.JobID,
 		Status:          record.Status,
@@ -63,6 +67,8 @@ func payloadFromRecord(record coredb.RunRecord) RunPayload {
 		Provenance:      record.Provenance,
 		RequestID:       record.RequestID,
 	}
+	applyRunIdentityFromProvenance(&payload)
+	return payload
 }
 
 func writeRunPayload(w http.ResponseWriter, payload RunPayload, status int) {

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -385,6 +385,8 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 
 	jobMap := make(map[string]indexer.JobInfo, len(result.Jobs))
 	mergeJobInfo(jobMap, result)
+	originByID := make(map[string]jobOrigin, len(result.Jobs))
+	mergeJobOrigins(originByID, result.Jobs, runSource)
 	lookup := newAliasLookup()
 	lookup.merge(result)
 
@@ -395,10 +397,16 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	var aliasUsed *indexer.AliasInfo
 
 	var scriptDir string
+	var runOrigin jobOrigin
+	originSet := false
 	setScriptDir := func(id string) bool {
 		if job, ok := jobMap[strings.ToLower(id)]; ok {
 			scriptDir = job.Path
 			effectiveID = job.ID
+			if origin, ok := originByID[strings.ToLower(job.ID)]; ok {
+				runOrigin = origin
+				originSet = true
+			}
 			return true
 		}
 		return false
@@ -437,6 +445,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 				mergeJobInfo(jobMap, alt)
+				mergeJobOrigins(originByID, alt.Jobs, nil)
 				lookup.merge(alt)
 				if aliasUsed == nil {
 					if resolveAlias() {
@@ -462,6 +471,14 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		}
 		response.Write(w, response.New(http.StatusNotFound, "job not found", response.WithDetail(scrubProblemDetail(requestedID, nil, nil, nil, nil))))
 		return
+	}
+
+	if !originSet {
+		if runSource != nil {
+			runOrigin = jobOrigin{SourceKind: mapSourceKind(runSource.Type), SourceName: runSource.Name}
+		} else {
+			runOrigin = defaultJobOrigin()
+		}
 	}
 
 	absScriptDir, err := filepath.Abs(scriptDir)
@@ -573,6 +590,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	if provenance == nil {
 		provenance = map[string]any{}
 	}
+	provenance = setRunIdentityInProvenance(provenance, resolvedTenant, runOrigin)
 	provenance["canonical_id"] = effectiveID
 	canonicalPath := indexer.DotJobIDToSlash(effectiveID)
 	if aliasUsed != nil {
@@ -699,6 +717,8 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resp := newRunPayload(runID, effectiveID, defaultRunStatus, now)
+	resp.Tenant = resolvedTenant
+	resp.Origin = runOrigin
 	resp.Executor = executorMode
 	resp.SecurityProfile = effProfile
 	resp.RequestID = requestIDFromContext(ctx)

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -238,6 +238,10 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := requestctx.Logger(ctx)
 	principal, _ := requestctx.Principal(ctx)
+	if _, prob := resolveTenant(ctx, req.Tenant); prob != nil {
+		response.Write(w, *prob)
+		return
+	}
 	idemKey := strings.TrimSpace(r.Header.Get("Idempotency-Key"))
 	if idemKey == "" {
 		response.Write(w, response.New(http.StatusBadRequest, "Idempotency-Key header required"))
@@ -867,6 +871,7 @@ func (h *RunsHandler) resolveProvenance(jobID string, src *RunSourceRef, scriptD
 
 type runRequest struct {
 	JobID                    string         `json:"job_id"`
+	Tenant                   string         `json:"tenant,omitempty"`
 	Args                     map[string]any `json:"args"`
 	RequestedSecurityProfile string         `json:"requested_security_profile"`
 	Source                   *RunSourceRef  `json:"source"`

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -84,9 +84,13 @@ func normalizeJobRefInput(input string) string {
 	if trimmed == "" {
 		return ""
 	}
-	normalized := indexer.DotJobIDToSlash(trimmed)
-	normalized = strings.Trim(normalized, "/")
-	return normalized
+	if trimmed == "/" || trimmed == "." {
+		return ""
+	}
+	if strings.HasPrefix(trimmed, "/") || strings.HasSuffix(trimmed, "/") {
+		return trimmed
+	}
+	return indexer.DotJobIDToSlash(trimmed)
 }
 
 var detectContainerRuntime = container.DetectRuntime
@@ -884,7 +888,7 @@ func (h *RunsHandler) discoverWithMountPath(root string, src *sourcestore.Source
 	if src == nil {
 		return h.discover(root)
 	}
-	mountPath := sourceMountPath(*src)
+	mountPath := sourceNameMountPath(*src)
 	if strings.TrimSpace(mountPath) == "" || mountPath == "." {
 		return h.discover(root)
 	}

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -79,6 +79,37 @@ func scopedIdempotencyKey(tenant, key string) string {
 	return hex.EncodeToString(sum[:]) + ":" + key
 }
 
+func hasEmptyJobIDSegment(input string) bool {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" || trimmed == "." || trimmed == "/" {
+		return false
+	}
+	normalized := strings.ReplaceAll(trimmed, "\\", "/")
+	prevSep := true
+	for _, r := range normalized {
+		if r == '/' || r == '.' {
+			if prevSep {
+				return true
+			}
+			prevSep = true
+			continue
+		}
+		prevSep = false
+	}
+	return prevSep
+}
+
+func invalidJobIDSegmentProblem(input string) response.Problem {
+	prob := response.New(http.StatusBadRequest, "invalid job_id",
+		response.WithType(response.ProblemTypeJobIDInvalidSegment),
+		response.WithExtension("code", response.ProblemCodeJobIDInvalidSegment),
+		response.WithDetail("job_id contains empty segments"),
+		response.WithExtension("path", input),
+		response.WithExtension("reason", "empty segment"),
+	)
+	return scrubProblemResponse(&prob, nil, nil, nil, nil)
+}
+
 func normalizeJobRefInput(input string) string {
 	trimmed := strings.TrimSpace(input)
 	if trimmed == "" {
@@ -225,6 +256,10 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 	if strings.TrimSpace(req.JobID) == "" && req.JobID != "" {
 		response.Write(w, response.New(http.StatusBadRequest, "job_id is required"))
+		return
+	}
+	if hasEmptyJobIDSegment(req.JobID) {
+		response.Write(w, invalidJobIDSegmentProblem(req.JobID))
 		return
 	}
 

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -352,6 +352,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		runRoot = "scripts"
 	}
 
+	var runSource *sourcestore.Source
 	if req.Source != nil && req.Source.Name != "" {
 		if h.sources != nil {
 			src, ok := h.sources.Get(req.Source.Name)
@@ -364,6 +365,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			runRoot = src.LocalPath
+			runSource = &src
 		}
 	}
 
@@ -374,6 +376,10 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		response.Write(w, response.New(http.StatusInternalServerError, "job discovery failed", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
+		return
+	}
+	if canonicalID, contenders, ok := findJobIDCollision(buildCollisionCandidates(result.Jobs, runRoot, runSource)); ok {
+		response.Write(w, jobIDCollisionProblem(canonicalID, contenders))
 		return
 	}
 
@@ -426,6 +432,10 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	if scriptDir == "" {
 		if req.Source != nil && req.Source.Name != "" && runRoot != h.root {
 			if alt, err := h.discover(h.root); err == nil {
+				if canonicalID, contenders, ok := findJobIDCollision(buildCollisionCandidates(alt.Jobs, h.root, nil)); ok {
+					response.Write(w, jobIDCollisionProblem(canonicalID, contenders))
+					return
+				}
 				mergeJobInfo(jobMap, alt)
 				lookup.merge(alt)
 				if aliasUsed == nil {

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -439,22 +439,29 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 
 	if scriptDir == "" {
 		if req.Source != nil && req.Source.Name != "" && runRoot != h.root {
-			if alt, err := h.discover(h.root); err == nil {
-				if canonicalID, contenders, ok := findJobIDCollision(buildCollisionCandidates(alt.Jobs, h.root, nil)); ok {
-					response.Write(w, jobIDCollisionProblem(canonicalID, contenders))
+			alt, err := h.discover(h.root)
+			if err != nil {
+				if prob, ok := discoveryProblem(err); ok {
+					response.Write(w, *prob)
 					return
 				}
-				mergeJobInfo(jobMap, alt)
-				mergeJobOrigins(originByID, alt.Jobs, nil)
-				lookup.merge(alt)
-				if aliasUsed == nil {
-					if resolveAlias() {
-						return
-					}
+				response.Write(w, response.New(http.StatusInternalServerError, "job discovery failed", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
+				return
+			}
+			if canonicalID, contenders, ok := findJobIDCollision(buildCollisionCandidates(alt.Jobs, h.root, nil)); ok {
+				response.Write(w, jobIDCollisionProblem(canonicalID, contenders))
+				return
+			}
+			mergeJobInfo(jobMap, alt)
+			mergeJobOrigins(originByID, alt.Jobs, nil)
+			lookup.merge(alt)
+			if aliasUsed == nil {
+				if resolveAlias() {
+					return
 				}
-				if scriptDir == "" {
-					setScriptDir(effectiveID)
-				}
+			}
+			if scriptDir == "" {
+				setScriptDir(effectiveID)
 			}
 		}
 	}

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -817,6 +817,11 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		attrs := []any{
 			slog.String("run_id", runID),
 			slog.String("job_id", effectiveID),
+			slog.String("tenant", resolvedTenant),
+			slog.Group("origin",
+				slog.String("source_kind", runOrigin.SourceKind),
+				slog.String("source_name", runOrigin.SourceName),
+			),
 			slog.String("status", resp.Status),
 			slog.String("executor", executorMode),
 			slog.String("security_profile", effProfile),

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -369,7 +369,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	result, err := h.discover(runRoot)
+	result, err := h.discoverWithMountPath(runRoot, runSource)
 	if err != nil {
 		if prob, ok := discoveryProblem(err); ok {
 			response.Write(w, *prob)
@@ -871,6 +871,17 @@ func (h *RunsHandler) ociRunUnsupported(jobID string) *response.Problem {
 		}
 	}
 	return nil
+}
+
+func (h *RunsHandler) discoverWithMountPath(root string, src *sourcestore.Source) (indexer.Result, error) {
+	if src == nil {
+		return h.discover(root)
+	}
+	mountPath := sourceMountPath(*src)
+	if strings.TrimSpace(mountPath) == "" || mountPath == "." {
+		return h.discover(root)
+	}
+	return indexer.DiscoverWithMountPath(root, mountPath)
 }
 
 func resolveEffectiveProfile(requested, cfgProfile string) (string, error) {

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -1235,7 +1235,7 @@ func publishPolicyDecisions(sink EventSink, payload *RunPayload, decisions []pol
 		if err != nil {
 			bytes = []byte("{}")
 		}
-		sink.Publish(payload.ID, sse.Event{Event: "policy.decision", Data: string(bytes)})
+		sink.Publish(payload.ID, sse.Event{Event: "policy.decision", Data: string(bytes), Tenant: payload.Tenant})
 		if dec.Decision == "denied" {
 			publishPolicyDenied(sink, payload, dec.Subject, dec.Code, dec.Reason)
 		}
@@ -1265,7 +1265,7 @@ func publishPolicyDenied(sink EventSink, payload *RunPayload, subject, code, rea
 	if err != nil {
 		bytes = []byte("{}")
 	}
-	sink.Publish(payload.ID, sse.Event{Event: "policy.denied", Data: string(bytes)})
+	sink.Publish(payload.ID, sse.Event{Event: "policy.denied", Data: string(bytes), Tenant: payload.Tenant})
 }
 
 func policyEventBase(payload *RunPayload) map[string]any {
@@ -1276,6 +1276,12 @@ func policyEventBase(payload *RunPayload) map[string]any {
 		"executor":         payload.Executor,
 		"runtime":          payload.Runtime,
 		"timestamp":        time.Now().UTC(),
+	}
+	if payload.Tenant != "" {
+		base["tenant"] = payload.Tenant
+	}
+	if payload.Origin.SourceKind != "" || payload.Origin.SourceName != "" {
+		base["origin"] = payload.Origin
 	}
 	if payload.Provenance != nil {
 		base["provenance"] = payload.Provenance
@@ -1487,12 +1493,28 @@ func (h *RunsHandler) failRun(runID string, status string, err error) {
 	h.updateRunStatus(runID, status, &stamp)
 	if h.events != nil {
 		payload := map[string]any{"status": status}
+		var tenant string
+		var origin jobOrigin
+		if run, ok := h.store.Get(runID); ok {
+			view := payloadFromStore(run)
+			payload["run_id"] = view.ID
+			payload["job_id"] = view.JobID
+			tenant = view.Tenant
+			origin = view.Origin
+		}
 		if err != nil {
 			payload["error"] = err.Error()
 		}
+		if tenant != "" {
+			payload["tenant"] = tenant
+		}
+		if origin.SourceKind != "" || origin.SourceName != "" {
+			payload["origin"] = origin
+		}
 		h.events.Publish(runID, sse.Event{
-			Event: "run.finished",
-			Data:  encodeData(payload),
+			Event:  "run.finished",
+			Data:   encodeData(payload),
+			Tenant: tenant,
 		})
 	}
 }
@@ -1501,26 +1523,33 @@ func (h *RunsHandler) publishRunCanceled(run runstore.Run, finished time.Time, r
 	if h.events == nil {
 		return
 	}
+	view := payloadFromStore(run)
 	payload := map[string]any{
-		"run_id":    run.ID,
-		"job_id":    run.JobID,
+		"run_id":    view.ID,
+		"job_id":    view.JobID,
 		"status":    "canceled",
 		"timestamp": finished,
 	}
 	if reason != "" {
 		payload["reason"] = reason
 	}
-	if run.Provenance != nil {
-		payload["provenance"] = run.Provenance
+	if view.Provenance != nil {
+		payload["provenance"] = view.Provenance
 	}
-	if run.Runtime != "" {
-		payload["runtime"] = run.Runtime
+	if view.Runtime != "" {
+		payload["runtime"] = view.Runtime
+	}
+	if view.Tenant != "" {
+		payload["tenant"] = view.Tenant
+	}
+	if view.Origin.SourceKind != "" || view.Origin.SourceName != "" {
+		payload["origin"] = view.Origin
 	}
 	bytes, err := json.Marshal(payload)
 	if err != nil {
 		bytes = []byte("{}")
 	}
-	h.events.Publish(run.ID, sse.Event{Event: "run.canceled", Data: string(bytes)})
+	h.events.Publish(run.ID, sse.Event{Event: "run.canceled", Data: string(bytes), Tenant: view.Tenant})
 }
 
 func isTerminalStatus(status string) bool {

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -888,7 +888,7 @@ func (h *RunsHandler) discoverWithMountPath(root string, src *sourcestore.Source
 	if src == nil {
 		return h.discover(root)
 	}
-	mountPath := sourceNameMountPath(*src)
+	mountPath := sourceLogicalMountPath(*src)
 	if strings.TrimSpace(mountPath) == "" || mountPath == "." {
 		return h.discover(root)
 	}

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -355,6 +355,10 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.discover(runRoot)
 	if err != nil {
+		if prob, ok := discoveryProblem(err); ok {
+			response.Write(w, *prob)
+			return
+		}
 		response.Write(w, response.New(http.StatusInternalServerError, "job discovery failed", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		return
 	}
@@ -371,7 +375,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	var scriptDir string
 	setScriptDir := func(id string) bool {
 		if job, ok := jobMap[strings.ToLower(id)]; ok {
-			scriptDir = filepath.Dir(job.Path)
+			scriptDir = job.Path
 			return true
 		}
 		return false
@@ -453,6 +457,10 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 
 	cfg, err := h.loadConfig(absScriptDir)
 	if err != nil {
+		if prob, ok := discoveryProblem(err); ok {
+			response.Write(w, *prob)
+			return
+		}
 		response.Write(w, response.New(http.StatusInternalServerError, "load config failed", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		return
 	}

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -71,11 +71,11 @@ var (
 	sha256Pattern         = regexp.MustCompile(`^[a-f0-9]{64}$`)
 )
 
-func scopedIdempotencyKey(principal, key string) string {
-	if principal == "" {
+func scopedIdempotencyKey(tenant, key string) string {
+	if tenant == "" {
 		return key
 	}
-	sum := sha256.Sum256([]byte(principal))
+	sum := sha256.Sum256([]byte(tenant))
 	return hex.EncodeToString(sum[:]) + ":" + key
 }
 
@@ -237,8 +237,8 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	logger := requestctx.Logger(ctx)
-	principal, _ := requestctx.Principal(ctx)
-	if _, prob := resolveTenant(ctx, req.Tenant); prob != nil {
+	resolvedTenant, prob := resolveTenant(ctx, req.Tenant)
+	if prob != nil {
 		response.Write(w, *prob)
 		return
 	}
@@ -251,7 +251,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		response.Write(w, response.New(http.StatusBadRequest, "invalid Idempotency-Key header"))
 		return
 	}
-	scopedKey := scopedIdempotencyKey(principal, idemKey)
+	scopedKey := scopedIdempotencyKey(resolvedTenant, idemKey)
 	endpoint := r.Method + " " + r.URL.Path
 	now := h.now()
 	reserved := false

--- a/internal/server/handlers/runs.go
+++ b/internal/server/handlers/runs.go
@@ -79,6 +79,16 @@ func scopedIdempotencyKey(tenant, key string) string {
 	return hex.EncodeToString(sum[:]) + ":" + key
 }
 
+func normalizeJobRefInput(input string) string {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return ""
+	}
+	normalized := indexer.DotJobIDToSlash(trimmed)
+	normalized = strings.Trim(normalized, "/")
+	return normalized
+}
+
 var detectContainerRuntime = container.DetectRuntime
 
 // RunsConfig configures the run handler.
@@ -200,12 +210,16 @@ func (h *RunsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
-	req, rawBody, err := decodeRunRequest(r.Body)
+	req, rawBody, jobIDPresent, err := decodeRunRequest(r.Body)
 	if err != nil {
 		response.Write(w, response.New(http.StatusBadRequest, "invalid request body", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		return
 	}
-	if req.JobID == "" {
+	if !jobIDPresent {
+		response.Write(w, response.New(http.StatusBadRequest, "job_id is required"))
+		return
+	}
+	if strings.TrimSpace(req.JobID) == "" && req.JobID != "" {
 		response.Write(w, response.New(http.StatusBadRequest, "job_id is required"))
 		return
 	}
@@ -368,14 +382,17 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	lookup := newAliasLookup()
 	lookup.merge(result)
 
-	requestedID := req.JobID
-	effectiveID := req.JobID
+	rawRequestedID := req.JobID
+	requestedID := strings.TrimSpace(req.JobID)
+	normalizedID := normalizeJobRefInput(requestedID)
+	effectiveID := normalizedID
 	var aliasUsed *indexer.AliasInfo
 
 	var scriptDir string
 	setScriptDir := func(id string) bool {
 		if job, ok := jobMap[strings.ToLower(id)]; ok {
 			scriptDir = job.Path
+			effectiveID = job.ID
 			return true
 		}
 		return false
@@ -547,7 +564,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		provenance = map[string]any{}
 	}
 	provenance["canonical_id"] = effectiveID
-	canonicalPath := strings.ReplaceAll(effectiveID, ".", "/")
+	canonicalPath := indexer.DotJobIDToSlash(effectiveID)
 	if aliasUsed != nil {
 		canonicalPath = aliasUsed.TargetPath
 		aliasMeta := map[string]any{
@@ -560,7 +577,7 @@ func (h *RunsHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 			aliasMeta["description"] = aliasUsed.Description
 		}
 		provenance["alias"] = aliasMeta
-		provenance["invoked_path"] = requestedID
+		provenance["invoked_path"] = rawRequestedID
 	}
 	provenance["canonical_path"] = canonicalPath
 
@@ -890,22 +907,27 @@ type RunSourceRef struct {
 	Name string `json:"name"`
 }
 
-func decodeRunRequest(body io.ReadCloser) (runRequest, []byte, error) {
+func decodeRunRequest(body io.ReadCloser) (runRequest, []byte, bool, error) {
 	defer body.Close()
 	var req runRequest
 	data, err := io.ReadAll(body)
 	if err != nil {
-		return req, nil, err
+		return req, nil, false, err
 	}
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&req); err != nil {
-		return req, data, err
+		return req, data, false, err
 	}
 	if req.Args == nil {
 		req.Args = map[string]any{}
 	}
-	return req, data, nil
+	jobIDPresent := false
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err == nil {
+		_, jobIDPresent = raw["job_id"]
+	}
+	return req, data, jobIDPresent, nil
 }
 
 func (h *RunsHandler) handleList(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/handlers/runs_test.go
+++ b/internal/server/handlers/runs_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/flowd-org/flowd/internal/policy/verify"
 	"github.com/flowd-org/flowd/internal/secrets"
 	"github.com/flowd-org/flowd/internal/server/requestctx"
+	"github.com/flowd-org/flowd/internal/server/response"
 	"github.com/flowd-org/flowd/internal/server/runstore"
 	"github.com/flowd-org/flowd/internal/server/sourcestore"
 	"github.com/flowd-org/flowd/internal/server/sse"
@@ -912,6 +913,45 @@ argspec:
 	}
 	if _, ok := problem["errors"].([]any); !ok {
 		t.Fatalf("expected errors field, got %v", problem["errors"])
+	}
+}
+
+func TestRunsHandlerInvalidJobIDProblem(t *testing.T) {
+	root := t.TempDir()
+	jobDir := filepath.Join(root, "!!!")
+	if err := os.MkdirAll(jobDir, 0o755); err != nil {
+		t.Fatalf("mkdir job dir: %v", err)
+	}
+	config := `version: v1
+job:
+  name: Bad Job
+`
+	if err := os.WriteFile(filepath.Join(jobDir, "config.yaml"), []byte(config), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	h := NewRunsHandler(RunsConfig{Root: root, Store: runstore.New()})
+	req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(`{"job_id":"bad"}`))
+	req.Header.Set("Content-Type", "application/json")
+	addIdempotencyHeader(req)
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if !strings.HasPrefix(resp.Header().Get("Content-Type"), "application/problem+json") {
+		t.Fatalf("expected problem response, got %q", resp.Header().Get("Content-Type"))
+	}
+	var problem map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&problem); err != nil {
+		t.Fatalf("decode problem: %v", err)
+	}
+	if problem["code"] != response.ProblemCodeJobIDInvalidSegment {
+		t.Fatalf("expected code %q, got %+v", response.ProblemCodeJobIDInvalidSegment, problem["code"])
+	}
+	if problem["type"] != response.ProblemTypeJobIDInvalidSegment {
+		t.Fatalf("expected type %q, got %+v", response.ProblemTypeJobIDInvalidSegment, problem["type"])
 	}
 }
 

--- a/internal/server/handlers/runs_test.go
+++ b/internal/server/handlers/runs_test.go
@@ -427,6 +427,16 @@ argspec:
 			wantCanonicalID:   "demo/child",
 			wantCanonicalPath: "demo/child",
 		},
+		{
+			name:       "leading slash rejected",
+			jobID:      "/demo",
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "trailing slash rejected",
+			jobID:      "demo/",
+			wantStatus: http.StatusNotFound,
+		},
 	}
 
 	for _, tc := range cases {
@@ -762,7 +772,7 @@ func TestRunsHandlerGitSource(t *testing.T) {
 	if !ok {
 		t.Fatal("expected git source in store")
 	}
-	jobID, err := indexer.CanonicalJobID(sourceMountPath(src), filepath.ToSlash(filepath.Join("scripts", "gitjob")))
+	jobID, err := indexer.CanonicalJobID(sourceNameMountPath(src), filepath.ToSlash(filepath.Join("scripts", "gitjob")))
 	if err != nil {
 		t.Fatalf("canonical job id: %v", err)
 	}
@@ -830,7 +840,7 @@ argspec:
 	})
 
 	h := NewRunsHandler(RunsConfig{Root: defaultRoot, Store: store, Sources: ss})
-	jobID, err := indexer.CanonicalJobID(sourceRoot, "remote")
+	jobID, err := indexer.CanonicalJobID("external", "remote")
 	if err != nil {
 		t.Fatalf("canonical job id: %v", err)
 	}

--- a/internal/server/handlers/runs_test.go
+++ b/internal/server/handlers/runs_test.go
@@ -534,6 +534,142 @@ argspec:
 	waitFor(func() bool { return sink.countBy("run.finished") >= 1 }, 500*time.Millisecond, t)
 }
 
+func TestRunsHandlerSSEJournalIdentityConsistency(t *testing.T) {
+	root := t.TempDir()
+	writeJobConfig(t, root, "demo", `
+version: v1
+job:
+  id: demo
+  name: Demo Job
+argspec:
+  args:
+    - name: name
+      type: string
+      required: true
+`)
+
+	ctx := context.Background()
+	db, err := coredb.Open(ctx, coredb.Options{DataDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open coredb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	journal := coredb.NewJournal(db, 0)
+
+	store := runstore.New()
+	sink := &recordingSink{}
+	eventSink := NewJournalEventSink(journal, sink)
+	h := NewRunsHandler(RunsConfig{Root: root, Store: store, Events: eventSink, DB: db})
+	getHandler := NewRunGetHandler(RunGetConfig{Store: store, DB: db})
+
+	req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(`{"job_id":"demo","args":{"name":"Alice"},"tenant":"acme"}`))
+	req.Header.Set("Content-Type", "application/json")
+	addIdempotencyHeader(req)
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", resp.Code, resp.Body.String())
+	}
+	var created map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	runID, ok := created["id"].(string)
+	if !ok || runID == "" {
+		t.Fatalf("expected run id, got %v", created["id"])
+	}
+	if created["tenant"] != "acme" {
+		t.Fatalf("expected tenant acme, got %v", created["tenant"])
+	}
+	assertOrigin(t, created["origin"], "fs", "local")
+
+	getReq := httptest.NewRequest(http.MethodGet, "/runs/"+runID, nil)
+	getResp := httptest.NewRecorder()
+	getHandler.ServeHTTP(getResp, getReq)
+	if getResp.Code != http.StatusOK {
+		t.Fatalf("expected GET /runs/{id} 200, got %d: %s", getResp.Code, getResp.Body.String())
+	}
+	var fetched map[string]any
+	if err := json.NewDecoder(getResp.Body).Decode(&fetched); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	if fetched["tenant"] != "acme" {
+		t.Fatalf("expected fetched tenant acme, got %v", fetched["tenant"])
+	}
+	assertOrigin(t, fetched["origin"], "fs", "local")
+
+	waitFor(func() bool { return sink.countBy("run.started") >= 1 }, 500*time.Millisecond, t)
+	var runStarted recordedEvent
+	for _, evt := range sink.snapshot() {
+		if evt.event.Event == "run.started" {
+			runStarted = evt
+			break
+		}
+	}
+	if runStarted.event.Event != "run.started" {
+		t.Fatal("expected run.started event")
+	}
+	if runStarted.event.Tenant != "acme" {
+		t.Fatalf("expected SSE tenant acme, got %q", runStarted.event.Tenant)
+	}
+	var ssePayload map[string]any
+	if err := json.Unmarshal([]byte(runStarted.event.Data), &ssePayload); err != nil {
+		t.Fatalf("decode SSE payload: %v", err)
+	}
+	if ssePayload["tenant"] != "acme" {
+		t.Fatalf("expected SSE tenant acme, got %v", ssePayload["tenant"])
+	}
+	if ssePayload["job_id"] != "demo" {
+		t.Fatalf("expected SSE job_id demo, got %v", ssePayload["job_id"])
+	}
+	assertOrigin(t, ssePayload["origin"], "fs", "local")
+
+	waitFor(func() bool {
+		earliest, _, err := journal.Bounds(context.Background(), runID)
+		return err == nil && earliest > 0
+	}, 500*time.Millisecond, t)
+
+	found := false
+	if err := journal.ForEach(context.Background(), runID, 0, func(entry coredb.JournalEntry) error {
+		if entry.EventType != "run.started" && entry.EventType != "run.finished" {
+			return nil
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(entry.Payload, &payload); err != nil {
+			return fmt.Errorf("decode journal payload: %w", err)
+		}
+		if payload["tenant"] != "acme" {
+			return fmt.Errorf("expected journal tenant acme, got %v", payload["tenant"])
+		}
+		if payload["job_id"] != "demo" {
+			return fmt.Errorf("expected journal job_id demo, got %v", payload["job_id"])
+		}
+		assertOrigin(t, payload["origin"], "fs", "local")
+		found = true
+		return nil
+	}); err != nil {
+		t.Fatalf("journal scan: %v", err)
+	}
+	if !found {
+		t.Fatal("expected journal run.started/run.finished event")
+	}
+}
+
+func assertOrigin(t *testing.T, value any, wantKind, wantName string) {
+	t.Helper()
+	origin, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("expected origin map, got %T", value)
+	}
+	if origin["source_kind"] != wantKind {
+		t.Fatalf("expected origin source_kind %q, got %v", wantKind, origin["source_kind"])
+	}
+	if origin["source_name"] != wantName {
+		t.Fatalf("expected origin source_name %q, got %v", wantName, origin["source_name"])
+	}
+}
+
 func TestRunsHandlerProvenanceFromResolver(t *testing.T) {
 	root := t.TempDir()
 	writeJobConfig(t, root, "demo", `

--- a/internal/server/handlers/runs_test.go
+++ b/internal/server/handlers/runs_test.go
@@ -137,6 +137,106 @@ argspec:
 	}
 }
 
+func TestRunsHandlerTenantResolution(t *testing.T) {
+	root := t.TempDir()
+	writeJobConfig(t, root, "demo", `
+version: v1
+job:
+  id: demo
+  name: Demo Job
+argspec:
+  args:
+    - name: name
+      type: string
+      required: true
+`)
+
+	h := NewRunsHandler(RunsConfig{Root: root, Store: runstore.New()})
+
+	baseBody := `{"job_id":"demo","args":{"name":"Alice"}}`
+	bodyWithTenant := func(tenant string) string {
+		return fmt.Sprintf(`{"job_id":"demo","args":{"name":"Alice"},"tenant":"%s"}`, tenant)
+	}
+
+	principalTenantCtx := requestctx.WithTenant(requestctx.WithPrincipal(context.Background(), "user-1"), "acme")
+	principalOnlyCtx := requestctx.WithPrincipal(context.Background(), "user-2")
+
+	cases := []struct {
+		name       string
+		ctx        context.Context
+		body       string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "principal tenant, no request tenant",
+			ctx:        principalTenantCtx,
+			body:       baseBody,
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name:       "principal tenant, matching request tenant",
+			ctx:        principalTenantCtx,
+			body:       bodyWithTenant("acme"),
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name:       "principal without tenant claim, request tenant absent",
+			ctx:        principalOnlyCtx,
+			body:       baseBody,
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name:       "no principal, request tenant present",
+			ctx:        context.Background(),
+			body:       bodyWithTenant("acme"),
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name:       "no principal, request tenant absent",
+			ctx:        context.Background(),
+			body:       baseBody,
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name:       "principal tenant mismatch",
+			ctx:        principalTenantCtx,
+			body:       bodyWithTenant("other"),
+			wantStatus: http.StatusForbidden,
+			wantCode:   "tenant.mismatch",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			addIdempotencyHeader(req)
+			req = req.WithContext(tc.ctx)
+			resp := httptest.NewRecorder()
+
+			h.ServeHTTP(resp, req)
+
+			if resp.Code != tc.wantStatus {
+				t.Fatalf("expected %d, got %d: %s", tc.wantStatus, resp.Code, resp.Body.String())
+			}
+			if tc.wantCode == "" {
+				return
+			}
+			if ct := resp.Header().Get("Content-Type"); ct != "application/problem+json" {
+				t.Fatalf("expected application/problem+json, got %q", ct)
+			}
+			var problem map[string]any
+			if err := json.NewDecoder(resp.Body).Decode(&problem); err != nil {
+				t.Fatalf("decode problem: %v", err)
+			}
+			if problem["code"] != tc.wantCode {
+				t.Fatalf("expected code %q, got %+v", tc.wantCode, problem)
+			}
+		})
+	}
+}
+
 func TestRunsHandlerEmitsRunStartEvent(t *testing.T) {
 	root := t.TempDir()
 	writeJobConfig(t, root, "demo", `

--- a/internal/server/handlers/runs_test.go
+++ b/internal/server/handlers/runs_test.go
@@ -305,14 +305,17 @@ argspec:
 			name:              "case-insensitive slash",
 			jobID:             "DeMo/ChIlD",
 			wantStatus:        http.StatusCreated,
-			wantJobID:         "DeMo/ChIlD",
-			wantCanonicalID:   "DeMo/ChIlD",
-			wantCanonicalPath: "DeMo/ChIlD",
+			wantJobID:         "demo/child",
+			wantCanonicalID:   "demo/child",
+			wantCanonicalPath: "demo/child",
 		},
 		{
-			name:       "legacy dot form",
-			jobID:      "demo.child",
-			wantStatus: http.StatusNotFound,
+			name:              "legacy dot form",
+			jobID:             "demo.child",
+			wantStatus:        http.StatusCreated,
+			wantJobID:         "demo/child",
+			wantCanonicalID:   "demo/child",
+			wantCanonicalPath: "demo/child",
 		},
 	}
 
@@ -509,7 +512,7 @@ func TestRunsHandlerGitSource(t *testing.T) {
 		Sources: sourceStore,
 	})
 
-	req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(`{"job_id":"gitjob","args":{"name":"Dana"},"source":{"name":"git-remote"}}`))
+	req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(`{"job_id":"scripts/gitjob","args":{"name":"Dana"},"source":{"name":"git-remote"}}`))
 	req.Header.Set("Content-Type", "application/json")
 	addIdempotencyHeader(req)
 	resp := httptest.NewRecorder()

--- a/internal/server/handlers/runs_test.go
+++ b/internal/server/handlers/runs_test.go
@@ -430,12 +430,12 @@ argspec:
 		{
 			name:       "leading slash rejected",
 			jobID:      "/demo",
-			wantStatus: http.StatusNotFound,
+			wantStatus: http.StatusBadRequest,
 		},
 		{
 			name:       "trailing slash rejected",
 			jobID:      "demo/",
-			wantStatus: http.StatusNotFound,
+			wantStatus: http.StatusBadRequest,
 		},
 	}
 
@@ -488,6 +488,81 @@ argspec:
 				if prov["canonical_path"] != tc.wantCanonicalPath {
 					t.Fatalf("expected canonical_path %q, got %v", tc.wantCanonicalPath, prov["canonical_path"])
 				}
+			}
+		})
+	}
+}
+
+func TestRunsHandlerRejectsEmptyJobIDSegments(t *testing.T) {
+	root := t.TempDir()
+	writeJobConfig(t, root, "demo", `
+version: v1
+job:
+  id: demo
+  name: Demo Job
+argspec:
+  args:
+    - name: name
+      type: string
+      required: true
+`)
+
+	h := NewRunsHandler(RunsConfig{Root: root, Store: runstore.New()})
+
+	cases := []struct {
+		name  string
+		jobID string
+	}{
+		{
+			name:  "leading slash",
+			jobID: "/demo",
+		},
+		{
+			name:  "trailing slash",
+			jobID: "demo/",
+		},
+		{
+			name:  "double slash",
+			jobID: "demo//child",
+		},
+		{
+			name:  "leading dot",
+			jobID: ".demo",
+		},
+		{
+			name:  "trailing dot",
+			jobID: "demo.",
+		},
+		{
+			name:  "double dot",
+			jobID: "demo..child",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := fmt.Sprintf(`{"job_id":"%s","args":{"name":"Alice"}}`, tc.jobID)
+			req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(payload))
+			req.Header.Set("Content-Type", "application/json")
+			addIdempotencyHeader(req)
+			resp := httptest.NewRecorder()
+			h.ServeHTTP(resp, req)
+
+			if resp.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d: %s", resp.Code, resp.Body.String())
+			}
+			if !strings.HasPrefix(resp.Header().Get("Content-Type"), "application/problem+json") {
+				t.Fatalf("expected problem response, got %q", resp.Header().Get("Content-Type"))
+			}
+			var problem map[string]any
+			if err := json.NewDecoder(resp.Body).Decode(&problem); err != nil {
+				t.Fatalf("decode problem: %v", err)
+			}
+			if problem["code"] != response.ProblemCodeJobIDInvalidSegment {
+				t.Fatalf("expected code %q, got %+v", response.ProblemCodeJobIDInvalidSegment, problem)
+			}
+			if problem["type"] != response.ProblemTypeJobIDInvalidSegment {
+				t.Fatalf("expected type %q, got %+v", response.ProblemTypeJobIDInvalidSegment, problem)
 			}
 		})
 	}

--- a/internal/server/handlers/runs_test.go
+++ b/internal/server/handlers/runs_test.go
@@ -237,6 +237,139 @@ argspec:
 	}
 }
 
+func TestRunsHandlerJobRefForms(t *testing.T) {
+	root := t.TempDir()
+	writeJobConfig(t, root, "demo", `
+version: v1
+job:
+  id: demo
+  name: Demo Job
+argspec:
+  args:
+    - name: name
+      type: string
+      required: true
+`)
+	writeJobConfig(t, root, filepath.Join("Demo", "Child"), `
+version: v1
+job:
+  id: demo/child
+  name: Demo Child Job
+argspec:
+  args:
+    - name: name
+      type: string
+      required: true
+`)
+
+	flwdYaml := `aliases:
+- from: demo
+  to: quick
+  description: Quick demo alias
+`
+	if err := os.WriteFile(filepath.Join(root, "flwd.yaml"), []byte(flwdYaml), 0o644); err != nil {
+		t.Fatalf("write flwd.yaml: %v", err)
+	}
+
+	h := NewRunsHandler(RunsConfig{Root: root, Store: runstore.New()})
+
+	cases := []struct {
+		name              string
+		jobID             string
+		wantStatus        int
+		wantJobID         string
+		wantAlias         bool
+		wantInvokedPath   string
+		wantCanonicalID   string
+		wantCanonicalPath string
+	}{
+		{
+			name:              "direct id",
+			jobID:             "demo",
+			wantStatus:        http.StatusCreated,
+			wantJobID:         "demo",
+			wantCanonicalID:   "demo",
+			wantCanonicalPath: "demo",
+		},
+		{
+			name:              "alias input",
+			jobID:             "QuIcK",
+			wantStatus:        http.StatusCreated,
+			wantJobID:         "demo",
+			wantAlias:         true,
+			wantInvokedPath:   "QuIcK",
+			wantCanonicalID:   "demo",
+			wantCanonicalPath: "demo",
+		},
+		{
+			name:              "case-insensitive slash",
+			jobID:             "DeMo/ChIlD",
+			wantStatus:        http.StatusCreated,
+			wantJobID:         "DeMo/ChIlD",
+			wantCanonicalID:   "DeMo/ChIlD",
+			wantCanonicalPath: "DeMo/ChIlD",
+		},
+		{
+			name:       "legacy dot form",
+			jobID:      "demo.child",
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := fmt.Sprintf(`{"job_id":"%s","args":{"name":"Alice"}}`, tc.jobID)
+			req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(payload))
+			req.Header.Set("Content-Type", "application/json")
+			addIdempotencyHeader(req)
+			resp := httptest.NewRecorder()
+			h.ServeHTTP(resp, req)
+
+			if resp.Code != tc.wantStatus {
+				t.Fatalf("expected %d, got %d: %s", tc.wantStatus, resp.Code, resp.Body.String())
+			}
+			if tc.wantStatus != http.StatusCreated {
+				return
+			}
+
+			var body map[string]any
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if body["job_id"] != tc.wantJobID {
+				t.Fatalf("expected job_id %q, got %v", tc.wantJobID, body["job_id"])
+			}
+
+			prov, ok := body["provenance"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected provenance map, got %T", body["provenance"])
+			}
+			if tc.wantAlias {
+				if _, ok := prov["alias"].(map[string]any); !ok {
+					t.Fatalf("expected alias metadata, got %T", prov["alias"])
+				}
+			} else if _, ok := prov["alias"]; ok {
+				t.Fatalf("expected no alias metadata, got %v", prov["alias"])
+			}
+			if tc.wantInvokedPath != "" {
+				if prov["invoked_path"] != tc.wantInvokedPath {
+					t.Fatalf("expected invoked_path %q, got %v", tc.wantInvokedPath, prov["invoked_path"])
+				}
+			}
+			if tc.wantCanonicalID != "" {
+				if prov["canonical_id"] != tc.wantCanonicalID {
+					t.Fatalf("expected canonical_id %q, got %v", tc.wantCanonicalID, prov["canonical_id"])
+				}
+			}
+			if tc.wantCanonicalPath != "" {
+				if prov["canonical_path"] != tc.wantCanonicalPath {
+					t.Fatalf("expected canonical_path %q, got %v", tc.wantCanonicalPath, prov["canonical_path"])
+				}
+			}
+		})
+	}
+}
+
 func TestRunsHandlerEmitsRunStartEvent(t *testing.T) {
 	root := t.TempDir()
 	writeJobConfig(t, root, "demo", `

--- a/internal/server/handlers/runs_test.go
+++ b/internal/server/handlers/runs_test.go
@@ -757,7 +757,15 @@ func TestRunsHandlerGitSource(t *testing.T) {
 		Sources: sourceStore,
 	})
 
-	req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(`{"job_id":"scripts/gitjob","args":{"name":"Dana"},"source":{"name":"git-remote"}}`))
+	src, ok := sourceStore.Get("git-remote")
+	if !ok {
+		t.Fatal("expected git source in store")
+	}
+	jobID, err := indexer.CanonicalJobID(sourceMountPath(src), filepath.ToSlash(filepath.Join("scripts", "gitjob")))
+	if err != nil {
+		t.Fatalf("canonical job id: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(fmt.Sprintf(`{"job_id":%q,"args":{"name":"Dana"},"source":{"name":"git-remote"}}`, jobID)))
 	req.Header.Set("Content-Type", "application/json")
 	addIdempotencyHeader(req)
 	resp := httptest.NewRecorder()
@@ -821,7 +829,11 @@ argspec:
 	})
 
 	h := NewRunsHandler(RunsConfig{Root: defaultRoot, Store: store, Sources: ss})
-	req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(`{"job_id":"remote","args":{"name":"Bob"},"source":{"name":"external"}}`))
+	jobID, err := indexer.CanonicalJobID(sourceRoot, "remote")
+	if err != nil {
+		t.Fatalf("canonical job id: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(fmt.Sprintf(`{"job_id":%q,"args":{"name":"Bob"},"source":{"name":"external"}}`, jobID)))
 	req.Header.Set("Content-Type", "application/json")
 	addIdempotencyHeader(req)
 	resp := httptest.NewRecorder()

--- a/internal/server/handlers/runs_test.go
+++ b/internal/server/handlers/runs_test.go
@@ -893,7 +893,7 @@ argspec:
 	}
 
 	store := coredb.NewIdempotencyStore(db)
-	body, status, _, ok, err := store.Lookup(context.Background(), key, "POST /runs", time.Now().UTC())
+	body, status, _, ok, err := store.Lookup(context.Background(), scopedIdempotencyKey(defaultTenant, key), "POST /runs", time.Now().UTC())
 	if err != nil {
 		t.Fatalf("lookup idempotency: %v", err)
 	}
@@ -929,7 +929,7 @@ argspec:
 	}
 }
 
-func TestRunsHandlerIdempotencyScopedByPrincipal(t *testing.T) {
+func TestRunsHandlerIdempotencyScopedByTenant(t *testing.T) {
 	root := t.TempDir()
 	writeJobConfig(t, root, "demo", `
 version: v1
@@ -949,12 +949,12 @@ argspec:
 
 	req1 := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(`{"job_id":"demo","args":{"name":"Alice"}}`))
 	req1.Header.Set("Content-Type", "application/json")
-	req1 = req1.WithContext(requestctx.WithPrincipal(req1.Context(), "tenant-A"))
+	req1 = req1.WithContext(requestctx.WithTenant(req1.Context(), "tenant-A"))
 	setSpecificIdempotencyKey(req1, key)
 	resp1 := httptest.NewRecorder()
 	h.ServeHTTP(resp1, req1)
 	if resp1.Code != http.StatusCreated {
-		t.Fatalf("expected 201 for first principal, got %d", resp1.Code)
+		t.Fatalf("expected 201 for first tenant, got %d", resp1.Code)
 	}
 	if resp1.Header().Get("Idempotent-Replay") != "" {
 		t.Fatalf("did not expect replay header on first request")
@@ -962,15 +962,15 @@ argspec:
 
 	req2 := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(`{"job_id":"demo","args":{"name":"Alice"}}`))
 	req2.Header.Set("Content-Type", "application/json")
-	req2 = req2.WithContext(requestctx.WithPrincipal(req2.Context(), "tenant-B"))
+	req2 = req2.WithContext(requestctx.WithTenant(req2.Context(), "tenant-B"))
 	setSpecificIdempotencyKey(req2, key)
 	resp2 := httptest.NewRecorder()
 	h.ServeHTTP(resp2, req2)
 	if resp2.Code != http.StatusCreated {
-		t.Fatalf("expected 201 for different principal, got %d", resp2.Code)
+		t.Fatalf("expected 201 for different tenant, got %d", resp2.Code)
 	}
 	if resp2.Header().Get("Idempotent-Replay") == "true" {
-		t.Fatalf("did not expect replay for different principal")
+		t.Fatalf("did not expect replay for different tenant")
 	}
 }
 

--- a/internal/server/handlers/runs_test.go
+++ b/internal/server/handlers/runs_test.go
@@ -167,36 +167,42 @@ argspec:
 		body       string
 		wantStatus int
 		wantCode   string
+		wantTenant string
 	}{
 		{
 			name:       "principal tenant, no request tenant",
 			ctx:        principalTenantCtx,
 			body:       baseBody,
 			wantStatus: http.StatusCreated,
+			wantTenant: "acme",
 		},
 		{
 			name:       "principal tenant, matching request tenant",
 			ctx:        principalTenantCtx,
 			body:       bodyWithTenant("acme"),
 			wantStatus: http.StatusCreated,
+			wantTenant: "acme",
 		},
 		{
 			name:       "principal without tenant claim, request tenant absent",
 			ctx:        principalOnlyCtx,
 			body:       baseBody,
 			wantStatus: http.StatusCreated,
+			wantTenant: defaultTenant,
 		},
 		{
 			name:       "no principal, request tenant present",
 			ctx:        context.Background(),
 			body:       bodyWithTenant("acme"),
 			wantStatus: http.StatusCreated,
+			wantTenant: "acme",
 		},
 		{
 			name:       "no principal, request tenant absent",
 			ctx:        context.Background(),
 			body:       baseBody,
 			wantStatus: http.StatusCreated,
+			wantTenant: defaultTenant,
 		},
 		{
 			name:       "principal tenant mismatch",
@@ -221,6 +227,13 @@ argspec:
 				t.Fatalf("expected %d, got %d: %s", tc.wantStatus, resp.Code, resp.Body.String())
 			}
 			if tc.wantCode == "" {
+				var payload map[string]any
+				if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+					t.Fatalf("decode response: %v", err)
+				}
+				if payload["tenant"] != tc.wantTenant {
+					t.Fatalf("expected tenant %q, got %v", tc.wantTenant, payload["tenant"])
+				}
 				return
 			}
 			if ct := resp.Header().Get("Content-Type"); ct != "application/problem+json" {
@@ -232,6 +245,102 @@ argspec:
 			}
 			if problem["code"] != tc.wantCode {
 				t.Fatalf("expected code %q, got %+v", tc.wantCode, problem)
+			}
+		})
+	}
+}
+
+func TestRunsHandlerRootJobAliases(t *testing.T) {
+	root := t.TempDir()
+	writeJobConfig(t, root, ".", `
+version: v1
+job:
+  id: root
+  name: Root Job
+`)
+
+	cases := []struct {
+		name  string
+		jobID string
+	}{
+		{
+			name:  "empty job id",
+			jobID: "",
+		},
+		{
+			name:  "dot alias",
+			jobID: ".",
+		},
+		{
+			name:  "slash alias",
+			jobID: "/",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := runstore.New()
+			sink := &recordingSink{}
+			h := NewRunsHandler(RunsConfig{Root: root, Store: store, Events: sink})
+
+			payload := fmt.Sprintf(`{"job_id":"%s"}`, tc.jobID)
+			req := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(payload))
+			req.Header.Set("Content-Type", "application/json")
+			addIdempotencyHeader(req)
+			resp := httptest.NewRecorder()
+			h.ServeHTTP(resp, req)
+
+			if resp.Code != http.StatusCreated {
+				t.Fatalf("expected 201, got %d: %s", resp.Code, resp.Body.String())
+			}
+			var body map[string]any
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if body["job_id"] != "" {
+				t.Fatalf("expected empty job_id, got %v", body["job_id"])
+			}
+			prov, ok := body["provenance"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected provenance map, got %T", body["provenance"])
+			}
+			if prov["canonical_id"] != "" {
+				t.Fatalf("expected canonical_id empty, got %v", prov["canonical_id"])
+			}
+			if prov["canonical_path"] != "" {
+				t.Fatalf("expected canonical_path empty, got %v", prov["canonical_path"])
+			}
+
+			runID, _ := body["id"].(string)
+			saved, ok := store.Get(runID)
+			if !ok {
+				t.Fatalf("expected stored run for %s", runID)
+			}
+			if saved.JobID != "" {
+				t.Fatalf("expected stored job_id empty, got %q", saved.JobID)
+			}
+
+			waitFor(func() bool { return sink.countBy("run.started") >= 1 }, 500*time.Millisecond, t)
+			events := sink.snapshot()
+			if len(events) == 0 {
+				t.Fatalf("expected at least one event")
+			}
+			var started recordedEvent
+			for _, ev := range events {
+				if ev.event.Event == "run.started" {
+					started = ev
+					break
+				}
+			}
+			if started.event.Event != "run.started" {
+				t.Fatalf("expected run.started event")
+			}
+			var eventPayload map[string]any
+			if err := json.Unmarshal([]byte(started.event.Data), &eventPayload); err != nil {
+				t.Fatalf("decode event payload: %v", err)
+			}
+			if eventPayload["job_id"] != "" {
+				t.Fatalf("expected event job_id empty, got %v", eventPayload["job_id"])
 			}
 		})
 	}
@@ -860,6 +969,98 @@ argspec:
 	}
 	if problem["type"] != idempotencyMismatchType {
 		t.Fatalf("expected conflict type %s, got %+v", idempotencyMismatchType, problem)
+	}
+}
+
+func TestRunsHandlerIdempotencyTenantScopedInFlight(t *testing.T) {
+	root := t.TempDir()
+	writeJobConfig(t, root, "demo", `
+version: v1
+job:
+  id: demo
+  name: Demo Job
+argspec:
+  args:
+    - name: name
+      type: string
+      required: true
+`)
+
+	db, err := coredb.Open(context.Background(), coredb.Options{DataDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open coredb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := runstore.New()
+	sink := &recordingSink{}
+	blocked := make(chan struct{})
+	unblock := make(chan struct{})
+	var discoverCalls int32
+	discover := func(root string) (indexer.Result, error) {
+		if atomic.AddInt32(&discoverCalls, 1) == 1 {
+			close(blocked)
+			<-unblock
+		}
+		return indexer.Discover(root)
+	}
+	h := NewRunsHandler(RunsConfig{
+		Root:     root,
+		Store:    store,
+		Events:   sink,
+		DB:       db,
+		Discover: discover,
+	})
+	key := "eeeeeeeeeeeeeeeeeeee"
+	payload := `{"job_id":"demo","args":{"name":"Alice"}}`
+
+	first := httptest.NewRecorder()
+	req1 := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(payload))
+	req1.Header.Set("Content-Type", "application/json")
+	req1 = req1.WithContext(requestctx.WithTenant(req1.Context(), "tenant-A"))
+	setSpecificIdempotencyKey(req1, key)
+	firstDone := make(chan struct{})
+	go func() {
+		h.ServeHTTP(first, req1)
+		close(firstDone)
+	}()
+
+	waitFor(func() bool {
+		select {
+		case <-blocked:
+			return true
+		default:
+			return false
+		}
+	}, 500*time.Millisecond, t)
+
+	second := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(payload))
+	req2.Header.Set("Content-Type", "application/json")
+	req2 = req2.WithContext(requestctx.WithTenant(req2.Context(), "tenant-B"))
+	setSpecificIdempotencyKey(req2, key)
+	h.ServeHTTP(second, req2)
+	if second.Code != http.StatusCreated {
+		t.Fatalf("expected 201 for different tenant, got %d", second.Code)
+	}
+	if second.Header().Get("Idempotent-Replay") == "true" {
+		t.Fatalf("did not expect replay for different tenant")
+	}
+
+	third := httptest.NewRecorder()
+	req3 := httptest.NewRequest(http.MethodPost, "/runs", strings.NewReader(payload))
+	req3.Header.Set("Content-Type", "application/json")
+	req3 = req3.WithContext(requestctx.WithTenant(req3.Context(), "tenant-A"))
+	setSpecificIdempotencyKey(req3, key)
+	h.ServeHTTP(third, req3)
+	if third.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 for in-flight idempotency, got %d", third.Code)
+	}
+
+	close(unblock)
+	<-firstDone
+	if first.Code != http.StatusCreated {
+		t.Fatalf("expected first request 201, got %d", first.Code)
 	}
 }
 

--- a/internal/server/handlers/sources.go
+++ b/internal/server/handlers/sources.go
@@ -253,7 +253,7 @@ func sanitizeSourceURL(raw string) string {
 	cleaned = stripURLQueryFragment(cleaned)
 	parsed, err := url.Parse(cleaned)
 	if err != nil {
-		return cleaned
+		return scrubUserInfoFallback(cleaned)
 	}
 	if parsed.User != nil {
 		parsed.User = nil
@@ -261,6 +261,35 @@ func sanitizeSourceURL(raw string) string {
 	parsed.RawQuery = ""
 	parsed.Fragment = ""
 	return parsed.String()
+}
+
+func scrubUserInfoFallback(value string) string {
+	if value == "" {
+		return value
+	}
+	if idx := strings.Index(value, "://"); idx >= 0 {
+		prefix := value[:idx+3]
+		rest := value[idx+3:]
+		return prefix + scrubUserInfoAuthority(rest)
+	}
+	return scrubUserInfoAuthority(value)
+}
+
+func scrubUserInfoAuthority(value string) string {
+	if value == "" {
+		return value
+	}
+	authorityEnd := strings.IndexAny(value, "/?#")
+	if authorityEnd < 0 {
+		authorityEnd = len(value)
+	}
+	authority := value[:authorityEnd]
+	lastAt := strings.LastIndex(authority, "@")
+	if lastAt < 0 {
+		return value
+	}
+	scrubbed := authority[lastAt+1:]
+	return scrubbed + value[authorityEnd:]
 }
 
 func stripURLQueryFragment(value string) string {

--- a/internal/server/handlers/sources.go
+++ b/internal/server/handlers/sources.go
@@ -252,6 +252,7 @@ func sanitizeSourceURL(raw string) string {
 	if cleaned == "" {
 		return cleaned
 	}
+	cleaned = stripURLQueryFragment(cleaned)
 	parsed, err := url.Parse(cleaned)
 	if err != nil {
 		return cleaned
@@ -262,6 +263,19 @@ func sanitizeSourceURL(raw string) string {
 	parsed.RawQuery = ""
 	parsed.Fragment = ""
 	return parsed.String()
+}
+
+func stripURLQueryFragment(value string) string {
+	if value == "" {
+		return value
+	}
+	if hash := strings.Index(value, "#"); hash >= 0 {
+		value = value[:hash]
+	}
+	if question := strings.Index(value, "?"); question >= 0 {
+		value = value[:question]
+	}
+	return value
 }
 
 func redactSourceConfig(values map[string]any) map[string]any {

--- a/internal/server/handlers/sources.go
+++ b/internal/server/handlers/sources.go
@@ -155,7 +155,7 @@ func buildSourceView(src sourcestore.Source, tenant string) sourceView {
 		Ref:              src.Ref,
 		ResolvedRef:      src.ResolvedRef,
 		ResolvedCommit:   src.ResolvedCommit,
-		URL:              src.URL,
+		URL:              sanitizeSourceURL(src.URL),
 		Trust:            src.Trust,
 		Aliases:          src.Aliases,
 		Metadata:         src.Metadata,
@@ -343,7 +343,7 @@ func buildSourceProvenance(src sourcestore.Source) map[string]any {
 		out["ref"] = src.Ref
 	}
 	if src.URL != "" {
-		out["url"] = src.URL
+		out["url"] = sanitizeSourceURL(src.URL)
 	}
 	if src.ResolvedCommit != "" {
 		out["resolved_commit"] = src.ResolvedCommit

--- a/internal/server/handlers/sources.go
+++ b/internal/server/handlers/sources.go
@@ -158,10 +158,8 @@ func buildSourceView(src sourcestore.Source, tenant string) sourceView {
 		URL:              sanitizeSourceURL(src.URL),
 		Trust:            src.Trust,
 		Aliases:          src.Aliases,
-		Metadata:         src.Metadata,
 		Digest:           src.Digest,
 		VerifySignatures: src.VerifySignatures,
-		Provenance:       src.Provenance,
 		Expose:           src.Expose,
 	}
 }
@@ -445,9 +443,6 @@ func handleListSources(w http.ResponseWriter, r *http.Request, cfg SourcesConfig
 	includeAliases := shouldExposeAliases(r, cfg)
 	views := make([]sourceView, 0, len(items))
 	for i := range items {
-		if items[i].Provenance == nil {
-			items[i].Provenance = buildSourceProvenance(items[i])
-		}
 		items[i] = sanitizeSourceForResponse(items[i], includeAliases)
 		views = append(views, buildSourceView(items[i], resolvedTenant))
 	}
@@ -981,9 +976,6 @@ func NewSourceGetHandler(cfg SourcesConfig) http.Handler {
 			}
 			includeAliases := shouldExposeAliases(r, cfg)
 			src = sanitizeSourceForResponse(src, includeAliases)
-			if src.Provenance == nil {
-				src.Provenance = buildSourceProvenance(src)
-			}
 			writeSourceResponse(r.Context(), w, src, false)
 		case http.MethodDelete:
 			if deleted := store.Delete(name); !deleted {

--- a/internal/server/handlers/sources.go
+++ b/internal/server/handlers/sources.go
@@ -259,6 +259,8 @@ func sanitizeSourceURL(raw string) string {
 	if parsed.User != nil {
 		parsed.User = nil
 	}
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
 	return parsed.String()
 }
 

--- a/internal/server/handlers/sources.go
+++ b/internal/server/handlers/sources.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/flowd-org/flowd/internal/configloader"
+	"github.com/flowd-org/flowd/internal/events"
 	"github.com/flowd-org/flowd/internal/executor/container"
 	"github.com/flowd-org/flowd/internal/paths"
 	"github.com/flowd-org/flowd/internal/policy"
@@ -51,6 +52,29 @@ type sourceRequest struct {
 	Trust            map[string]interface{} `json:"trust"`
 	Expose           string                 `json:"expose"`
 	VerifySignatures bool                   `json:"verify_signatures"`
+}
+
+type sourceView struct {
+	ID               string               `json:"id"`
+	Tenant           string               `json:"tenant"`
+	Kind             string               `json:"kind"`
+	MountPath        string               `json:"mountPath"`
+	Layout           string               `json:"layout"`
+	PullPolicy       string               `json:"pull_policy"`
+	Config           map[string]any       `json:"config"`
+	Name             string               `json:"name"`
+	Type             string               `json:"type"`
+	Ref              string               `json:"ref,omitempty"`
+	ResolvedRef      string               `json:"resolved_ref,omitempty"`
+	ResolvedCommit   string               `json:"resolved_commit,omitempty"`
+	URL              string               `json:"url,omitempty"`
+	Trust            map[string]any       `json:"trust,omitempty"`
+	Aliases          []types.CommandAlias `json:"aliases,omitempty"`
+	Metadata         map[string]any       `json:"metadata,omitempty"`
+	Digest           string               `json:"digest,omitempty"`
+	VerifySignatures bool                 `json:"verify_signatures,omitempty"`
+	Provenance       map[string]any       `json:"provenance,omitempty"`
+	Expose           string               `json:"expose,omitempty"`
 }
 
 var (
@@ -108,6 +132,202 @@ func sanitizeSourceForResponse(src sourcestore.Source, includeAliases bool) sour
 		clone.Aliases = nil
 	}
 	return clone
+}
+
+func buildSourceView(src sourcestore.Source, tenant string) sourceView {
+	kind := sourceKindForView(src.Type)
+	mountPath := sourceMountPath(src)
+	layout := sourceLayoutForView(kind, mountPath)
+	pullPolicy := sourcePullPolicyForView(src.PullPolicy)
+	config := sourceConfigForView(src, pullPolicy)
+
+	return sourceView{
+		ID:               src.Name,
+		Tenant:           tenant,
+		Kind:             kind,
+		MountPath:        mountPath,
+		Layout:           layout,
+		PullPolicy:       pullPolicy,
+		Config:           config,
+		Name:             src.Name,
+		Type:             src.Type,
+		Ref:              src.Ref,
+		ResolvedRef:      src.ResolvedRef,
+		ResolvedCommit:   src.ResolvedCommit,
+		URL:              src.URL,
+		Trust:            src.Trust,
+		Aliases:          src.Aliases,
+		Metadata:         src.Metadata,
+		Digest:           src.Digest,
+		VerifySignatures: src.VerifySignatures,
+		Provenance:       src.Provenance,
+		Expose:           src.Expose,
+	}
+}
+
+func sourceKindForView(sourceType string) string {
+	switch strings.ToLower(strings.TrimSpace(sourceType)) {
+	case "local":
+		return "fs"
+	case "git":
+		return "git"
+	case "oci":
+		return "oci"
+	default:
+		return strings.ToLower(strings.TrimSpace(sourceType))
+	}
+}
+
+func sourceMountPath(src sourcestore.Source) string {
+	if src.LocalPath != "" {
+		return src.LocalPath
+	}
+	if src.Metadata != nil {
+		if resolved, ok := src.Metadata["resolved_path"].(string); ok && resolved != "" {
+			return resolved
+		}
+		if checkout, ok := src.Metadata["checkout_path"].(string); ok && checkout != "" {
+			return checkout
+		}
+		if manifestPath, ok := src.Metadata["manifest_path"].(string); ok && manifestPath != "" {
+			return filepath.Dir(manifestPath)
+		}
+	}
+	return ""
+}
+
+func sourceLayoutForView(kind string, mountPath string) string {
+	if kind == "fs" || kind == "git" {
+		if mountPath != "" {
+			return "tree-v1"
+		}
+	}
+	return ""
+}
+
+func sourcePullPolicyForView(pullPolicy string) string {
+	if strings.TrimSpace(pullPolicy) == "" {
+		return "always"
+	}
+	return pullPolicy
+}
+
+func sourceConfigForView(src sourcestore.Source, pullPolicy string) map[string]any {
+	config := map[string]any{}
+	switch strings.ToLower(strings.TrimSpace(src.Type)) {
+	case "local":
+		if src.Ref != "" {
+			config["path"] = src.Ref
+		}
+	case "git":
+		if src.URL != "" {
+			config["url"] = sanitizeSourceURL(src.URL)
+		}
+		if src.Ref != "" {
+			config["ref"] = src.Ref
+		}
+	case "oci":
+		if src.Ref != "" {
+			config["ref"] = src.Ref
+		}
+		if src.Digest != "" {
+			config["digest"] = src.Digest
+		}
+		if pullPolicy != "" {
+			config["pull_policy"] = pullPolicy
+		}
+		if src.VerifySignatures {
+			config["verify_signatures"] = true
+		}
+	}
+	if len(config) == 0 {
+		return map[string]any{}
+	}
+	return redactSourceConfig(config)
+}
+
+func sanitizeSourceURL(raw string) string {
+	cleaned := strings.TrimSpace(raw)
+	if cleaned == "" {
+		return cleaned
+	}
+	parsed, err := url.Parse(cleaned)
+	if err != nil {
+		return cleaned
+	}
+	if parsed.User != nil {
+		parsed.User = nil
+	}
+	return parsed.String()
+}
+
+func redactSourceConfig(values map[string]any) map[string]any {
+	if len(values) == 0 {
+		return values
+	}
+	out := make(map[string]any, len(values))
+	for key, value := range values {
+		if isSecretConfigKey(key) {
+			out[key] = events.SecretToken()
+			continue
+		}
+		out[key] = redactSourceConfigValue(value)
+	}
+	return out
+}
+
+func redactSourceConfigValue(value any) any {
+	switch v := value.(type) {
+	case map[string]any:
+		return redactSourceConfig(v)
+	case map[string]string:
+		out := make(map[string]any, len(v))
+		for key, val := range v {
+			if isSecretConfigKey(key) {
+				out[key] = events.SecretToken()
+				continue
+			}
+			out[key] = val
+		}
+		return out
+	case []any:
+		out := make([]any, len(v))
+		for i, elem := range v {
+			out[i] = redactSourceConfigValue(elem)
+		}
+		return out
+	case []string:
+		out := make([]any, len(v))
+		for i, elem := range v {
+			out[i] = elem
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+func isSecretConfigKey(key string) bool {
+	clean := strings.ToLower(strings.TrimSpace(key))
+	if clean == "" {
+		return false
+	}
+	if clean == "token" || clean == "password" || clean == "secret" || clean == "apikey" || clean == "api_key" {
+		return true
+	}
+	if clean == "access_key" || clean == "access_key_id" || clean == "secret_key" || clean == "secret_access_key" {
+		return true
+	}
+	if clean == "private_key" || clean == "ssh_key" || clean == "ssh_key_path" {
+		return true
+	}
+	if strings.Contains(clean, "token") || strings.Contains(clean, "password") || strings.Contains(clean, "secret") {
+		return true
+	}
+	if strings.Contains(clean, "credential") || strings.Contains(clean, "private_key") || strings.Contains(clean, "access_key") {
+		return true
+	}
+	return false
 }
 
 func buildSourceProvenance(src sourcestore.Source) map[string]any {
@@ -199,15 +419,22 @@ func handleListSources(w http.ResponseWriter, r *http.Request, cfg SourcesConfig
 	if store == nil {
 		store = sourcestore.New()
 	}
+	resolvedTenant, prob := resolveTenant(r.Context(), "")
+	if prob != nil {
+		response.Write(w, scrubProblemResponse(prob, nil, nil, nil, nil))
+		return
+	}
 	items := store.List()
 	includeAliases := shouldExposeAliases(r, cfg)
+	views := make([]sourceView, 0, len(items))
 	for i := range items {
 		if items[i].Provenance == nil {
 			items[i].Provenance = buildSourceProvenance(items[i])
 		}
 		items[i] = sanitizeSourceForResponse(items[i], includeAliases)
+		views = append(views, buildSourceView(items[i], resolvedTenant))
 	}
-	data, err := json.Marshal(items)
+	data, err := json.Marshal(views)
 	if err != nil {
 		response.Write(w, response.New(http.StatusInternalServerError, "encode sources failed", response.WithDetail(scrubProblemDetail(err.Error(), nil, nil, nil, nil))))
 		return
@@ -238,7 +465,7 @@ func handleUpsertSource(ctx context.Context, w http.ResponseWriter, r *http.Requ
 
 	switch req.Type {
 	case "local":
-		handleLocalSource(w, req, cfg)
+		handleLocalSource(ctx, w, req, cfg)
 	case "git":
 		handleGitSource(ctx, w, req, cfg)
 	case "oci":
@@ -255,7 +482,7 @@ func shouldExposeAliases(r *http.Request, cfg SourcesConfig) bool {
 	return cfg.AliasesPublic
 }
 
-func handleLocalSource(w http.ResponseWriter, req sourceRequest, cfg SourcesConfig) {
+func handleLocalSource(ctx context.Context, w http.ResponseWriter, req sourceRequest, cfg SourcesConfig) {
 	if req.Ref == "" {
 		response.Write(w, response.New(http.StatusBadRequest, "ref is required for local sources"))
 		return
@@ -323,7 +550,7 @@ func handleLocalSource(w http.ResponseWriter, req sourceRequest, cfg SourcesConf
 	}
 
 	created := cfg.Store.Upsert(src)
-	writeSourceResponse(w, sanitizeSourceForResponse(src, true), created)
+	writeSourceResponse(ctx, w, sanitizeSourceForResponse(src, true), created)
 }
 
 func handleGitSource(ctx context.Context, w http.ResponseWriter, req sourceRequest, cfg SourcesConfig) {
@@ -442,7 +669,7 @@ func handleGitSource(ctx context.Context, w http.ResponseWriter, req sourceReque
 	}
 
 	created := cfg.Store.Upsert(src)
-	writeSourceResponse(w, sanitizeSourceForResponse(src, true), created)
+	writeSourceResponse(ctx, w, sanitizeSourceForResponse(src, true), created)
 }
 
 func handleOCISource(ctx context.Context, w http.ResponseWriter, req sourceRequest, cfg SourcesConfig) {
@@ -683,11 +910,17 @@ func handleOCISource(ctx context.Context, w http.ResponseWriter, req sourceReque
 	if created {
 		metrics.Default.RecordSourceAdded(src.Type)
 	}
-	writeSourceResponse(w, sanitizeSourceForResponse(src, true), created)
+	writeSourceResponse(ctx, w, sanitizeSourceForResponse(src, true), created)
 }
 
-func writeSourceResponse(w http.ResponseWriter, src sourcestore.Source, created bool) {
-	data, err := json.Marshal(src)
+func writeSourceResponse(ctx context.Context, w http.ResponseWriter, src sourcestore.Source, created bool) {
+	resolvedTenant, prob := resolveTenant(ctx, "")
+	if prob != nil {
+		response.Write(w, scrubProblemResponse(prob, nil, nil, nil, nil))
+		return
+	}
+	view := buildSourceView(src, resolvedTenant)
+	data, err := json.Marshal(view)
 	if err != nil {
 		response.Write(w, response.New(http.StatusInternalServerError, "encode source failed", response.WithDetail(err.Error())))
 		return
@@ -726,7 +959,7 @@ func NewSourceGetHandler(cfg SourcesConfig) http.Handler {
 			if src.Provenance == nil {
 				src.Provenance = buildSourceProvenance(src)
 			}
-			writeSourceResponse(w, src, false)
+			writeSourceResponse(r.Context(), w, src, false)
 		case http.MethodDelete:
 			if deleted := store.Delete(name); !deleted {
 				response.Write(w, response.New(http.StatusNotFound, "source not found", response.WithDetail(name)))

--- a/internal/server/handlers/sources.go
+++ b/internal/server/handlers/sources.go
@@ -437,13 +437,11 @@ func handleListSources(w http.ResponseWriter, r *http.Request, cfg SourcesConfig
 	}
 	logger := requestctx.Logger(r.Context())
 	if logger != nil {
-		for _, view := range views {
-			logger.Info("source.listed",
-				slog.String("tenant", resolvedTenant),
-				slog.String("source_id", view.ID),
-				slog.String("source_kind", view.Kind),
-			)
-		}
+		logger.Info("sources.listed",
+			slog.String("tenant", resolvedTenant),
+			slog.Int("sources_total", len(views)),
+			slog.Bool("aliases_exposed", includeAliases),
+		)
 	}
 	data, err := json.Marshal(views)
 	if err != nil {

--- a/internal/server/handlers/sources.go
+++ b/internal/server/handlers/sources.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -433,6 +434,16 @@ func handleListSources(w http.ResponseWriter, r *http.Request, cfg SourcesConfig
 		}
 		items[i] = sanitizeSourceForResponse(items[i], includeAliases)
 		views = append(views, buildSourceView(items[i], resolvedTenant))
+	}
+	logger := requestctx.Logger(r.Context())
+	if logger != nil {
+		for _, view := range views {
+			logger.Info("source.listed",
+				slog.String("tenant", resolvedTenant),
+				slog.String("source_id", view.ID),
+				slog.String("source_kind", view.Kind),
+			)
+		}
 	}
 	data, err := json.Marshal(views)
 	if err != nil {

--- a/internal/server/handlers/sources_test.go
+++ b/internal/server/handlers/sources_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -18,9 +19,53 @@ import (
 	"github.com/flowd-org/flowd/internal/policy"
 	policyverify "github.com/flowd-org/flowd/internal/policy/verify"
 	"github.com/flowd-org/flowd/internal/server/metrics"
+	"github.com/flowd-org/flowd/internal/server/requestctx"
 	"github.com/flowd-org/flowd/internal/server/sourcestore"
 	"github.com/flowd-org/flowd/internal/types"
 )
+
+type captureHandler struct {
+	records []string
+}
+
+func (h *captureHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	var b strings.Builder
+	b.WriteString(r.Message)
+	r.Attrs(func(attr slog.Attr) bool {
+		appendAttrString(&b, attr)
+		return true
+	})
+	h.records = append(h.records, b.String())
+	return nil
+}
+
+func (h *captureHandler) WithAttrs([]slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *captureHandler) WithGroup(string) slog.Handler {
+	return h
+}
+
+func appendAttrString(b *strings.Builder, attr slog.Attr) {
+	attr.Value = attr.Value.Resolve()
+	switch attr.Value.Kind() {
+	case slog.KindString:
+		b.WriteString(attr.Value.String())
+	case slog.KindAny:
+		if value, ok := attr.Value.Any().(string); ok {
+			b.WriteString(value)
+		}
+	case slog.KindGroup:
+		for _, child := range attr.Value.Group() {
+			appendAttrString(b, child)
+		}
+	}
+}
 
 func TestSourcesHandlerLocalSuccess(t *testing.T) {
 	root := t.TempDir()
@@ -74,6 +119,37 @@ func TestSourcesHandlerLocalSuccess(t *testing.T) {
 	}
 	if prov, ok := list[0]["provenance"].(map[string]any); !ok || prov["resolved_path"] == "" {
 		t.Fatalf("expected provenance in list response, got %+v", list[0]["provenance"])
+	}
+}
+
+func TestSourcesHandlerListDoesNotLogSecrets(t *testing.T) {
+	secret := "supersecret"
+	store := sourcestore.New()
+	store.Upsert(sourcestore.Source{
+		Name: "git",
+		Type: "git",
+		URL:  "https://user:" + secret + "@example.com/repo.git",
+		Ref:  "main",
+	})
+	h := NewSourcesHandler(SourcesConfig{Store: store})
+
+	handler := &captureHandler{}
+	logger := slog.New(handler)
+	req := httptest.NewRequest(http.MethodGet, "/sources", nil)
+	req = req.WithContext(requestctx.WithLogger(req.Context(), logger))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for list, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(handler.records) == 0 {
+		t.Fatalf("expected log entries to be captured")
+	}
+	for _, entry := range handler.records {
+		if strings.Contains(entry, secret) {
+			t.Fatalf("expected logs to exclude secret substring, got %q", entry)
+		}
 	}
 }
 

--- a/internal/server/handlers/sources_test.go
+++ b/internal/server/handlers/sources_test.go
@@ -252,6 +252,18 @@ func TestSourcesHandlerListCoreViewAndRedaction(t *testing.T) {
 	}
 }
 
+func TestSanitizeSourceURLMalformed(t *testing.T) {
+	secret := "supersecret"
+	input := "https://user:" + secret + "@example.com/repo.git%"
+	output := sanitizeSourceURL(input)
+	if strings.Contains(output, secret) {
+		t.Fatalf("expected sanitized url to remove credentials, got %q", output)
+	}
+	if strings.Contains(output, "@") {
+		t.Fatalf("expected sanitized url to remove userinfo delimiter, got %q", output)
+	}
+}
+
 func sourceByID(list []map[string]any, id string) (map[string]any, bool) {
 	for _, item := range list {
 		if value, ok := item["id"].(string); ok && value == id {

--- a/internal/server/handlers/sources_test.go
+++ b/internal/server/handlers/sources_test.go
@@ -153,6 +153,139 @@ func TestSourcesHandlerListDoesNotLogSecrets(t *testing.T) {
 	}
 }
 
+func TestSourcesHandlerListCoreViewAndRedaction(t *testing.T) {
+	secret := "supersecret"
+	store := sourcestore.New()
+	localRoot := t.TempDir()
+	gitRoot := t.TempDir()
+	ociRoot := t.TempDir()
+
+	store.Upsert(sourcestore.Source{
+		Name:      "local",
+		Type:      "local",
+		Ref:       "demo",
+		LocalPath: localRoot,
+		Expose:    "read",
+	})
+	store.Upsert(sourcestore.Source{
+		Name:           "git",
+		Type:           "git",
+		Ref:            "main",
+		ResolvedRef:    "deadbeef",
+		ResolvedCommit: "deadbeef",
+		URL:            "https://user:" + secret + "@example.com/repo.git",
+		LocalPath:      gitRoot,
+		Expose:         "read",
+	})
+	store.Upsert(sourcestore.Source{
+		Name:             "addon",
+		Type:             "oci",
+		Ref:              "ghcr.io/example/addon:1.0",
+		Digest:           "sha256:abc123",
+		PullPolicy:       "always",
+		VerifySignatures: true,
+		LocalPath:        ociRoot,
+		Expose:           "read",
+	})
+
+	h := NewSourcesHandler(SourcesConfig{Store: store})
+	handler := &captureHandler{}
+	logger := slog.New(handler)
+	req := httptest.NewRequest(http.MethodGet, "/sources", nil)
+	req = req.WithContext(requestctx.WithLogger(req.Context(), logger))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for list, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), secret) {
+		t.Fatalf("expected response to exclude secret substring")
+	}
+	for _, entry := range handler.records {
+		if strings.Contains(entry, secret) {
+			t.Fatalf("expected logs to exclude secret substring, got %q", entry)
+		}
+	}
+
+	var list []map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(list) != 3 {
+		t.Fatalf("expected three sources, got %d", len(list))
+	}
+
+	local, ok := sourceByID(list, "local")
+	if !ok {
+		t.Fatalf("expected local source in response")
+	}
+	assertCoreViewFields(t, local, "local", "fs", localRoot, "tree-v1")
+	localConfig, _ := local["config"].(map[string]any)
+	if localConfig["path"] != "demo" {
+		t.Fatalf("expected local config path demo, got %+v", localConfig)
+	}
+
+	git, ok := sourceByID(list, "git")
+	if !ok {
+		t.Fatalf("expected git source in response")
+	}
+	assertCoreViewFields(t, git, "git", "git", gitRoot, "tree-v1")
+	gitConfig, _ := git["config"].(map[string]any)
+	if gitConfig["url"] != "https://example.com/repo.git" {
+		t.Fatalf("expected sanitized git url, got %+v", gitConfig)
+	}
+	if git["name"] != "git" || git["type"] != "git" || git["ref"] != "main" || git["resolved_ref"] != "deadbeef" {
+		t.Fatalf("expected legacy fields present, got %+v", git)
+	}
+
+	oci, ok := sourceByID(list, "addon")
+	if !ok {
+		t.Fatalf("expected oci source in response")
+	}
+	if oci["kind"] != "oci" {
+		t.Fatalf("expected oci kind, got %+v", oci["kind"])
+	}
+	ociConfig, _ := oci["config"].(map[string]any)
+	if ociConfig["ref"] != "ghcr.io/example/addon:1.0" || ociConfig["digest"] != "sha256:abc123" {
+		t.Fatalf("expected oci config ref/digest, got %+v", ociConfig)
+	}
+}
+
+func sourceByID(list []map[string]any, id string) (map[string]any, bool) {
+	for _, item := range list {
+		if value, ok := item["id"].(string); ok && value == id {
+			return item, true
+		}
+	}
+	return nil, false
+}
+
+func assertCoreViewFields(t *testing.T, payload map[string]any, id, kind, mountPath, layout string) {
+	t.Helper()
+	if payload["id"] != id {
+		t.Fatalf("expected id %s, got %+v", id, payload["id"])
+	}
+	if payload["tenant"] != "default" {
+		t.Fatalf("expected default tenant, got %+v", payload["tenant"])
+	}
+	if payload["kind"] != kind {
+		t.Fatalf("expected kind %s, got %+v", kind, payload["kind"])
+	}
+	if payload["mountPath"] != mountPath {
+		t.Fatalf("expected mountPath %s, got %+v", mountPath, payload["mountPath"])
+	}
+	if payload["layout"] != layout {
+		t.Fatalf("expected layout %s, got %+v", layout, payload["layout"])
+	}
+	if payload["pull_policy"] != "always" {
+		t.Fatalf("expected pull_policy always, got %+v", payload["pull_policy"])
+	}
+	if _, ok := payload["config"]; !ok {
+		t.Fatalf("expected config to be present, got %+v", payload)
+	}
+}
+
 func TestSourcesHandlerGitHostBlocked(t *testing.T) {
 	store := sourcestore.New()
 	h := NewSourcesHandler(SourcesConfig{

--- a/internal/server/handlers/sources_test.go
+++ b/internal/server/handlers/sources_test.go
@@ -173,7 +173,7 @@ func TestSourcesHandlerListCoreViewAndRedaction(t *testing.T) {
 		Ref:            "main",
 		ResolvedRef:    "deadbeef",
 		ResolvedCommit: "deadbeef",
-		URL:            "https://user:" + secret + "@example.com/repo.git",
+		URL:            "https://user:" + secret + "@example.com/repo.git?access_token=" + secret + "#" + secret,
 		LocalPath:      gitRoot,
 		Expose:         "read",
 	})

--- a/internal/server/handlers/sources_test.go
+++ b/internal/server/handlers/sources_test.go
@@ -100,8 +100,8 @@ func TestSourcesHandlerLocalSuccess(t *testing.T) {
 	if payload["expose"] != "read" {
 		t.Fatalf("expected expose read, got %v", payload["expose"])
 	}
-	if prov, ok := payload["provenance"].(map[string]any); !ok || prov["resolved_path"] == "" {
-		t.Fatalf("expected provenance with resolved_path, got %+v", payload["provenance"])
+	if _, ok := payload["provenance"]; ok {
+		t.Fatalf("expected provenance to be omitted from response, got %+v", payload["provenance"])
 	}
 
 	listReq := httptest.NewRequest(http.MethodGet, "/sources", nil)
@@ -117,8 +117,8 @@ func TestSourcesHandlerLocalSuccess(t *testing.T) {
 	if len(list) != 1 {
 		t.Fatalf("expected one source in list, got %d", len(list))
 	}
-	if prov, ok := list[0]["provenance"].(map[string]any); !ok || prov["resolved_path"] == "" {
-		t.Fatalf("expected provenance in list response, got %+v", list[0]["provenance"])
+	if _, ok := list[0]["provenance"]; ok {
+		t.Fatalf("expected provenance to be omitted from list response, got %+v", list[0]["provenance"])
 	}
 }
 

--- a/internal/server/handlers/sse_sink.go
+++ b/internal/server/handlers/sse_sink.go
@@ -79,6 +79,12 @@ func (s *sseSink) basePayload() map[string]any {
 	if s.run != nil {
 		payload["run_id"] = s.run.ID
 		payload["job_id"] = s.run.JobID
+		if s.run.Tenant != "" {
+			payload["tenant"] = s.run.Tenant
+		}
+		if s.run.Origin.SourceKind != "" || s.run.Origin.SourceName != "" {
+			payload["origin"] = s.run.Origin
+		}
 		if !s.run.StartedAt.IsZero() {
 			payload["started_at"] = s.run.StartedAt
 		}
@@ -103,5 +109,9 @@ func (s *sseSink) publish(event string, payload map[string]any) {
 	if err != nil {
 		bytes = []byte("{}")
 	}
-	s.sink.Publish(s.run.ID, sse.Event{Event: event, Data: string(bytes)})
+	ev := sse.Event{Event: event, Data: string(bytes)}
+	if s.run != nil {
+		ev.Tenant = s.run.Tenant
+	}
+	s.sink.Publish(s.run.ID, ev)
 }

--- a/internal/server/handlers/tenant.go
+++ b/internal/server/handlers/tenant.go
@@ -21,7 +21,8 @@ func resolveTenant(ctx context.Context, requestTenant string) (string, *response
 		if reqTenant != "" && reqTenant != principalTenant {
 			detail := fmt.Sprintf("request tenant %q does not match principal tenant %q", reqTenant, principalTenant)
 			prob := response.New(http.StatusForbidden, "tenant mismatch",
-				response.WithExtension("code", "tenant.mismatch"),
+				response.WithType(response.ProblemTypeTenantMismatch),
+				response.WithExtension("code", response.ProblemCodeTenantMismatch),
 				response.WithDetail(detail),
 				response.WithExtension("request_tenant", reqTenant),
 				response.WithExtension("principal_tenant", principalTenant),

--- a/internal/server/handlers/tenant.go
+++ b/internal/server/handlers/tenant.go
@@ -1,0 +1,41 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/flowd-org/flowd/internal/server/requestctx"
+	"github.com/flowd-org/flowd/internal/server/response"
+)
+
+const defaultTenant = "default"
+
+func resolveTenant(ctx context.Context, requestTenant string) (string, *response.Problem) {
+	reqTenant := strings.TrimSpace(requestTenant)
+	principalTenant, hasPrincipalTenant := requestctx.Tenant(ctx)
+	_, hasPrincipal := requestctx.Principal(ctx)
+
+	if hasPrincipalTenant {
+		if reqTenant != "" && reqTenant != principalTenant {
+			detail := fmt.Sprintf("request tenant %q does not match principal tenant %q", reqTenant, principalTenant)
+			prob := response.New(http.StatusForbidden, "tenant mismatch",
+				response.WithExtension("code", "tenant.mismatch"),
+				response.WithDetail(detail),
+				response.WithExtension("request_tenant", reqTenant),
+				response.WithExtension("principal_tenant", principalTenant),
+			)
+			return "", &prob
+		}
+		return principalTenant, nil
+	}
+
+	if reqTenant != "" {
+		return reqTenant, nil
+	}
+	if hasPrincipal {
+		return defaultTenant, nil
+	}
+	return defaultTenant, nil
+}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -134,6 +134,9 @@ func authMiddleware(cfg Config) Middleware {
 			}
 			ctx := withAuth(r.Context(), info)
 			ctx = requestctx.WithPrincipal(ctx, info.principal())
+			if tenant, ok := info.tenantClaim(); ok {
+				ctx = requestctx.WithTenant(ctx, tenant)
+			}
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -1,9 +1,12 @@
 package server
 
 import (
+	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/flowd-org/flowd/internal/server/requestctx"
 )
 
 func TestAuthMiddlewareRequiresToken(t *testing.T) {
@@ -89,7 +92,62 @@ func TestAuthMiddlewareForbidden(t *testing.T) {
 	}
 }
 
+func TestAuthMiddlewareTenantClaimPresent(t *testing.T) {
+	mw := authMiddleware(Config{Dev: true})
+	var gotTenant string
+	var gotTenantOK bool
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTenant, gotTenantOK = requestctx.Tenant(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+	token := unsignedJWT(`{"sub":"tester","tenant":"acme","scope":"jobs:read"}`)
+	req := httptest.NewRequest(http.MethodGet, "/jobs", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.Code)
+	}
+	if !gotTenantOK {
+		t.Fatalf("expected tenant claim to be present")
+	}
+	if gotTenant != "acme" {
+		t.Fatalf("expected tenant %q, got %q", "acme", gotTenant)
+	}
+}
+
+func TestAuthMiddlewareTenantClaimAbsent(t *testing.T) {
+	mw := authMiddleware(Config{Dev: true})
+	var gotTenantOK bool
+	var gotPrincipalOK bool
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, gotTenantOK = requestctx.Tenant(r.Context())
+		_, gotPrincipalOK = requestctx.Principal(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+	token := unsignedJWT(`{"sub":"tester","scope":"jobs:read"}`)
+	req := httptest.NewRequest(http.MethodGet, "/jobs", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.Code)
+	}
+	if gotTenantOK {
+		t.Fatalf("expected tenant claim to be absent")
+	}
+	if !gotPrincipalOK {
+		t.Fatalf("expected principal to be present")
+	}
+}
+
 type nopWriter struct{}
 
 func (nopWriter) Write(p []byte) (int, error) { return len(p), nil }
 func (nopWriter) Sync() error                 { return nil }
+
+func unsignedJWT(payload string) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	body := base64.RawURLEncoding.EncodeToString([]byte(payload))
+	return header + "." + body + "."
+}

--- a/internal/server/requestctx/requestctx.go
+++ b/internal/server/requestctx/requestctx.go
@@ -10,11 +10,13 @@ import (
 type profileKey struct{}
 type metadataKey struct{}
 type principalKey struct{}
+type tenantKey struct{}
 
 var (
 	ctxProfileKey   = &profileKey{}
 	ctxMetadataKey  = &metadataKey{}
 	ctxPrincipalKey = &principalKey{}
+	ctxTenantKey    = &tenantKey{}
 )
 
 // Metadata stores auxiliary request attributes for structured logging.
@@ -174,6 +176,26 @@ func Principal(ctx context.Context) (string, bool) {
 		return "", false
 	}
 	return principal, true
+}
+
+// WithTenant stores the authenticated tenant claim on the context.
+func WithTenant(ctx context.Context, tenant string) context.Context {
+	if tenant == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxTenantKey, tenant)
+}
+
+// Tenant retrieves the authenticated tenant claim from context.
+func Tenant(ctx context.Context) (string, bool) {
+	if ctx == nil {
+		return "", false
+	}
+	tenant, _ := ctx.Value(ctxTenantKey).(string)
+	if tenant == "" {
+		return "", false
+	}
+	return tenant, true
 }
 
 // LogPolicyDecision emits a structured policy decision log using the request-scoped logger.

--- a/internal/server/requestctx/requestctx_test.go
+++ b/internal/server/requestctx/requestctx_test.go
@@ -1,0 +1,33 @@
+package requestctx
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTenantAbsentWithoutContext(t *testing.T) {
+	if _, ok := Tenant(nil); ok {
+		t.Fatalf("expected tenant to be absent when context is nil")
+	}
+	if _, ok := Tenant(context.Background()); ok {
+		t.Fatalf("expected tenant to be absent when context has no tenant")
+	}
+}
+
+func TestTenantAbsentWithPrincipalOnly(t *testing.T) {
+	ctx := WithPrincipal(context.Background(), "tester")
+	if _, ok := Tenant(ctx); ok {
+		t.Fatalf("expected tenant to be absent when only principal is present")
+	}
+}
+
+func TestTenantPresent(t *testing.T) {
+	ctx := WithTenant(context.Background(), "acme")
+	got, ok := Tenant(ctx)
+	if !ok {
+		t.Fatalf("expected tenant to be present")
+	}
+	if got != "acme" {
+		t.Fatalf("expected tenant %q, got %q", "acme", got)
+	}
+}

--- a/internal/server/response/problem.go
+++ b/internal/server/response/problem.go
@@ -6,6 +6,14 @@ import (
 	"net/http"
 )
 
+const (
+	ProblemTypeJobIDCollision        = "https://flowd.org/problems/job-id-collision"
+	ProblemTypeJobConfigDualSentinel = "https://flowd.org/problems/job-config/dual-sentinel"
+	ProblemTypeTenantMismatch        = "https://flowd.org/problems/tenant-mismatch"
+	ProblemCodeJobIDCollision        = "job_id.collision"
+	ProblemCodeTenantMismatch        = "tenant.mismatch"
+)
+
 // Problem represents an RFC7807 problem response with optional custom extensions.
 type Problem struct {
 	Type     string

--- a/internal/server/response/problem.go
+++ b/internal/server/response/problem.go
@@ -8,9 +8,11 @@ import (
 
 const (
 	ProblemTypeJobIDCollision        = "https://flowd.org/problems/job-id-collision"
+	ProblemTypeJobIDInvalidSegment   = "https://flowd.org/problems/job-id-invalid-segment"
 	ProblemTypeJobConfigDualSentinel = "https://flowd.org/problems/job-config/dual-sentinel"
 	ProblemTypeTenantMismatch        = "https://flowd.org/problems/tenant-mismatch"
 	ProblemCodeJobIDCollision        = "job_id.collision"
+	ProblemCodeJobIDInvalidSegment   = "job_id.invalid_segment"
 	ProblemCodeTenantMismatch        = "tenant.mismatch"
 )
 


### PR DESCRIPTION
# M1/PR1 identity spine (tenants + sources + job identity)

## Summary
- Problem statement:
  - flowd's current identity spine is not Core-SoT aligned: discovery is legacy-only + dot IDs; tenant is not consistently accepted/stored/propagated; origin is not consistently present across APIs/events; sources do not expose Core fields (tenant/mountPath/layout).
- Goal / outcome:
  - PR1 aligns the identity spine to Core SoT (scope-limited):
    - Sources model and `GET /sources` response shape are Core-aligned (with an explicit extension rule for existing OCI sources).
    - Discovery produces canonical slash job IDs only; canonical IDs are relative to the tenant scripts root (mountPath is a canonical prefix), and collisions hard-fail with contenders listed.
    - Root job mapping is Core-aligned: the tenant scripts root maps to canonical `job_id=""`; clients can invoke it via defined request aliases.
    - `/jobs` and `/runs` responses, SSE envelopes, and run journal entries carry consistent `tenant` and `origin {source_kind, source_name}`.
    - Idempotency behavior is preserved but scoped by resolved tenant.
    - Legacy discovery inputs remain accepted via a temporary dual-read bridge (`config.yaml` + legacy `config.d/config.yaml`).
- Non-goals:
  - no new tenant management APIs or tenant lifecycle/administration
  - no authn/authz redesign beyond tenant defaulting + mismatch rejection rules in this spec
  - no expansion of the mutating `/sources` surface beyond what already exists today
  - no OCI add-on identity/discovery work in this PR1 slice

## Key changes
- ### 2.1 Current behavior (baseline)

- Discovery (`internal/indexer/indexer.go`) scans for legacy sentinel `config.d/config.yaml` and derives dot-delimited IDs from relative paths.
- Config loading (`internal/configloader/loader.go`) loads job config from legacy `config.d/config.yaml`.
- `GET /jobs` (`internal/server/handlers/jobs.go`) aggregates discovered jobs across the default scripts root + materialized sources; it surfaces `jobView.Source {name,type}` and supports alias listing.
  - Aliases (`internal/indexer/aliases.go`) normalize alias targets into dot-form IDs by converting `/` to `.`.
- `POST /runs` (`internal/server/handlers/runs.go`) resolves job refs using discovered jobs + aliases; it stores/returns the discovered job ID and keeps additional identity in a `provenance` map (including `canonical_path` derived by `strings.ReplaceAll(effectiveID, ".", "/")`).
- Request identity context (`internal/server/requestctx/requestctx.go`) exposes an identity-only principal string via `requestctx.Principal(ctx)`; there is no tenant-claim accessor in context today.
- Idempotency scoping in `POST /runs` uses the principal string as the scope key.
- SSE/journal sinks (`internal/server/handlers/sse_sink.go`, `internal/server/handlers/journal_sink.go`, `internal/server/sse/hub.go`) support a `tenant` field in the SSE envelope (`sse.Event.Tenant`) but events emitted today do not set it; journal payloads persist only the JSON event payload (no tenant/origin unless included in payload).
- Sources handler (`internal/server/handlers/sources.go`) returns `[]sourcestore.Source` directly; it does not emit Core fields like `tenant/mountPath/layout/config` (and the store's `LocalPath` is not serialized).

### 2.2 Proposed changes (PR1)

#### A) Canonical job IDs (slash + kebab normalization)

Introduce a canonical job ID utility used by tree-v1 discovery and any API surface that needs to validate/normalize tree-v1 job IDs.

Canonical ID derivation (Core SoT 1.5):
- Canonical ID pieces:
  - `rel` = `relFromMountRoot(jobDir)` with mount-root mapping `"." -> ""`.
  - `prefix` = `""` if `mountPath == "."`, else `mountPath`.
  - `canonical_id = join(prefix, rel)` where `join(a,b)` joins non-empty pieces with `/`.
- This implies:
  - If `jobDir` is the mount root and `mountPath=="."`, `canonical_id == ""` (root job mapping).
  - If `jobDir` is the mount root and `mountPath!="."`, `canonical_id == mountPath` (non-empty) and the job is allowed.
- Canonicalization MUST NOT change semantics: accepting the legacy sentinel MUST NOT introduce a different canonical ID scheme.

Normalization + validation (non-empty IDs):
- For each path segment, normalize to lowercase kebab-case; after normalization each segment must match `^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$`.
- If any segment cannot be normalized to a valid segment, discovery fails with an error that includes the offending path.
- Canonical IDs are emitted/stored as slash-delimited strings only.

Root job mapping (explicit; per `spec.md` + clarify):
- Canonical `job_id=""` (empty string) is allowed only when:
  - the discovered job directory is exactly the mount root (relative path from mount root maps to `""`), AND
  - the source `mountPath` is exactly `"."`.
- When allowed, the empty ID bypasses the per-segment regex rules (because there are zero segments).

Input normalization (compatibility):
- Normalize legacy dot-form job refs to canonical slash IDs for lookup (input compatibility only).
- Define root job invocation aliases for `POST /runs` when the resolved canonical job ID is `""`: accept request `job_id` values `""`, `"."`, and `"/"` and normalize to canonical `""`.

Implementation details:
- Add a small utility in `internal/indexer/` (or a new `internal/identity/` package if preferred by repo conventions) to:
  - compute canonical ID from `(mountPath, jobDirRel)` as above,
  - normalize segments and validate regex,
  - normalize legacy dot-form inputs to canonical slash IDs (input compatibility only),
  - derive a legacy dot form from a canonical slash id (for compatibility/diagnostics only).

#### B) Discovery dual-read sentinel + dual-config rejection

Update tree-v1 discovery to:
- Treat `config.yaml` in a directory as the primary sentinel.
- Also accept legacy `config.d/config.yaml` during PR1.
- Reject dual config in the same job directory:
  - If `jobDir/config.yaml` and `jobDir/config.d/config.yaml` both exist, discovery fails for that jobDir with a clear RFC7807 error using HTTP 409.

Concrete changes:
- Update `internal/indexer/indexer.go`:
  - Replace the "collect cfgPaths only under config.d" walk with logic that recognizes both patterns:
    - `*/config.yaml` (primary)
    - `*/config.d/config.yaml` (legacy)
  - For each discovered jobDir, compute canonical slash ID from jobDir relative to mount root using the canonical job ID utility (mountPath-prefix semantics).
  - Stop using YAML `job.id` as the external ID; keep `job.name`/`summary` as metadata, but treat identity as path-derived.
  - Update `JobInfo.Path` semantics to point to the job directory (not the sentinel file path), so that handlers do not need to guess directory levels.
- Update config loading utilities to dual-read:
  - `internal/configloader/loader.go` currently targets legacy `config.d/config.yaml`; change it to:
    - prefer `config.yaml` at the job directory root
    - fall back to `config.d/config.yaml` for legacy jobs
  - Audit other readers to ensure they follow the same precedence.

Compatibility notes:
- The dual-read bridge is discovery + load-time only; canonical ID semantics remain path-based and do not encode whether the job was discovered via legacy or primary sentinel.

#### C) Hard-fail on canonical ID collisions (with contenders list)

Add collision detection across all discovered tree-v1 jobs:
- Collisions occur when two or more job definitions map to the same canonical slash job ID after normalization (including the empty-ID root mapping when permitted).
- Collision handling: hard-fail discovery with an RFC7807 problem response using HTTP 409 and including a contenders list.

Where to enforce:
- `/jobs` handler aggregates across targets (default root + sources). It is the natural place to enforce global uniqueness across all tree-v1 jobs.
- For `POST /runs`, enforce collision behavior consistently in its resolution path:
  - If the request specifies a source (`req.source.name`), discovery scope is that source root; collisions within that root still hard-fail.
  - If `POST /runs` falls back to multiple targets, collisions across the combined set must also hard-fail (to avoid "it depends" identity results).

Error shape (align with existing problem responses like `alias.collision`):
- HTTP status: `409 Conflict`
- Content type: `application/problem+json`
- Problem fields:
  - `code`: `job_id.collision`
  - `detail`: human-readable remediation hint
  - `canonical_job_id`: the colliding canonical ID
  - `contenders`: array of objects with enough data to disambiguate without logs:
    - `canonical_job_id`
    - `source_kind`
    - `source_name`
    - `mountPath`
    - `job_dir` (job directory path relative to mountPath)

Concrete integration points:
- Add a "job registry" aggregation step in `internal/server/handlers/jobs.go` that:
  - collects `[]discoveredJob` including source metadata,
  - builds `map[canonicalID][]contender` and errors on any key with len>1.
- Mirror the same aggregation in `internal/server/handlers/runs.go` where it currently builds job lookups from discovery results.

#### D) Tenant claim extraction + request context accessor (cross-cutting)

Add tenant-claim plumbing so handlers can resolve tenant consistently without overloading the identity-only principal string.

Concrete changes:
- Update auth/middleware so that when a request is authenticated, the JWT claim `tenant` (Core SoT 4.1.1) is extracted and stored in request context.
- Add a dedicated accessor in `internal/server/requestctx/requestctx.go` (e.g. `Tenant(ctx) (string, bool)` or similar) that:
  - returns `(tenant, true)` if an authoritative tenant claim exists,
  - returns `("", false)` if principal exists but has no tenant claim,
  - returns `("", false)` if no principal exists.

Usage rule:
- `requestctx.Principal(ctx)` remains identity-only; all tenant resolution uses the tenant accessor (plus request/defaulting rules).

#### E) Jobs API: canonical IDs + tenant + origin

Update `GET /jobs` output:
- Ensure `id` is the canonical slash job ID for tree-v1 discovered jobs.
- Add:
  - `tenant`
  - `origin { source_kind, source_name }`

Tenant and origin derivation:
- Determine request tenant using the same tenant resolution helper used by runs (principal claim if present; otherwise request/default rules).
- Default scripts root jobs: tenant is the resolved request tenant; `origin={source_kind:"fs", source_name:"local"}`.
- Configured source jobs:
  - tenant is the resolved request tenant (PR1 does not introduce per-source tenant configuration).
  - `origin={source_kind: mapped source kind (local->fs, git->git, oci->oci), source_name:source.name}`.

Note on OCI jobs:
- OCI jobs are discovered from add-on manifests and already use slash-delimited IDs (e.g. `source-name/job-id`). PR1 does not redefine OCI job identity semantics; it only ensures `tenant` and `origin` are present consistently.

#### F) Runs API: request tenant + canonical IDs out + origin everywhere

Update `POST /runs` and run payloads:
- Add optional request field `tenant` to `runRequest`.
- Resolve effective tenant using spec rules:
  - If an authoritative principal tenant claim exists (via the new request context accessor), treat it as authoritative.
  - If request tenant is present and differs from the principal tenant, reject (RFC7807).
  - If request tenant absent, use principal tenant.
  - If principal exists but has no tenant claim, treat it as "no principal tenant" (so request tenant/default rules apply).
  - If no principal tenant and request tenant absent, default to `default`.

Canonical job-ref compatibility (inputs):
- Accept canonical slash IDs case-insensitively.
- Accept configured aliases unchanged.
- Accept any legacy dot-delimited forms that currently resolve (do not expand accepted formats beyond the status quo).
- Root job invocation aliases: when the resolved canonical job ID is `""`, accept request `job_id` values `""`, `"."`, and `"/"` and normalize to canonical `""`.

Alias + dot-form compatibility strategy (transition-safe):
- Build resolution against a canonical registry:
  - Discovery emits canonical slash IDs.
  - Normalize any dot-form job ref into the canonical slash form before lookup.
  - Update alias indexing so alias targets can continue to be declared as paths and dot-oriented targets continue to resolve by normalizing their derived target IDs to canonical slash IDs.
- Preserve existing alias collision/invalid behavior and error envelopes.

Outputs/persistence/events:
- Persist run records using canonical slash IDs only.
- Return run payloads with canonical slash `job_id` only.
- Add `tenant` and `origin {source_kind, source_name}` to:
  - `POST /runs` response
  - `GET /runs` responses (list + get), if present
  - all run-related SSE events
  - all run journal entries

Persistence carrier decision (per spec):
- Prefer explicit run store fields for `tenant` and `origin` if the current run persistence schema already supports them.
- Otherwise, use `Provenance` (or embedded JSON) as the source-of-truth carrier and project into top-level API fields on read.
- In either case, implement a single projection path and cover it with read-after-write tests (create -> read -> SSE/journal).

Origin derivation for a run:
- For source-scoped runs (`req.source.name` present): origin is that source.
- For runs without explicit source: origin must be the source that provided the resolved job definition during discovery.
  - This requires `POST /runs` resolution to track which discovered job entry matched the requested job-ref and carry its origin into the run payload.

#### G) Idempotency: tenant-scoped keys

Change idempotency scoping from "principal string" to "resolved tenant":
- Replace `scopedIdempotencyKey(principal, key)` with `scopedIdempotencyKey(tenant, key)`.
- The tenant value used must be the same effective tenant computed for the run request.

Behavior to preserve:
- Replay returns original response.
- Payload mismatch returns 409.
- In-flight collision returns 429.

#### H) SSE + journal: consistent tenant + origin

Ensure every run-related event includes tenant + origin:
- SSE envelope: set `sse.Event.Tenant` for all run-related events.
- Journal payload: include `tenant` and `origin` inside the JSON payload (so the persisted journal contains the fields even if the journal schema remains unchanged).

Concrete changes:
- Update `internal/server/handlers/sse_sink.go`:
  - include `tenant` and `origin` in `basePayload()`.
  - set `sse.Event.Tenant` when publishing.
- Update direct publishes in `internal/server/handlers/runs.go` (policy events, cancel events, etc.) to set tenant in the `sse.Event` and include tenant/origin in the serialized payload.

#### I) Sources model + GET /sources Core-aligned output (additive)

Goal: emit Core-required fields without expanding the mutating `/sources` surface.

Backward-compat stance (explicit):
- `GET /sources` changes are additive-only in PR1:
  - keep existing response fields as-is (unless a field is clearly unsafe to expose)
  - add Core-aligned fields alongside them
  - avoid renaming/removing existing keys in this PR1 slice

Core fields to emit (minimum):
- `id`: stable identifier (use existing `source.name`).
- `tenant`: derived per request using the tenant resolution rules (principal tenant claim if present; otherwise request/default rules).
- `kind`: map existing `source.type`:
  - `local` -> `fs`
  - `git` -> `git`
  - `oci` -> `oci` (flowd extension; documented as non-Core)
- `mountPath`:
  - use the on-disk materialization path used for discovery/lookup (derive from `Source.LocalPath` and/or existing metadata fields).
- `layout`:
  - emit `tree-v1` for this PR1 slice (sources are materialized to a filesystem path in current implementation); if a source has no usable materialization path, emit empty string and document as follow-up (do not block PR1).
- `pull_policy`:
  - keep existing `pull_policy` semantics (already present for OCI sources; for others default to a stable value).
- `config`:
  - opaque object describing source configuration (subset of existing fields)
  - MUST redact secret values (render as `REDACTED`)

Concrete changes:
- Update `internal/server/handlers/sources.go` to emit a dedicated response view type instead of marshalling `[]sourcestore.Source` directly, so we can:
  - add Core fields safely
  - redact secrets in `config`
  - avoid accidentally leaking internal-only fields (but preserve legacy fields per additive-only requirement)
- Redaction approach:
  - Prefer reusing existing redaction helpers already used for run args/events/logging.
  - If no suitable helper exists, implement a conservative key-based redactor for known credential fields used by git/oci sources (and add tests).

### 2.3 Sequencing and dependencies

Order work to reduce risk and keep behavior changes testable:
1. Establish request tenant plumbing:
  - JWT tenant claim extraction + request context accessor
  - shared `resolveTenant(ctx, requestTenant)` helper for runs and sources/jobs projections
2. Establish shared identity helpers:
  - canonical job ID normalization/validation with mountPath-prefix semantics (including root job empty-ID mapping)
  - dot/slash normalization helpers for compatibility inputs, including root-job invocation aliases
3. Discovery + config loading:
  - implement dual sentinel detection + dual-config rejection (409)
  - switch tree-v1 discovery identity to canonical slash IDs
  - ensure config loader precedence matches discovery
4. Collision handling:
  - implement contenders aggregation and 409 problem payloads
  - enforce in both `/jobs` and `POST /runs` resolution paths
5. Alias + legacy job-ref compatibility layer:
  - refactor alias resolution to work against canonical slash IDs while preserving existing alias config semantics
  - lock current accepted dot-form inputs in regression tests before switching emitted IDs
6. Jobs API projection:
  - canonical IDs for tree-v1 jobs; add `tenant` + `origin`
7. Runs API changes:
  - accept request `tenant`
  - preserve input compatibility for job refs; normalize outputs/persistence to canonical IDs
  - propagate `tenant` + `origin` everywhere (API payload, store, SSE, journal)
  - choose persistence carrier (explicit fields vs provenance) and implement a single projection path
8. Idempotency scoping:
  - switch scoping to resolved tenant; preserve replay/409/429 semantics
9. Sources API view:
  - additive response shaping with Core fields
  - implement `config` secret redaction
10. Tests in lockstep:
  - add/update tests as each slice lands (tenant claim + resolution, discovery + mountPath-prefix canonical IDs + collisions, alias/dot compatibility, jobs, runs root-job aliasing, idempotency, SSE/journal, sources redaction)

## Docs
- `docs/api-reference.md`
- `docs/sources-structure.md`
- `docs/sources.md`

## Testing
- `go test ./...` (passed)

## Related issues
- #78 — Fix mountPath-prefix canonical IDs for sources and collision contender mountPath
- #79 — Fail discovery on invalid canonical job ID segments with RFC7807
- #53 — JWT tenant-claim extraction + request context plumbing
- #54 — Tenant resolution helper + mismatch rejection behavior (incl. "principal present but no tenant claim")
- #55 — Idempotency scope key = resolved tenant (not principal string)
- #56 — Canonical job ID utility (mountPath-prefix canonical IDs; slash IDs only; kebab normalization + regex enforcement; root mapping)
- #57 — Discovery + config loading: dual-sentinel support + dual-config invalidity + canonical IDs (mountPath-prefix)
- #58 — Regression lock: accepted run job-ref forms + resolution order (aliases + dot-form + case-insensitive slash)
- #59 — Run job-ref compatibility layer: accept aliases + legacy dot inputs + root-job aliases; canonical IDs everywhere on output/persistence/events
- #60 — Stabilize tests/fixtures after canonical IDs + dual sentinel change
- #61 — Collision detection: canonical ID collisions hard-fail early with deterministic contenders list (409 RFC7807)
- #63 — Jobs API projection: canonical slash IDs only + tenant + origin
- …plus 15 additional task issues created for this work.

## Notes / risks
- Review: no must-fix findings recorded.

<details>
<summary>Git context</summary>

```text
Diffstat vs main:
docs/api-reference.md                         |  43 +-
 docs/sources-structure.md                     |  38 +-
 docs/sources.md                               |  39 ++
 internal/configloader/loader.go               |  52 ++-
 internal/e2e/cli_e2e_test.go                  |  35 +-
 internal/engine/orchestrator.go               |   2 +-
 internal/indexer/aliases.go                   |   8 +-
 internal/indexer/indexer.go                   | 116 +++--
 internal/indexer/indexer_test.go              | 204 +++++++-
 internal/indexer/jobid.go                     | 181 ++++++++
 internal/indexer/jobid_test.go                | 188 ++++++++
 internal/server/auth.go                       |  11 +
 internal/server/handlers/discovery_problem.go |  53 +++
 internal/server/handlers/job_collision.go     | 133 ++++++
 internal/server/handlers/jobs.go              | 102 +++-
 internal/server/handlers/jobs_test.go         | 181 ++++++++
 internal/server/handlers/journal_sink.go      |  36 +-
 internal/server/handlers/plans.go             |  11 +-
 internal/server/handlers/plans_test.go        |   6 +-
 internal/server/handlers/problem_pr1_test.go  | 120 +++++
 internal/server/handlers/run_identity.go      | 127 +++++
 internal/server/handlers/run_payload.go       |  10 +-
 internal/server/handlers/runs.go              | 191 ++++++--
 internal/server/handlers/runs_test.go         | 643 +++++++++++++++++++++++++-
 internal/server/handlers/sources.go           | 264 ++++++++++-
 internal/server/handlers/sources_test.go      | 209 +++++++++
 internal/server/handlers/sse_sink.go          |  12 +-
 internal/server/handlers/tenant.go            |  42 ++
 internal/server/middleware.go                 |   3 +
 internal/server/middleware_test.go            |  58 +++
 internal/server/requestctx/requestctx.go      |  22 +
 internal/server/requestctx/requestctx_test.go |  33 ++
 internal/server/response/problem.go           |  10 +
 33 files changed, 3063 insertions(+), 120 deletions(-)

Commits:
1f59a5c [T-027] Fail discovery on invalid canonical job ID segments with RFC7807 (issue #79)
5b4bf1c Fix mountPath-prefix canonical IDs for sources and collision contender mountPath (issue #78)
d8c96c2 [T-023] Document PR1 identity spine behavior changes (canonical IDs, tenant/origin propagation, /sources fields + OCI extension, idempotency tenant scoping) (issue #76)
e3024ec [T-022] E2E regression updates for canonical IDs and enriched event shapes (issue #75)
aa192e1 [T-021] /sources handler tests: response shaping, OCI extension, conservative redaction, and "no secret substring" (API + logs) (issue #74)
7ad50d3 [T-020] SSE + journal consistency tests: tenant+origin do not drift; read-after-write coverage (issue #73)
c7236b3 [T-018] Runs handler tests: tenant resolution branches + root-job aliases; canonical IDs out (issue #71)
f79cd64 [T-019] Idempotency tests: replay vs 409 mismatch vs 429 in-flight, scoped by resolved tenant (issue #72)
966af23 [T-016] Discovery + jobs tests: dual sentinel, dual-config invalidity (409), mountPath-prefix canonicalization, and collision contenders ordering (issue #70)
4e139a7 [T-015] Unit tests for canonical job ID utility (mountPath-prefix; kebab + regex; root mapping; dot/slash helpers) (issue #69)
3bfa4e3 [T-013] Observability: structured logs include tenant/job_id/origin without leaking secrets (issue #68)
d86dfda [T-012] /sources response shaping (Core fields) + OCI extension + config redaction (dedicated view types) (issue #67)
4081406 [T-011] Journal payload propagation: include tenant + origin in persisted journal entries (issue #66)
88c8bf9 [T-010] SSE envelope: set `sse.Event.Tenant` and include origin in payload (issue #65)
e0546bf [T-009] Run tenant + origin source-of-truth carrier + projection path (API vs SSE vs journal must not drift) (issue #64)
34510f9 [T-007] Jobs API projection: canonical slash IDs only + tenant + origin (issue #63)
983ea94 [T-014] RFC7807 problem types/codes for PR1 identity-spine errors (issue #62)
3797075 [T-006] Collision detection: canonical ID collisions hard-fail early with deterministic contenders list (409 RFC7807) (issue #61)
bc61c9c [T-025] Stabilize tests/fixtures after canonical IDs + dual sentinel change (issue #60)
89c855c [T-008] Run job-ref compatibility layer: accept aliases + legacy dot inputs + root-job aliases; canonical IDs everywhere on output/persistence/events (issue #59)
f9ea157 [T-017] Regression lock: accepted run job-ref forms + resolution order (issue #58)
7804fb8 [T-005] Discovery + config loading: dual-sentinel support + dual-config invalidity + canonical IDs (mountPath-prefix) (issue #57)
aa8badf [T-004] Canonical job ID utility (mountPath-prefix canonical IDs; slash IDs only; kebab normalization + regex enforcement; root mapping) (issue #56)
c700216 [T-003] Idempotency scope key = resolved tenant (not principal string) (issue #55)
9e141d7 [T-002] Tenant resolution helper + mismatch rejection behavior (incl. "principal present but no tenant claim") (issue #54)
cd9b53d [T-001] JWT tenant-claim extraction + request context plumbing (issue #53)
```

</details>

