### PR TITLE
Fix Dependabot GitHub Actions schema option

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,3 @@ updates:
     directory: /
     schedule:
       interval: daily
-    versioning-strategy: auto


### PR DESCRIPTION
## Summary
- Removes unsupported `versioning-strategy: auto` from the GitHub Actions Dependabot update entry.

## Linked issue
- Fixes #531

## Problem
- The `github-actions` ecosystem does not support `versioning-strategy`, so this Dependabot entry includes an invalid option.

## Fix
- Keeps the existing schedule and directory.
- Leaves `versioning-strategy` untouched for ecosystems where it is supported.
- Updates only `.github/dependabot.yml`.

## Tests
- YAML parse check passed.
- Focused schema guard passed on this commit and failed on the parent as expected.
- `git diff --check HEAD~1..HEAD`
- `go test ./...`

## Risk notes
- Config-only change limited to Dependabot settings.
