### PR TITLE
m1 pr2 health introspection endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,11 @@ flwd :serve --bind 127.0.0.1:8080 --profile secure --dev
 
 Serve mode exposes REST endpoints and SSE streams that mirror the CLI functionality:
 
+- `GET /healthz`, `GET /startupz`, `GET /readyz` (public probes)
 - `GET /jobs`
 - `POST /plans`
 - `POST /runs`, `GET /runs`, `GET /runs/{id}`
+- `GET /limits`, `GET /capabilities` (requires `jobs:read`)
 - `GET /runs/{id}/events` (SSE)
 - `GET /sources`, `POST /sources`, `GET /sources/{name}`
 - `GET /metrics` (Prometheus text exposition)
@@ -270,5 +272,4 @@ Policy overrides (e.g., `rootfs_writable`, `network`) granted for permissive/dis
 - **`source.trust.required`** — OCI sources must opt in; add `trusted=true` (API) or `--trusted` (CLI).
 - **`E_ADDON_MANIFEST`** — manifest missing/invalid; see problem detail for fields to fix.
 - **`E_OCI`** — runtime pull/extract failure; inspect podman/docker logs and verify registry access.
-
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -13,10 +13,21 @@ flwd exposes a REST API for programmatic access to jobs, runs, artifacts, and sy
 
 ## Base URL
 
-When running in serve mode, the API is available at:
+This document covers two classes of endpoints:
+
+- API endpoints (most of this reference) live under the versioned API prefix.
+- Operational endpoints (probes, metrics, SSE) are rooted at the server base URL (no `/api/v1` prefix).
+
+When running in serve mode, the versioned API base URL is:
 
 ```
 http://localhost:8080/api/v1
+```
+
+Operational base URL:
+
+```
+http://localhost:8080
 ```
 
 ## Authentication
@@ -36,6 +47,8 @@ All other endpoints in this document require authentication with the appropriate
 ## Endpoints
 
 ### Operational probes and introspection
+
+These operational endpoints are served at the server root (they are not under `/api/v1`).
 
 #### Startup probe
 
@@ -471,6 +484,8 @@ Returns system information and configuration.
 ## Server-Sent Events (SSE)
 
 flwd supports real-time event streaming via Server-Sent Events for monitoring runs and system events.
+
+SSE endpoints are served at the server root (they are not under `/api/v1`).
 
 ### Endpoints
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -23,7 +23,102 @@ http://localhost:8080/api/v1
 
 Authentication and authorization are handled via the Security Profiles system. See the [Configuration]({{< ref "configuration" >}}) documentation for details on setting up API access.
 
+The following probe endpoints are intentionally public (no bearer token required):
+
+- `GET /healthz`
+- `GET /startupz`
+- `GET /readyz`
+
+All other endpoints in this document require authentication with the appropriate scopes.
+
 ## Endpoints
+
+### Operational probes and introspection
+
+#### Startup probe
+
+```http
+GET /startupz
+```
+
+Readiness for process startup completion.
+
+- `204 No Content`: startup sequence complete.
+- `503 Service Unavailable`: startup is incomplete.
+  - Problem `type`: `https://flowd.org/problems/startup-incomplete`
+
+#### Readiness probe
+
+```http
+GET /readyz
+```
+
+Readiness for serving traffic.
+
+- `204 No Content`: Core DB and storage checks are healthy.
+- `503 Service Unavailable`: server is not ready.
+  - Problem `type`: `https://flowd.org/problems/not-ready`
+  - Includes a `checks` extension with per-subsystem status.
+
+#### Runtime limits
+
+```http
+GET /limits
+```
+
+Returns runtime scheduling limits and queue defaults.
+
+- Auth required.
+- Required scope: `jobs:read`
+
+Example response:
+
+```json
+{
+  "algorithm": "wfq",
+  "concurrency": 8,
+  "queue_max_depth": 1024,
+  "backpressure_mode": "reject_when_full",
+  "queue_stats": {
+    "len": 0,
+    "enqueued": 0,
+    "dequeued": 0,
+    "dropped": 0
+  },
+  "updated_at": "2026-02-11T10:00:00Z"
+}
+```
+
+#### Server capabilities
+
+```http
+GET /capabilities
+```
+
+Returns core identity/version plus compiled and enabled extension metadata.
+
+- Auth required.
+- Required scope: `jobs:read`
+
+Example response:
+
+```json
+{
+  "core": {
+    "version": "1.0.0",
+    "spec_version": "1.0.1",
+    "app_id": "org.flowd.runner"
+  },
+  "extensions": [
+    {
+      "name": "export",
+      "version": "1.0.0",
+      "compiled": true,
+      "enabled": false
+    }
+  ]
+}
+```
 
 ### Jobs
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -29,6 +29,8 @@ The following probe endpoints are intentionally public (no bearer token required
 - `GET /startupz`
 - `GET /readyz`
 
+`GET /metrics` may also be unauthenticated when the server binds to a loopback address (for other bind addresses, it requires a bearer token with the usual scopes).
+
 All other endpoints in this document require authentication with the appropriate scopes.
 
 ## Endpoints
@@ -107,7 +109,7 @@ Example response:
   "core": {
     "version": "1.0.0",
     "spec_version": "1.0.1",
-    "app_id": "org.flowd.runner"
+    "app_id": "flwd"
   },
   "extensions": [
     {

--- a/docs/serve-mode.md
+++ b/docs/serve-mode.md
@@ -92,6 +92,38 @@ The legacy `/events` path is an alias of `/events/stream`.
 Events are sent as SSE and can be parsed by dashboards, CLIs or monitoring tools.
 See the API reference for the SSE envelope (`event: flowd`, `retry: 3000`), resume behavior, and stale-cursor semantics.
 
+## Health probes and introspection endpoints
+
+Serve mode also exposes lightweight operational endpoints for startup/readiness probing and runtime introspection.
+
+Public probes (no bearer token required):
+
+- `GET /healthz`
+- `GET /startupz`
+- `GET /readyz`
+
+Protected introspection endpoints (bearer token required, scope `jobs:read`):
+
+- `GET /limits`
+- `GET /capabilities`
+
+Probe semantics:
+
+- `GET /startupz`: returns `204 No Content` when startup is complete; otherwise `503 Service Unavailable` with RFC7807 type `https://flowd.org/problems/startup-incomplete`.
+- `GET /readyz`: returns `204 No Content` when Core DB and storage checks pass; otherwise `503 Service Unavailable` with RFC7807 type `https://flowd.org/problems/not-ready` and per-check status details.
+
+Quick checks:
+
+```bash
+# Public startup/readiness probes
+$ curl -i http://127.0.0.1:8080/startupz
+$ curl -i http://127.0.0.1:8080/readyz
+
+# Protected introspection endpoints
+$ curl -s -H 'Authorization: Bearer dev-token' http://127.0.0.1:8080/limits | jq
+$ curl -s -H 'Authorization: Bearer dev-token' http://127.0.0.1:8080/capabilities | jq
+```
+
 ## Authentication and scopes
 
 Serve mode uses bearer tokens (JWTs) for authentication and simple scopes for

--- a/internal/server/authz/scopes.go
+++ b/internal/server/authz/scopes.go
@@ -47,6 +47,8 @@ func RequiredScopes(method, path string) []string {
 			return []string{ScopeJobsRead}
 		case path == "/limits":
 			return []string{ScopeJobsRead}
+		case path == "/capabilities":
+			return []string{ScopeJobsRead}
 		}
 	case http.MethodPost:
 		switch {

--- a/internal/server/authz/scopes.go
+++ b/internal/server/authz/scopes.go
@@ -45,6 +45,8 @@ func RequiredScopes(method, path string) []string {
 			return []string{ScopeRuleYRead}
 		case path == "/health/storage":
 			return []string{ScopeJobsRead}
+		case path == "/limits":
+			return []string{ScopeJobsRead}
 		}
 	case http.MethodPost:
 		switch {

--- a/internal/server/authz/scopes_test.go
+++ b/internal/server/authz/scopes_test.go
@@ -22,6 +22,7 @@ func TestRequiredScopes(t *testing.T) {
 		{method: "GET", path: "/events", want: []string{ScopeEventsRead}},
 		{method: "GET", path: "/events/stream", want: []string{ScopeEventsRead}},
 		{method: "GET", path: "/health/storage", want: []string{ScopeJobsRead}},
+		{method: "GET", path: "/limits", want: []string{ScopeJobsRead}},
 		{method: "GET", path: "/capabilities", want: []string{ScopeJobsRead}},
 	}
 

--- a/internal/server/authz/scopes_test.go
+++ b/internal/server/authz/scopes_test.go
@@ -22,6 +22,7 @@ func TestRequiredScopes(t *testing.T) {
 		{method: "GET", path: "/events", want: []string{ScopeEventsRead}},
 		{method: "GET", path: "/events/stream", want: []string{ScopeEventsRead}},
 		{method: "GET", path: "/health/storage", want: []string{ScopeJobsRead}},
+		{method: "GET", path: "/capabilities", want: []string{ScopeJobsRead}},
 	}
 
 	for _, tc := range tests {

--- a/internal/server/buildinfo/buildinfo.go
+++ b/internal/server/buildinfo/buildinfo.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package buildinfo
+
+import (
+	"os"
+	"strings"
+)
+
+const (
+	CoreAppID       = "flwd"
+	CoreSpecVersion = "1.0.1"
+)
+
+// Version returns the runtime build version exposed by server introspection and metrics.
+func Version() string {
+	version := strings.TrimSpace(os.Getenv("FLWD_VERSION"))
+	if version == "" {
+		return "dev"
+	}
+	return version
+}

--- a/internal/server/handlers/capabilities.go
+++ b/internal/server/handlers/capabilities.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+
+	"github.com/flowd-org/flowd/internal/server/buildinfo"
+	"github.com/flowd-org/flowd/internal/server/response"
+)
+
+type capabilitiesCore struct {
+	Version     string `json:"version"`
+	SpecVersion string `json:"spec_version"`
+	AppID       string `json:"app_id"`
+}
+
+type capabilitiesExtension struct {
+	Name     string `json:"name"`
+	Version  string `json:"version"`
+	Compiled bool   `json:"compiled"`
+	Enabled  bool   `json:"enabled"`
+}
+
+type capabilitiesResponse struct {
+	Core       capabilitiesCore        `json:"core"`
+	Extensions []capabilitiesExtension `json:"extensions"`
+}
+
+type capabilitiesHandler struct {
+	version           string
+	compiledExtension map[string]bool
+}
+
+// NewCapabilitiesHandler returns an HTTP handler for GET /capabilities.
+func NewCapabilitiesHandler(extensionEnabled map[string]bool) http.Handler {
+	compiled := map[string]bool{
+		"export": extensionEnabled["export"],
+	}
+	return &capabilitiesHandler{
+		version:           buildinfo.Version(),
+		compiledExtension: compiled,
+	}
+}
+
+func (h *capabilitiesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		response.Write(w, response.New(http.StatusMethodNotAllowed, "method not allowed"))
+		return
+	}
+
+	names := make([]string, 0, len(h.compiledExtension))
+	for name := range h.compiledExtension {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	extensions := make([]capabilitiesExtension, 0, len(names))
+	for _, name := range names {
+		extensions = append(extensions, capabilitiesExtension{
+			Name:     name,
+			Version:  h.version,
+			Compiled: true,
+			Enabled:  h.compiledExtension[name],
+		})
+	}
+
+	payload := capabilitiesResponse{
+		Core: capabilitiesCore{
+			Version:     h.version,
+			SpecVersion: buildinfo.CoreSpecVersion,
+			AppID:       buildinfo.CoreAppID,
+		},
+		Extensions: extensions,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(payload)
+}

--- a/internal/server/handlers/capabilities.go
+++ b/internal/server/handlers/capabilities.go
@@ -30,18 +30,22 @@ type capabilitiesResponse struct {
 }
 
 type capabilitiesHandler struct {
-	version           string
-	compiledExtension map[string]bool
+	version            string
+	compiledExtensions []string
+	enabledExtensions  map[string]bool
 }
 
 // NewCapabilitiesHandler returns an HTTP handler for GET /capabilities.
 func NewCapabilitiesHandler(extensionEnabled map[string]bool) http.Handler {
-	compiled := map[string]bool{
-		"export": extensionEnabled["export"],
+	compiledExtensions := []string{"export"}
+	enabledExtensions := make(map[string]bool, len(compiledExtensions))
+	for _, name := range compiledExtensions {
+		enabledExtensions[name] = extensionEnabled[name]
 	}
 	return &capabilitiesHandler{
-		version:           buildinfo.Version(),
-		compiledExtension: compiled,
+		version:            buildinfo.Version(),
+		compiledExtensions: compiledExtensions,
+		enabledExtensions:  enabledExtensions,
 	}
 }
 
@@ -51,10 +55,7 @@ func (h *capabilitiesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	names := make([]string, 0, len(h.compiledExtension))
-	for name := range h.compiledExtension {
-		names = append(names, name)
-	}
+	names := append([]string(nil), h.compiledExtensions...)
 	sort.Strings(names)
 
 	extensions := make([]capabilitiesExtension, 0, len(names))
@@ -63,7 +64,7 @@ func (h *capabilitiesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 			Name:     name,
 			Version:  h.version,
 			Compiled: true,
-			Enabled:  h.compiledExtension[name],
+			Enabled:  h.enabledExtensions[name],
 		})
 	}
 

--- a/internal/server/handlers/capabilities_test.go
+++ b/internal/server/handlers/capabilities_test.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/flowd-org/flowd/internal/server/buildinfo"
+)
+
+func TestCapabilitiesHandlerMethodNotAllowed(t *testing.T) {
+	handler := NewCapabilitiesHandler(map[string]bool{"export": true})
+	req := httptest.NewRequest(http.MethodPost, "/capabilities", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rec.Code)
+	}
+}
+
+func TestCapabilitiesHandlerResponse(t *testing.T) {
+	handler := NewCapabilitiesHandler(map[string]bool{"export": true})
+	req := httptest.NewRequest(http.MethodGet, "/capabilities", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected application/json, got %q", ct)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Fatalf("expected no-store cache header, got %q", cc)
+	}
+
+	var body struct {
+		Core struct {
+			Version     string `json:"version"`
+			SpecVersion string `json:"spec_version"`
+			AppID       string `json:"app_id"`
+		} `json:"core"`
+		Extensions []struct {
+			Name     string `json:"name"`
+			Version  string `json:"version"`
+			Compiled bool   `json:"compiled"`
+			Enabled  bool   `json:"enabled"`
+		} `json:"extensions"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+
+	if body.Core.SpecVersion != buildinfo.CoreSpecVersion {
+		t.Fatalf("expected core.spec_version=%q, got %q", buildinfo.CoreSpecVersion, body.Core.SpecVersion)
+	}
+	if body.Core.AppID != buildinfo.CoreAppID {
+		t.Fatalf("expected core.app_id=%q, got %q", buildinfo.CoreAppID, body.Core.AppID)
+	}
+	if len(body.Extensions) != 1 {
+		t.Fatalf("expected one compiled extension, got %d", len(body.Extensions))
+	}
+	ext := body.Extensions[0]
+	if ext.Name != "export" {
+		t.Fatalf("expected extension name export, got %q", ext.Name)
+	}
+	if !ext.Compiled {
+		t.Fatal("expected export extension to be compiled")
+	}
+	if !ext.Enabled {
+		t.Fatal("expected export extension to be enabled")
+	}
+	if ext.Version != body.Core.Version {
+		t.Fatalf("expected extension version to match core.version (%q), got %q", body.Core.Version, ext.Version)
+	}
+}

--- a/internal/server/handlers/limits.go
+++ b/internal/server/handlers/limits.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"runtime"
+	"time"
+
+	"github.com/flowd-org/flowd/internal/server/response"
+)
+
+const (
+	limitsAlgorithmDefault        = "wfq"
+	limitsQueueMaxDepthDefault    = 1024
+	limitsBackpressureModeDefault = "reject_when_full"
+	limitsConcurrencyMin          = 4
+)
+
+type limitsQueueStats struct {
+	Len      int `json:"len"`
+	Enqueued int `json:"enqueued"`
+	Dequeued int `json:"dequeued"`
+	Dropped  int `json:"dropped"`
+}
+
+type limitsResponse struct {
+	Algorithm        string           `json:"algorithm"`
+	Concurrency      int              `json:"concurrency"`
+	QueueMaxDepth    int              `json:"queue_max_depth"`
+	BackpressureMode string           `json:"backpressure_mode"`
+	QueueStats       limitsQueueStats `json:"queue_stats"`
+	UpdatedAt        string           `json:"updated_at"`
+}
+
+type limitsHandler struct {
+	now func() time.Time
+}
+
+// NewLimitsHandler returns an HTTP handler for GET /limits.
+func NewLimitsHandler() http.Handler {
+	return &limitsHandler{
+		now: time.Now,
+	}
+}
+
+func (h *limitsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		response.Write(w, response.New(http.StatusMethodNotAllowed, "method not allowed"))
+		return
+	}
+
+	payload := limitsResponse{
+		Algorithm:        limitsAlgorithmDefault,
+		Concurrency:      defaultConcurrency(runtime.GOMAXPROCS(0)),
+		QueueMaxDepth:    limitsQueueMaxDepthDefault,
+		BackpressureMode: limitsBackpressureModeDefault,
+		QueueStats:       limitsQueueStats{},
+		UpdatedAt:        h.now().UTC().Format(time.RFC3339),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func defaultConcurrency(gomaxprocs int) int {
+	concurrency := 2 * gomaxprocs
+	if concurrency < limitsConcurrencyMin {
+		return limitsConcurrencyMin
+	}
+	return concurrency
+}

--- a/internal/server/handlers/limits_test.go
+++ b/internal/server/handlers/limits_test.go
@@ -1,0 +1,105 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestLimitsHandlerMethodNotAllowed(t *testing.T) {
+	handler := NewLimitsHandler()
+	req := httptest.NewRequest(http.MethodPost, "/limits", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rec.Code)
+	}
+}
+
+func TestLimitsHandlerResponseDefaultsAndShape(t *testing.T) {
+	prev := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(prev)
+
+	handler := NewLimitsHandler()
+	req := httptest.NewRequest(http.MethodGet, "/limits", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected application/json, got %q", ct)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Fatalf("expected no-store cache header, got %q", cc)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+
+	if got := body["algorithm"]; got != limitsAlgorithmDefault {
+		t.Fatalf("expected algorithm %q, got %v", limitsAlgorithmDefault, got)
+	}
+	if got := int(body["concurrency"].(float64)); got != 4 {
+		t.Fatalf("expected concurrency 4 for GOMAXPROCS=1, got %d", got)
+	}
+	if got := int(body["queue_max_depth"].(float64)); got != limitsQueueMaxDepthDefault {
+		t.Fatalf("expected queue_max_depth %d, got %d", limitsQueueMaxDepthDefault, got)
+	}
+	if got := body["backpressure_mode"]; got != limitsBackpressureModeDefault {
+		t.Fatalf("expected backpressure_mode %q, got %v", limitsBackpressureModeDefault, got)
+	}
+
+	queueStats, ok := body["queue_stats"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected queue_stats object, got %T", body["queue_stats"])
+	}
+	if got := int(queueStats["len"].(float64)); got != 0 {
+		t.Fatalf("expected queue_stats.len=0, got %d", got)
+	}
+	if got := int(queueStats["enqueued"].(float64)); got != 0 {
+		t.Fatalf("expected queue_stats.enqueued=0, got %d", got)
+	}
+	if got := int(queueStats["dequeued"].(float64)); got != 0 {
+		t.Fatalf("expected queue_stats.dequeued=0, got %d", got)
+	}
+	if got := int(queueStats["dropped"].(float64)); got != 0 {
+		t.Fatalf("expected queue_stats.dropped=0, got %d", got)
+	}
+
+	updatedAt, ok := body["updated_at"].(string)
+	if !ok {
+		t.Fatalf("expected updated_at string, got %T", body["updated_at"])
+	}
+	if _, err := time.Parse(time.RFC3339, updatedAt); err != nil {
+		t.Fatalf("expected RFC3339 updated_at, got %q (%v)", updatedAt, err)
+	}
+
+	if _, exists := body["per_tenant_weights"]; exists {
+		t.Fatal("expected per_tenant_weights to be omitted when not implemented")
+	}
+	if _, exists := body["per_tenant_concurrency"]; exists {
+		t.Fatal("expected per_tenant_concurrency to be omitted when not implemented")
+	}
+	if _, exists := body["drain_timeout_ms"]; exists {
+		t.Fatal("expected drain_timeout_ms to be omitted when not implemented")
+	}
+}
+
+func TestDefaultConcurrencyUsesTwiceGOMAXPROCSWithMinFour(t *testing.T) {
+	if got := defaultConcurrency(1); got != 4 {
+		t.Fatalf("expected min concurrency 4, got %d", got)
+	}
+	if got := defaultConcurrency(3); got != 6 {
+		t.Fatalf("expected concurrency 6 for gomaxprocs=3, got %d", got)
+	}
+}

--- a/internal/server/handlers/limits_test.go
+++ b/internal/server/handlers/limits_test.go
@@ -22,9 +22,6 @@ func TestLimitsHandlerMethodNotAllowed(t *testing.T) {
 }
 
 func TestLimitsHandlerResponseDefaultsAndShape(t *testing.T) {
-	prev := runtime.GOMAXPROCS(1)
-	defer runtime.GOMAXPROCS(prev)
-
 	handler := NewLimitsHandler()
 	req := httptest.NewRequest(http.MethodGet, "/limits", nil)
 	rec := httptest.NewRecorder()
@@ -49,8 +46,9 @@ func TestLimitsHandlerResponseDefaultsAndShape(t *testing.T) {
 	if got := body["algorithm"]; got != limitsAlgorithmDefault {
 		t.Fatalf("expected algorithm %q, got %v", limitsAlgorithmDefault, got)
 	}
-	if got := int(body["concurrency"].(float64)); got != 4 {
-		t.Fatalf("expected concurrency 4 for GOMAXPROCS=1, got %d", got)
+	expectedConcurrency := defaultConcurrency(runtime.GOMAXPROCS(0))
+	if got := int(body["concurrency"].(float64)); got != expectedConcurrency {
+		t.Fatalf("expected concurrency %d for current GOMAXPROCS, got %d", expectedConcurrency, got)
 	}
 	if got := int(body["queue_max_depth"].(float64)); got != limitsQueueMaxDepthDefault {
 		t.Fatalf("expected queue_max_depth %d, got %d", limitsQueueMaxDepthDefault, got)

--- a/internal/server/handlers/readyz.go
+++ b/internal/server/handlers/readyz.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 package handlers
 
 import (

--- a/internal/server/handlers/readyz.go
+++ b/internal/server/handlers/readyz.go
@@ -13,6 +13,7 @@ import (
 const (
 	readyzNotReadyProblemType = "https://flowd.org/problems/not-ready"
 	readyzPingTimeout         = 2 * time.Second
+	readyzStorageTimeout      = 2 * time.Second
 )
 
 type coreDBReadyFunc func(*http.Request) error
@@ -68,7 +69,9 @@ func (h *readyzHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	stats, err := h.storageStats(r)
+	storageCtx, cancel := context.WithTimeout(r.Context(), readyzStorageTimeout)
+	defer cancel()
+	stats, err := h.storageStats(r.WithContext(storageCtx))
 	if err != nil {
 		response.Write(w, response.New(http.StatusServiceUnavailable, "not ready",
 			response.WithType(readyzNotReadyProblemType),

--- a/internal/server/handlers/readyz.go
+++ b/internal/server/handlers/readyz.go
@@ -1,0 +1,92 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/flowd-org/flowd/internal/coredb"
+	"github.com/flowd-org/flowd/internal/server/response"
+)
+
+const (
+	readyzNotReadyProblemType = "https://flowd.org/problems/not-ready"
+	readyzPingTimeout         = 2 * time.Second
+)
+
+type coreDBReadyFunc func(*http.Request) error
+type readyzStorageStatsFunc func(*http.Request) (coredb.StorageStats, error)
+
+type readyzHandler struct {
+	coredbReady  coreDBReadyFunc
+	storageStats readyzStorageStatsFunc
+}
+
+// NewReadyzHandler returns an HTTP handler for GET /readyz.
+func NewReadyzHandler(db *coredb.DB) http.Handler {
+	return NewReadyzHandlerWithChecks(
+		func(r *http.Request) error {
+			if db == nil || db.SQL() == nil {
+				return errors.New("coredb is not initialised")
+			}
+			ctx, cancel := context.WithTimeout(r.Context(), readyzPingTimeout)
+			defer cancel()
+			return db.SQL().PingContext(ctx)
+		},
+		func(r *http.Request) (coredb.StorageStats, error) {
+			return coredb.CollectStorageStats(r.Context(), db)
+		},
+	)
+}
+
+// NewReadyzHandlerWithChecks returns an HTTP handler for GET /readyz using injected readiness checks.
+func NewReadyzHandlerWithChecks(coredbReady coreDBReadyFunc, storageStats readyzStorageStatsFunc) http.Handler {
+	if coredbReady == nil {
+		coredbReady = func(*http.Request) error { return nil }
+	}
+	if storageStats == nil {
+		storageStats = func(*http.Request) (coredb.StorageStats, error) {
+			return coredb.StorageStats{OK: true}, nil
+		}
+	}
+	return &readyzHandler{coredbReady: coredbReady, storageStats: storageStats}
+}
+
+func (h *readyzHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		response.Write(w, response.New(http.StatusMethodNotAllowed, "method not allowed"))
+		return
+	}
+
+	if err := h.coredbReady(r); err != nil {
+		response.Write(w, response.New(http.StatusServiceUnavailable, "not ready",
+			response.WithType(readyzNotReadyProblemType),
+			response.WithDetail("core database is not ready"),
+			response.WithExtension("checks", map[string]string{"coredb": "failed", "storage": "unknown"}),
+		))
+		return
+	}
+
+	stats, err := h.storageStats(r)
+	if err != nil {
+		response.Write(w, response.New(http.StatusServiceUnavailable, "not ready",
+			response.WithType(readyzNotReadyProblemType),
+			response.WithDetail("storage health check failed"),
+			response.WithExtension("checks", map[string]string{"coredb": "ok", "storage": "failed"}),
+		))
+		return
+	}
+
+	if !stats.OK {
+		response.Write(w, response.New(http.StatusServiceUnavailable, "not ready",
+			response.WithType(readyzNotReadyProblemType),
+			response.WithDetail("storage is not healthy"),
+			response.WithExtension("checks", map[string]string{"coredb": "ok", "storage": "failed"}),
+		))
+		return
+	}
+
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/server/handlers/readyz_test.go
+++ b/internal/server/handlers/readyz_test.go
@@ -1,0 +1,105 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/flowd-org/flowd/internal/coredb"
+)
+
+func TestReadyzHandlerMethodNotAllowed(t *testing.T) {
+	handler := NewReadyzHandlerWithChecks(nil, nil)
+	req := httptest.NewRequest(http.MethodPost, "/readyz", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rec.Code)
+	}
+}
+
+func TestReadyzHandlerCoreDBNotReady(t *testing.T) {
+	handler := NewReadyzHandlerWithChecks(
+		func(*http.Request) error { return errors.New("boom") },
+		func(*http.Request) (coredb.StorageStats, error) {
+			return coredb.StorageStats{OK: true}, nil
+		},
+	)
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/problem+json" {
+		t.Fatalf("expected application/problem+json, got %q", ct)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode problem: %v", err)
+	}
+	if body["type"] != readyzNotReadyProblemType {
+		t.Fatalf("expected problem type %q, got %v", readyzNotReadyProblemType, body["type"])
+	}
+}
+
+func TestReadyzHandlerStorageError(t *testing.T) {
+	handler := NewReadyzHandlerWithChecks(
+		func(*http.Request) error { return nil },
+		func(*http.Request) (coredb.StorageStats, error) {
+			return coredb.StorageStats{}, errors.New("storage error")
+		},
+	)
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rec.Code)
+	}
+}
+
+func TestReadyzHandlerStorageNotHealthy(t *testing.T) {
+	handler := NewReadyzHandlerWithChecks(
+		func(*http.Request) error { return nil },
+		func(*http.Request) (coredb.StorageStats, error) {
+			return coredb.StorageStats{OK: false}, nil
+		},
+	)
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rec.Code)
+	}
+}
+
+func TestReadyzHandlerOK(t *testing.T) {
+	handler := NewReadyzHandlerWithChecks(
+		func(*http.Request) error { return nil },
+		func(*http.Request) (coredb.StorageStats, error) {
+			return coredb.StorageStats{OK: true}, nil
+		},
+	)
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", rec.Code)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Fatalf("expected no-store cache header, got %q", cc)
+	}
+}

--- a/internal/server/handlers/readyz_test.go
+++ b/internal/server/handlers/readyz_test.go
@@ -65,6 +65,17 @@ func TestReadyzHandlerStorageError(t *testing.T) {
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", rec.Code)
 	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/problem+json" {
+		t.Fatalf("expected application/problem+json, got %q", ct)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode problem: %v", err)
+	}
+	if body["type"] != readyzNotReadyProblemType {
+		t.Fatalf("expected problem type %q, got %v", readyzNotReadyProblemType, body["type"])
+	}
 }
 
 func TestReadyzHandlerStorageNotHealthy(t *testing.T) {
@@ -81,6 +92,17 @@ func TestReadyzHandlerStorageNotHealthy(t *testing.T) {
 
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/problem+json" {
+		t.Fatalf("expected application/problem+json, got %q", ct)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode problem: %v", err)
+	}
+	if body["type"] != readyzNotReadyProblemType {
+		t.Fatalf("expected problem type %q, got %v", readyzNotReadyProblemType, body["type"])
 	}
 }
 

--- a/internal/server/handlers/readyz_test.go
+++ b/internal/server/handlers/readyz_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/flowd-org/flowd/internal/coredb"
 )
@@ -103,6 +104,32 @@ func TestReadyzHandlerStorageNotHealthy(t *testing.T) {
 	}
 	if body["type"] != readyzNotReadyProblemType {
 		t.Fatalf("expected problem type %q, got %v", readyzNotReadyProblemType, body["type"])
+	}
+}
+
+func TestReadyzHandlerStorageCheckHasDeadline(t *testing.T) {
+	handler := NewReadyzHandlerWithChecks(
+		func(*http.Request) error { return nil },
+		func(r *http.Request) (coredb.StorageStats, error) {
+			dl, ok := r.Context().Deadline()
+			if !ok {
+				t.Fatalf("expected storage check context to have a deadline")
+			}
+			if until := time.Until(dl); until <= 0 {
+				t.Fatalf("expected storage check deadline to be in the future")
+			} else if until > readyzStorageTimeout {
+				t.Fatalf("expected storage check deadline <= %s, got %s", readyzStorageTimeout, until)
+			}
+			return coredb.StorageStats{OK: true}, nil
+		},
+	)
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", rec.Code)
 	}
 }
 

--- a/internal/server/handlers/startupz.go
+++ b/internal/server/handlers/startupz.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/flowd-org/flowd/internal/server/response"
+)
+
+const startupIncompleteProblemType = "https://flowd.org/problems/startup-incomplete"
+
+type startupStateFunc func(*http.Request) bool
+
+type startupzHandler struct {
+	isStartupComplete startupStateFunc
+}
+
+// NewStartupzHandler returns an HTTP handler for GET /startupz.
+func NewStartupzHandler() http.Handler {
+	return NewStartupzHandlerWithState(func(*http.Request) bool { return true })
+}
+
+// NewStartupzHandlerWithState returns an HTTP handler for GET /startupz using an injected startup state check.
+func NewStartupzHandlerWithState(isStartupComplete startupStateFunc) http.Handler {
+	if isStartupComplete == nil {
+		isStartupComplete = func(*http.Request) bool { return true }
+	}
+	return &startupzHandler{isStartupComplete: isStartupComplete}
+}
+
+func (h *startupzHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		response.Write(w, response.New(http.StatusMethodNotAllowed, "method not allowed"))
+		return
+	}
+
+	if !h.isStartupComplete(r) {
+		response.Write(w, response.New(http.StatusServiceUnavailable, "startup incomplete",
+			response.WithType(startupIncompleteProblemType),
+			response.WithDetail("server startup sequence is not complete"),
+		))
+		return
+	}
+
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/server/handlers/startupz_test.go
+++ b/internal/server/handlers/startupz_test.go
@@ -1,0 +1,58 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestStartupzHandlerMethodNotAllowed(t *testing.T) {
+	handler := NewStartupzHandlerWithState(nil)
+	req := httptest.NewRequest(http.MethodPost, "/startupz", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rec.Code)
+	}
+}
+
+func TestStartupzHandlerIncomplete(t *testing.T) {
+	handler := NewStartupzHandlerWithState(func(*http.Request) bool { return false })
+	req := httptest.NewRequest(http.MethodGet, "/startupz", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/problem+json" {
+		t.Fatalf("expected application/problem+json, got %q", ct)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode problem: %v", err)
+	}
+	if body["type"] != startupIncompleteProblemType {
+		t.Fatalf("expected problem type %q, got %v", startupIncompleteProblemType, body["type"])
+	}
+}
+
+func TestStartupzHandlerComplete(t *testing.T) {
+	handler := NewStartupzHandlerWithState(func(*http.Request) bool { return true })
+	req := httptest.NewRequest(http.MethodGet, "/startupz", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", rec.Code)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Fatalf("expected no-store cache header, got %q", cc)
+	}
+}

--- a/internal/server/metrics/metrics.go
+++ b/internal/server/metrics/metrics.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	coremetrics "github.com/flowd-org/flowd/internal/metrics"
+	"github.com/flowd-org/flowd/internal/server/buildinfo"
 )
 
 // Registry collects counters, gauges, and histograms for Prometheus exposition.
@@ -57,7 +58,7 @@ func NewRegistry() *Registry {
 		sourcesAdded:  make(map[string]uint64),
 		buildInfoLabels: map[string]string{
 			"version":      "dev",
-			"spec_version": "1.2.0",
+			"spec_version": buildinfo.CoreSpecVersion,
 		},
 		containerRuns:        newSimpleHistogram([]float64{0.5, 1, 2, 5, 10, 20, 60, 120, 300}),
 		containerPulls:       newSimpleHistogram([]float64{0.5, 1, 2, 5, 10, 20, 60, 120, 300}),

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -53,6 +53,9 @@ func loggingMiddleware(cfg Config) Middleware {
 				ctx = requestctx.WithRequestID(ctx, requestID)
 			}
 			next.ServeHTTP(recorder, r.WithContext(ctx))
+			if isPublicProbeRequest(r.Method, r.URL.Path) && recorder.status == http.StatusNoContent {
+				return
+			}
 			effective, ok := requestctx.EffectiveProfile(ctx)
 			if !ok || effective == "" {
 				effective = cfg.Profile

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -112,6 +112,10 @@ func corsMiddleware(cfg Config) Middleware {
 func authMiddleware(cfg Config) Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if isPublicProbeRequest(r.Method, r.URL.Path) {
+				next.ServeHTTP(w, r)
+				return
+			}
 			if cfg.MetricsEnabled && cfg.MetricsAllowUnauthenticated && r.Method == http.MethodGet && r.URL.Path == "/metrics" {
 				next.ServeHTTP(w, r)
 				return
@@ -142,6 +146,18 @@ func authMiddleware(cfg Config) Middleware {
 	}
 }
 
+func isPublicProbeRequest(method, path string) bool {
+	if method != http.MethodGet {
+		return false
+	}
+	switch path {
+	case "/healthz", "/startupz", "/readyz":
+		return true
+	default:
+		return false
+	}
+}
+
 func metricsMiddleware(cfg Config) Middleware {
 	if !cfg.MetricsEnabled {
 		return func(next http.Handler) http.Handler { return next }
@@ -167,8 +183,16 @@ func templateRoute(path string) string {
 		return "/metrics"
 	case path == "/healthz":
 		return "/healthz"
+	case path == "/startupz":
+		return "/startupz"
+	case path == "/readyz":
+		return "/readyz"
 	case path == "/health/storage":
 		return "/health/storage"
+	case path == "/limits":
+		return "/limits"
+	case path == "/capabilities":
+		return "/capabilities"
 	case path == "/plans":
 		return "/plans"
 	case path == "/runs":

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -1,9 +1,11 @@
 package server
 
 import (
+	"bytes"
 	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/flowd-org/flowd/internal/server/requestctx"
@@ -196,6 +198,53 @@ func TestAuthMiddlewareProtectsHealthStorageAndIntrospectionEndpoints(t *testing
 				t.Fatalf("expected WWW-Authenticate header for %s", tt.path)
 			}
 		})
+	}
+}
+
+func TestLoggingMiddlewareSuppressesSuccessfulPublicProbeLogs(t *testing.T) {
+	var out bytes.Buffer
+	mw := loggingMiddleware(Config{Log: "text", Profile: "secure", StdOut: &out})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	paths := []string{"/healthz", "/startupz", "/readyz"}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			out.Reset()
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req)
+			if resp.Code != http.StatusNoContent {
+				t.Fatalf("expected 204 for %s, got %d", path, resp.Code)
+			}
+			if got := out.String(); got != "" {
+				t.Fatalf("expected no log output for successful probe %s, got %q", path, got)
+			}
+		})
+	}
+}
+
+func TestLoggingMiddlewareKeepsProbeFailureLogs(t *testing.T) {
+	var out bytes.Buffer
+	mw := loggingMiddleware(Config{Log: "text", Profile: "secure", StdOut: &out})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", resp.Code)
+	}
+	logOutput := out.String()
+	if !strings.Contains(logOutput, "msg=request") {
+		t.Fatalf("expected request log line, got %q", logOutput)
+	}
+	if !strings.Contains(logOutput, "path=/readyz") {
+		t.Fatalf("expected probe path in log output, got %q", logOutput)
 	}
 }
 

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -141,6 +141,64 @@ func TestAuthMiddlewareTenantClaimAbsent(t *testing.T) {
 	}
 }
 
+func TestAuthMiddlewareAllowsPublicProbeEndpointsWithoutToken(t *testing.T) {
+	mw := authMiddleware(Config{})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "healthz", path: "/healthz"},
+		{name: "startupz", path: "/startupz"},
+		{name: "readyz", path: "/readyz"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req)
+			if resp.Code != http.StatusNoContent {
+				t.Fatalf("expected 204 for %s without token, got %d", tt.path, resp.Code)
+			}
+		})
+	}
+}
+
+func TestAuthMiddlewareProtectsHealthStorageAndIntrospectionEndpoints(t *testing.T) {
+	mw := authMiddleware(Config{})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "health storage", path: "/health/storage"},
+		{name: "limits", path: "/limits"},
+		{name: "capabilities", path: "/capabilities"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req)
+
+			if resp.Code != http.StatusUnauthorized {
+				t.Fatalf("expected 401 for %s without token, got %d", tt.path, resp.Code)
+			}
+			if challenge := resp.Header().Get("WWW-Authenticate"); challenge == "" {
+				t.Fatalf("expected WWW-Authenticate header for %s", tt.path)
+			}
+		})
+	}
+}
+
 type nopWriter struct{}
 
 func (nopWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/flowd-org/flowd/internal/coredb"
@@ -15,6 +14,7 @@ import (
 	"github.com/flowd-org/flowd/internal/paths"
 	"github.com/flowd-org/flowd/internal/policy"
 	policyverify "github.com/flowd-org/flowd/internal/policy/verify"
+	"github.com/flowd-org/flowd/internal/server/buildinfo"
 	"github.com/flowd-org/flowd/internal/server/handlers"
 	"github.com/flowd-org/flowd/internal/server/metrics"
 	"github.com/flowd-org/flowd/internal/server/runstore"
@@ -45,11 +45,10 @@ func Run(ctx context.Context, cfg Config) error {
 		}
 	}
 	if norm.MetricsEnabled {
-		version := os.Getenv("FLWD_VERSION")
-		if version == "" {
-			version = "dev"
-		}
-		metrics.Default.SetBuildInfo(map[string]string{"version": version})
+		metrics.Default.SetBuildInfo(map[string]string{
+			"version":      buildinfo.Version(),
+			"spec_version": buildinfo.CoreSpecVersion,
+		})
 		metrics.Default.RecordSecurityProfileGauge(norm.Profile)
 	}
 	runtime, err := runtimeDetector()
@@ -201,6 +200,9 @@ func buildHandler(cfg Config, policyCtx *policy.Context, verifier policyverify.I
 	readyHealth := handlers.NewReadyzHandler(cfg.CoreDB)
 	storageHealth := handlers.NewStorageHealthHandler(cfg.CoreDB)
 	limitsHandler := handlers.NewLimitsHandler()
+	capabilitiesHandler := handlers.NewCapabilitiesHandler(map[string]bool{
+		"export": cfg.ExtensionEnabled("export"),
+	})
 	runHandler := handlers.NewRunsHandler(handlers.RunsConfig{
 		Root:          cfg.ScriptsRoot,
 		Store:         runStore,
@@ -230,6 +232,7 @@ func buildHandler(cfg Config, policyCtx *policy.Context, verifier policyverify.I
 	mux.Handle("/startupz", startupHealth)
 	mux.Handle("/readyz", readyHealth)
 	mux.Handle("/limits", limitsHandler)
+	mux.Handle("/capabilities", capabilitiesHandler)
 	mux.Handle("/runs", runHandler)
 	mux.Handle("/runs/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, ":cancel") {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -197,6 +197,7 @@ func buildHandler(cfg Config, policyCtx *policy.Context, verifier policyverify.I
 	runGet := handlers.NewRunGetHandler(handlers.RunGetConfig{Store: runStore, DB: cfg.CoreDB})
 	runEvents := handlers.NewRunEventsHandler(runStore, hub, journal)
 	runEventsExport := handlers.NewRunEventsExportHandler(runStore, journal, cfg.ExtensionEnabled("export"))
+	startupHealth := handlers.NewStartupzHandler()
 	storageHealth := handlers.NewStorageHealthHandler(cfg.CoreDB)
 	runHandler := handlers.NewRunsHandler(handlers.RunsConfig{
 		Root:          cfg.ScriptsRoot,
@@ -224,6 +225,7 @@ func buildHandler(cfg Config, policyCtx *policy.Context, verifier policyverify.I
 		Verifier: verifier,
 		Runtime:  cfg.ContainerRuntime,
 	}))
+	mux.Handle("/startupz", startupHealth)
 	mux.Handle("/runs", runHandler)
 	mux.Handle("/runs/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, ":cancel") {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -200,6 +200,7 @@ func buildHandler(cfg Config, policyCtx *policy.Context, verifier policyverify.I
 	startupHealth := handlers.NewStartupzHandler()
 	readyHealth := handlers.NewReadyzHandler(cfg.CoreDB)
 	storageHealth := handlers.NewStorageHealthHandler(cfg.CoreDB)
+	limitsHandler := handlers.NewLimitsHandler()
 	runHandler := handlers.NewRunsHandler(handlers.RunsConfig{
 		Root:          cfg.ScriptsRoot,
 		Store:         runStore,
@@ -228,6 +229,7 @@ func buildHandler(cfg Config, policyCtx *policy.Context, verifier policyverify.I
 	}))
 	mux.Handle("/startupz", startupHealth)
 	mux.Handle("/readyz", readyHealth)
+	mux.Handle("/limits", limitsHandler)
 	mux.Handle("/runs", runHandler)
 	mux.Handle("/runs/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, ":cancel") {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -198,6 +198,7 @@ func buildHandler(cfg Config, policyCtx *policy.Context, verifier policyverify.I
 	runEvents := handlers.NewRunEventsHandler(runStore, hub, journal)
 	runEventsExport := handlers.NewRunEventsExportHandler(runStore, journal, cfg.ExtensionEnabled("export"))
 	startupHealth := handlers.NewStartupzHandler()
+	readyHealth := handlers.NewReadyzHandler(cfg.CoreDB)
 	storageHealth := handlers.NewStorageHealthHandler(cfg.CoreDB)
 	runHandler := handlers.NewRunsHandler(handlers.RunsConfig{
 		Root:          cfg.ScriptsRoot,
@@ -226,6 +227,7 @@ func buildHandler(cfg Config, policyCtx *policy.Context, verifier policyverify.I
 		Runtime:  cfg.ContainerRuntime,
 	}))
 	mux.Handle("/startupz", startupHealth)
+	mux.Handle("/readyz", readyHealth)
 	mux.Handle("/runs", runHandler)
 	mux.Handle("/runs/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, ":cancel") {

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -119,6 +119,9 @@ func TestMetricsEndpointExposesSeries(t *testing.T) {
 	if !strings.Contains(body, "flwd_build_info") {
 		t.Fatalf("expected flwd_build_info metric, got body: %s", body)
 	}
+	if !strings.Contains(body, `spec_version="1.0.1"`) {
+		t.Fatalf("expected flwd_build_info spec_version=1.0.1, got body: %s", body)
+	}
 	if !strings.Contains(body, "http_requests_total") {
 		t.Fatalf("expected http_requests_total metric, got body: %s", body)
 	}


### PR DESCRIPTION
# m1 pr2 health introspection endpoints

## Summary
- Problem statement:
  - Serve-mode HTTP is missing M1 operational endpoints: distinct startup/readiness probes and schema-correct introspection surfaces for limits and capabilities.
  - Existing health behavior needs alignment to the Core SoT probe contract (public probe endpoints; success returns 204).
- Goal / outcome:
  - Provide public, unauthenticated health probe endpoints (`/healthz`, `/startupz`, `/readyz`) with consistent 204 success semantics and RFC7807 failures.
  - Provide schema-correct introspection endpoints (`/limits`, `/capabilities`) per Core SoT schemas.
  - Preserve auth boundaries: public probes remain public; protected health remains protected.
- Non-goals:
  - Implementing missing subsystems (scheduler, indexer/janitor, container runtime integration) beyond what is required to report truthful readiness/limits/capabilities.
  - Filling optional `/limits` fields unless backed by real runtime values.

## Key changes
- ### 2.1 Current behavior and data flow
- Routing is built in `internal/server/router.go` via `http.ServeMux`.
- `GET /healthz` exists and returns `204` with `Cache-Control: no-store`.
- Auth is enforced by `internal/server/middleware.go` (`authMiddleware`), which currently requires a token for all requests (except optional `/metrics` unauth path).
- `GET /health/storage` exists as `internal/server/handlers/health_storage.go`, backed by CoreDB storage stats (`coredb.CollectStorageStats`). It is scope-protected via `internal/server/authz/scopes.go`.
- RFC7807 is implemented via `internal/server/response/problem.go`.

### 2.2 Proposed changes (by endpoint)
#### 2.2.1 `GET /healthz` (public liveness)
- Keep current handler semantics: always `204 No Content`, empty body, `Cache-Control: no-store`.
- Make it publicly accessible by bypassing auth for this route in `authMiddleware` (GET + exact path match).

#### 2.2.2 `GET /startupz` (public startup-complete)
- Add a handler that reports whether startup has completed.
- Implementation detail:
  - In serve mode today, the server does not listen until after core initialization (CoreDB open, runtime preflight, policy context load). In practice that means startup is complete by the time `/startupz` can be called.
  - Still implement a minimal startup state hook for correctness and unit testability (e.g., an atomic bool or injected `func(context.Context) bool`), returning:
    - `204` when complete
    - `503` RFC7807 with type `https://flowd.org/problems/startup-incomplete` when not complete

#### 2.2.3 `GET /readyz` (public readiness)
- Add a readiness handler that gates on the M1 subset in `spec.md` §3.1:
  - CoreDB reachable/usable.
  - Storage healthy.
- Checks should be lightweight and bounded:
  - CoreDB: `PingContext` (or trivial query) with a short timeout.
  - Storage: call `coredb.CollectStorageStats` and treat `err != nil` or `stats.OK == false` as not-ready.
- Response semantics:
  - Success: `204 No Content`, empty body, `Cache-Control: no-store`.
  - Failure: `503` RFC7807 with type `https://flowd.org/problems/not-ready`.
  - RFC7807 body MUST avoid leaking secrets (no connection strings, file paths, etc.). Prefer stable, operator-safe detail strings.
  - Optional (RFC7807 extensions): include a small `checks` object like `{ "coredb": "ok|failed", "storage": "ok|failed" }` to aid debugging without leaking sensitive data.

#### 2.2.4 `GET /health/storage` (protected)
- No behavior change besides ensuring auth bypass rules do not accidentally make it public.
- Keep required scope behavior intact (`jobs:read` in `internal/server/authz/scopes.go`).

#### 2.2.5 `GET /limits` (auth-protected; schema-correct)
- Add `internal/server/handlers/limits.go` and route it from `internal/server/router.go`.
- Response must conform to Core SoT `Limits Schema (GET /limits)` and `spec.md` §3.1:
  - Required fields always present:
    - `algorithm`: `"wfq"`
    - `concurrency`: integer >= 1
    - `queue_max_depth`: integer >= 0
    - `backpressure_mode`: `"reject_when_full"` | `"block_when_full"`
    - `queue_stats`: object with required integer counters `len`, `enqueued`, `dequeued`, `dropped`
    - `updated_at`: RFC3339 timestamp (UTC)
  - If runtime values are not implemented, required fields must fall back to Core SoT scheduler defaults:
    - `concurrency`: default to `max(4, 2*GOMAXPROCS)` (Core SoT §3.2: "Global Concurrency: 2 * GOMAXPROCS (min 4)")
    - `queue_max_depth`: default `1024`
    - `backpressure_mode`: default `"reject_when_full"`
    - `queue_stats`: default all counters to `0`
  - Optional fields omitted unless backed by real runtime values:
    - `per_tenant_weights`, `per_tenant_concurrency`, `drain_timeout_ms`
- Authz:
  - Keep endpoint auth-protected by default (no auth bypass).
  - Add a RequiredScopes entry for `GET /limits` (recommended: `jobs:read`, matching `/health/storage`).

#### 2.2.6 `GET /capabilities` (auth-protected; schema-correct)
- Add `internal/server/handlers/capabilities.go` and route it from `internal/server/router.go`.
- Response must conform to Core SoT `Capabilities Schema (GET /capabilities)` and `spec.md` §3.1:
  - Required core fields:
    - `core.version`: derived from `FLWD_VERSION` env if set, else `"dev"` (consistent with existing metrics build-info behavior).
    - `core.spec_version`: report the Core Profile spec version implemented by this runtime (Core SoT v1.0.1 => `"1.0.1"`). This MUST match the version exported by metrics (fix drift from the older runner-framework value).
    - `core.app_id`: set to `"flwd"` (canonical CLI/app identifier per Core/Dev SoT conventions).
  - `extensions[]`:
    - Must list all compiled extensions with truthful `compiled` and `enabled`.
    - For M1, the only currently-referenced compiled extension in code is `export` (via `cfg.ExtensionEnabled("export")` in `internal/server/router.go`).
    - Must include at least the Export extension entry, with:
      - `name`: `"export"`
      - `enabled`: derived from `cfg.ExtensionEnabled("export")`
      - `compiled`: `true`
      - `version`: use `core.version` (same build version) unless/until per-extension versions exist
- Authz:
  - Keep endpoint auth-protected by default (no auth bypass).
  - Add a RequiredScopes entry for `GET /capabilities` (recommended: `jobs:read`).

### 2.3 Cross-cutting: routing, auth, and request classification
- Routing updates in `internal/server/router.go`:
  - Register new handlers for `/startupz`, `/readyz`, `/limits`, `/capabilities`.
- Auth updates in `internal/server/middleware.go`:
  - Add an explicit allowlist for unauthenticated public probe endpoints:
    - `GET /healthz`
    - `GET /startupz`
    - `GET /readyz`
  - Ensure the allowlist is exact-match and method-scoped so it cannot be used to bypass auth on other endpoints.
- Metrics route templating in `internal/server/middleware.go` (`templateRoute`):
  - Add stable route ids for the new endpoints:
    - `/startupz`, `/readyz`, `/limits`, `/capabilities`

### 2.4 Data / migration considerations
- None. This work is additive to the HTTP surface and does not change persistence schema.

## Docs
- `README.md`
- `docs/api-reference.md`
- `docs/serve-mode.md`

## Testing
- `go test ./...` (passed)

## Related issues
- #113 — Fix API reference: /capabilities app_id example + auth note
- #105 — Make probes public + add stable route IDs
- #106 — Implement `GET /startupz` handler (204 success, 503 RFC7807 on incomplete)
- #107 — Implement `GET /readyz` handler (gates on CoreDB + storage)
- #108 — Implement `GET /limits` (Core SoT schema + defaults)
- #109 — Implement `GET /capabilities` (Core SoT schema; compiled vs enabled; spec_version alignment)
- #110 — Add unit tests for probe auth bypass and protected endpoints
- #111 — Add handler tests for `/startupz`, `/readyz`, `/limits`, `/capabilities`
- #112 — Document new endpoints and auth/probe semantics
- #114 — Add RequiredScopes test coverage for GET /limits

## Notes / risks
- Must-fix:
  - None.
- Should-fix:
  - None.

<details>
<summary>Git context</summary>

```text
Diffstat vs main:
README.md                                     |   3 +-
 docs/api-reference.md                         |  97 ++++++++++++++++++++
 docs/serve-mode.md                            |  32 +++++++
 internal/server/authz/scopes.go               |   4 +
 internal/server/authz/scopes_test.go          |   2 +
 internal/server/buildinfo/buildinfo.go        |  22 +++++
 internal/server/handlers/capabilities.go      |  83 +++++++++++++++++
 internal/server/handlers/capabilities_test.go |  80 ++++++++++++++++
 internal/server/handlers/limits.go            |  75 +++++++++++++++
 internal/server/handlers/limits_test.go       | 105 +++++++++++++++++++++
 internal/server/handlers/readyz.go            |  92 +++++++++++++++++++
 internal/server/handlers/readyz_test.go       | 127 ++++++++++++++++++++++++++
 internal/server/handlers/startupz.go          |  48 ++++++++++
 internal/server/handlers/startupz_test.go     |  58 ++++++++++++
 internal/server/metrics/metrics.go            |   3 +-
 internal/server/middleware.go                 |  24 +++++
 internal/server/middleware_test.go            |  58 ++++++++++++
 internal/server/router.go                     |  21 +++--
 internal/server/router_test.go                |   3 +
 19 files changed, 929 insertions(+), 8 deletions(-)

Commits:
b1fdd04 Add RequiredScopes test coverage for GET /limits (issue #114)
9ae6ed3 [T-021] Fix API reference: /capabilities app_id example + auth note (issue #113)
215355b [T-020] Document new endpoints and auth/probe semantics (issue #112)
3f08010 Add handler tests for `/startupz`, `/readyz`, `/limits`, `/capabilities` (issue #111)
a9c9b11 Add unit tests for probe auth bypass and protected endpoints (issue #110)
4ff0543 Implement `GET /capabilities` (Core SoT schema; compiled vs enabled; spec_version alignment) (issue #109)
3fd81d1 Implement `GET /limits` (Core SoT schema + defaults) (issue #108)
e599760 Implement `GET /readyz` handler (gates on CoreDB + storage) (issue #107)
0c41d6f Implement `GET /startupz` handler (204 success, 503 RFC7807 on incomplete) (issue #106)
4687fdf Make probes public + add stable route IDs (issue #105)
```

</details>

